### PR TITLE
Update workflow to run on forked PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,9 @@
 
 name: Go Pipeline
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,12 @@
 
 name: Go Pipeline
 
+# Enable this workflow to run for pull requests and
+# pushes to the main branch
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Fixes #21 

Run GitHub workflows on PR's so external contributors can validate their contribution against the CI/CD pipeline. The workflows will run on direct pushes to main (very rare) and on branches that have an open PR. 