### PR TITLE
Add --version to print the config-file-validator release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         goarch: ${{ matrix.goarch }}
         go_version: 1.21
         binary_name: "validator"
-        ld_flags: -w -s -extldflags "-static"
+        ld_flags: -w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=${{ github.event.release.tag_name }}
         build_tags: -tags netgo
         project_path: cmd/validator
         extra_files: LICENSE README.md
@@ -75,3 +75,4 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           BASE_IMAGE=${{ matrix.base }}
+          VALIDATOR_VERSION=${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         goarch: ${{ matrix.goarch }}
         go_version: 1.21
         binary_name: "validator"
-        ld_flags: -w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=${{ github.event.release.tag_name }}
+        ldflags: -w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=${{ github.event.release.tag_name }}
         build_tags: -tags netgo
         project_path: cmd/validator
         extra_files: LICENSE README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=alpine:3.18
+ARG VALIDATOR_VERSION=unknown
 
 FROM golang:1.21 as go-builder
 COPY . /build/
@@ -7,7 +8,7 @@ RUN CGO_ENABLED=0 \
   GOOS=linux \
   GOARCH=amd64 \
   go build \
-  -ldflags='-w -s -extldflags "-static"' \
+  -ldflags='-w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=$VALIDATOR_VERSION' \
   -tags netgo \
   -o validator \
   cmd/validator/validator.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 ARG BASE_IMAGE=alpine:3.18
-ARG VALIDATOR_VERSION=unknown
 
 FROM golang:1.21 as go-builder
+ARG VALIDATOR_VERSION=unknown
 COPY . /build/
 WORKDIR /build
 RUN CGO_ENABLED=0 \
   GOOS=linux \
   GOARCH=amd64 \
   go build \
-  -ldflags='-w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=$VALIDATOR_VERSION' \
+  -ldflags="-w -s -extldflags '-static' -X github.com/Boeing/config-file-validator.version=$VALIDATOR_VERSION" \
   -tags netgo \
   -o validator \
   cmd/validator/validator.go

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"strings"
 
+	configfilevalidator "github.com/Boeing/config-file-validator"
 	"github.com/Boeing/config-file-validator/pkg/cli"
 	"github.com/Boeing/config-file-validator/pkg/finder"
 	"github.com/Boeing/config-file-validator/pkg/reporter"
@@ -38,6 +39,7 @@ type validatorConfig struct {
 	excludeDirs      *string
 	excludeFileTypes *string
 	reportType       *string
+	versionQuery     *bool
 }
 
 // Custom Usage function to cover
@@ -61,6 +63,7 @@ func getFlags() (validatorConfig, error) {
 	excludeDirsPtr := flag.String("exclude-dirs", "", "Subdirectories to exclude when searching for configuration files")
 	reportTypePtr := flag.String("reporter", "standard", "Format of the printed report. Options are standard and json")
 	excludeFileTypesPtr := flag.String("exclude-file-types", "", "A comma separated list of file types to ignore")
+	versionPtr := flag.Bool("version", false, "Version prints the release version of validator")
 	flag.Parse()
 
 	var searchPath string
@@ -86,6 +89,7 @@ func getFlags() (validatorConfig, error) {
 		excludeDirsPtr,
 		excludeFileTypesPtr,
 		reportTypePtr,
+		versionPtr,
 	}
 
 	return config, nil
@@ -106,6 +110,11 @@ func mainInit() int {
 	validatorConfig, err := getFlags()
 	if err != nil {
 		return 1
+	}
+
+	if *validatorConfig.versionQuery {
+		fmt.Println(configfilevalidator.GetVersion())
+		return 0
 	}
 
 	searchPath := validatorConfig.searchPath

--- a/cmd/validator/validator_test.go
+++ b/cmd/validator/validator_test.go
@@ -22,6 +22,7 @@ func Test_flags(t *testing.T) {
 		{"flags set, junit reported", []string{"--exclude-dirs=subdir", "--reporter=junit", "."}, 1},
 		{"bad path", []string{"/path/does/not/exit"}, 1},
 		{"exclude file types set", []string{"--exclude-file-types=json", "."}, 0},
+		{"version", []string{"--version"}, 0},
 	}
 	for _, tc := range cases {
 		// this call is required because otherwise flags panics,

--- a/version.go
+++ b/version.go
@@ -1,0 +1,26 @@
+package configfilevalidator
+
+import "fmt"
+
+// Version information set by link flags during build. We fall back to these sane
+// default values when not provided
+var (
+	version = "unknown"
+)
+
+// Version contains config-file-validator version information
+type Version struct {
+	Version string
+}
+
+// String outputs the version as a string
+func (v Version) String() string {
+	return fmt.Sprintf("validator version %v", v.Version)
+}
+
+// GetVersion returns the version information
+func GetVersion() Version {
+	return Version{
+		Version: version,
+	}
+}


### PR DESCRIPTION
Resolves #24 

The version returns the version provided as ldflag and defaults to unknown if not provided. Implementation done similar to that in `argo-proj`

I modified the release action to use the release tag as `ldflags`.

Providing the release created in my fork:
https://github.com/gokulav137/config-file-validator/releases/tag/0.1.8
```
tar -x -f validator-0.1.8-linux-amd64.tar.gz
./validator --version
validator version 0.1.8
```
https://github.com/gokulav137?tab=packages&repo_name=config-file-validator
```
docker run --entrypoint "/validator" ghcr.io/gokulav137/config-file-validator:0.1.8 --version
validator version 0.1.8
docker run --entrypoint "/validator" ghcr.io/gokulav137/config-file-validator-ubuntu:0.1.8 --version
validator version 0.1.8
docker run --entrypoint "/validator" ghcr.io/gokulav137/config-file-validator-scratch:0.1.8 --version
validator version 0.1.8
```