### PR TITLE
feat(ci/cd): Add container image packages to release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.base }}"
     - name: Build and push Docker image
       uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,33 @@ jobs:
         build_tags: -tags netgo
         project_path: cmd/validator
         extra_files: LICENSE README.md
+
+  registery-matrix:
+    name: Push Docker images to Container Registry
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        base: [alpine:3.18, scratch, ubuntu:20.04]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        args:
+          BASE_IMAGE: ${{ matrix.base }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         project_path: cmd/validator
         extra_files: LICENSE README.md
 
-  registery-matrix:
+  registry-matrix:
     name: Push Docker images to Container Registry
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base: [alpine:3.18, scratch, ubuntu:20.04]
+        base: ["alpine:3.18", scratch, "ubuntu:20.04"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,5 +63,5 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        args:
-          BASE_IMAGE: ${{ matrix.base }}
+        build-args: |
+          BASE_IMAGE=${{ matrix.base }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base: ["alpine:3.18", scratch, "ubuntu:20.04"]
+        include:
+          - base: "alpine:3.18"
+            postfix: ""
+          - base: "scratch"
+            postfix: "-scratch"
+          - base: "ubuntu:20.04"
+            postfix: "-ubuntu"
 
     steps:
     - uses: actions/checkout@v3
@@ -59,7 +65,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
-        images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.base }}"
+        images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.postfix }}"
     - name: Build and push Docker image
       uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_IMAGE=alpine:3.18
+
 FROM golang:1.21 as go-builder
 COPY . /build/
 WORKDIR /build
@@ -10,6 +12,6 @@ RUN CGO_ENABLED=0 \
   -o validator \
   cmd/validator/validator.go
 
-FROM alpine:3.18
+FROM $BASE_IMAGE
 COPY --from=go-builder /build/validator /
 ENTRYPOINT [ "/validator" ]


### PR DESCRIPTION
Resolves #8 

Images will be created for alpine, ubuntu and scratch and pushed to github registry

I tested the release out in my fork.

Packages: https://github.com/gokulav137?tab=packages&repo_name=config-file-validator

workflow run: https://github.com/gokulav137/config-file-validator/actions/runs/6431248766