### PR TITLE
Update Go version to 1.21 from 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
         
     - name: Static Analysis
       run: go vet ./...
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Build
       run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags='-w -s -extldflags "-static"' -tags netgo -o validator cmd/validator/validator.go
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        go_version: 1.18
+        go_version: 1.21
         binary_name: "validator"
         ld_flags: -w -s -extldflags "-static"
         build_tags: -tags netgo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as go-builder
+FROM golang:1.21 as go-builder
 COPY . /build/
 WORKDIR /build
 RUN CGO_ENABLED=0 \
@@ -10,6 +10,6 @@ RUN CGO_ENABLED=0 \
   -o validator \
   cmd/validator/validator.go
 
-FROM alpine:3.15
+FROM alpine:3.18
 COPY --from=go-builder /build/validator /
 ENTRYPOINT [ "/validator" ]

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,14 @@
 module github.com/Boeing/config-file-validator
 
-go 1.18
+go 1.21
 
 require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,14 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"slices"
+
 	"github.com/Boeing/config-file-validator/pkg/filetype"
-	"golang.org/x/exp/slices"
 )
 
 type FileSystemFinder struct {
@@ -92,7 +93,7 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 				// filepath.Ext() returns the extension name with a dot so it
 				// needs to be removed.
 				walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
-				if fsf.isExtensionExcluded(walkFileExtension) {
+				if slices.Contains[[]string](fsf.ExcludeFileTypes, walkFileExtension) {
 					return nil
 				}
 
@@ -114,9 +115,4 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 	}
 
 	return matchingFiles, nil
-}
-
-// isExtensionExcluded returns true if extension exists in exclude list.
-func (fsf FileSystemFinder) isExtensionExcluded(ext string) bool {
-	return slices.Contains[[]string](fsf.ExcludeFileTypes, ext)
 }

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -92,7 +92,7 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 				// filepath.Ext() returns the extension name with a dot so it
 				// needs to be removed.
 				walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
-				if slices.Contains[[]string](fsf.ExcludeFileTypes, walkFileExtension) {
+				if fsf.isExtensionExcluded(walkFileExtension) {
 					return nil
 				}
 
@@ -114,4 +114,9 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 	}
 
 	return matchingFiles, nil
+}
+
+// isExtensionExcluded returns true if extension exists in exclude list.
+func (fsf FileSystemFinder) isExtensionExcluded(ext string) bool {
+	return slices.Contains[[]string](fsf.ExcludeFileTypes, ext)
 }

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Boeing/config-file-validator/pkg/filetype"
+	"golang.org/x/exp/slices"
 )
 
 type FileSystemFinder struct {
@@ -91,7 +92,7 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 				// filepath.Ext() returns the extension name with a dot so it
 				// needs to be removed.
 				walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
-				if fsf.isExtensionExcluded(walkFileExtension) {
+				if slices.Contains[[]string](fsf.ExcludeFileTypes, walkFileExtension) {
 					return nil
 				}
 
@@ -113,16 +114,4 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 	}
 
 	return matchingFiles, nil
-}
-
-// isExtensionExcluded returns true if extension exists in exclude list.
-// TODO: refactor to slices.Contains when project will be updated to go 1.21.
-func (fsf FileSystemFinder) isExtensionExcluded(ext string) bool {
-	for _, typ := range fsf.ExcludeFileTypes {
-		if typ == ext {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
**Changes in this PR**

- Update Go version to 1.21 from 1.19.  
- Replace IsExtensionExcluded with slices.Contains
- Update go versions in workflow and Dockerfile

resolves #36 