### PR TITLE
A few documentation updates before next release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ We welcome contributions! We want to make contributing to this project as easy a
 ## We Develop with Github
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
-Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+## We Use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow)). We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ If you have a go environment on your desktop you can use [go install](https://go
 go install github.com/Boeing/config-file-validator/cmd/validator
 ```
 
-
-### Executables
-Executables are available for Linux and Windows (macOS coming soon!). Navigate to the [releases](https://github.com/Boeing/config-file-validator/releases) page to download the latest version. Once the executable has been downloaded it needs to be installed by moving the downloaded file to a location on your OS PATH.
+### Binaries
+Binary downloads are available for Linux, Windows, and MacOS. Navigate to the [releases](https://github.com/Boeing/config-file-validator/releases) page to download the latest version. Once the binary has been downloaded it needs to be installed by moving the downloaded file to a location on your OS PATH.
 
 ## Using
 ```
@@ -77,6 +76,13 @@ validator -search-path /path/to/search -exclude-dirs=/path/to/search/tests
 ```
 
 ![Exclude Dirs Run](./img/exclude_dirs.png)
+
+#### JSON Output
+Output the results in JSON
+
+```
+validator -search-path /path/to/search -reporter json
+```
 
 #### Container Run
 ```


### PR DESCRIPTION
I'm getting release 1.3.0 ready and made the following changes:

* Added an example in the README that showed how to use the JSON reporter
* Cleaned up some wording in the docs
* Changed MacOS coming soon to official support since I can now build/test it
* Fixed a dead link in the contributing guidelines