### PR TITLE
Publish standard golang coverage report

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -72,7 +72,9 @@ jobs:
         go-version: 1.21
 
     - name: Unit test
-      run: go test -v -cover -coverprofile coverage.out ./...
+      run: |
+        go test -v -cover -coverprofile coverage.out ./...
+        go tool cover -html=coverage.out -o gocoverage.html
 
     - name: Check coverage
       id: check-coverage
@@ -92,7 +94,13 @@ jobs:
         echo "total_coverage=$totalCoverage" >> "$GITHUB_OUTPUT"
       env:
         COVERAGE_THRESHOLD: 95
-    
+
+    - name: Create coverage pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: .
+
     - name: Create badge img tag and apply to README files
       id: generate-badge
       run: |


### PR DESCRIPTION
We can resolve issue #74 with https://github.com/peaceiris/actions-gh-pages

FYI: https://goropikari.hatenablog.com/entry/go_coverage_github_pages
This site is only written in Japanese, but I guess you can read some of code snippets.
I've tried to execute the actions before I made this PR, but I cannot grasp any clue which execute the actions before making pull request.