### PR TITLE
Fix 'Exclude' typo

### DIFF
--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -57,13 +57,13 @@ func WithDepth(depthVal int) FSFinderOptions {
 }
 
 func FileSystemFinderInit(opts ...FSFinderOptions) *FileSystemFinder {
-	var defaultExludeDirs []string
+	var defaultExcludeDirs []string
 	defaultPathRoots := []string{"."}
 
 	fsfinder := &FileSystemFinder{
 		PathRoots:   defaultPathRoots,
 		FileTypes:   filetype.FileTypes,
-		ExcludeDirs: defaultExludeDirs,
+		ExcludeDirs: defaultExcludeDirs,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Fixes a typo with the `defaultExludeDirs` variable.