### PR TITLE
Optimize element lookup in FileSystemFinder by switching from []string to map[string]struct{}

### DIFF
--- a/pkg/filetype/file_type.go
+++ b/pkg/filetype/file_type.go
@@ -1,6 +1,7 @@
 package filetype
 
 import (
+	"github.com/Boeing/config-file-validator/pkg/misc"
 	"github.com/Boeing/config-file-validator/pkg/validator"
 )
 
@@ -10,7 +11,7 @@ import (
 // to be able to validate the file
 type FileType struct {
 	Name       string
-	Extensions []string
+	Extensions map[string]struct{}
 	Validator  validator.Validator
 }
 
@@ -18,7 +19,7 @@ type FileType struct {
 // represent a JSON file
 var JsonFileType = FileType{
 	"json",
-	[]string{"json"},
+	misc.ArrToMap("json"),
 	validator.JsonValidator{},
 }
 
@@ -26,7 +27,7 @@ var JsonFileType = FileType{
 // represent a YAML file
 var YamlFileType = FileType{
 	"yaml",
-	[]string{"yml", "yaml"},
+	misc.ArrToMap("yml", "yaml"),
 	validator.YamlValidator{},
 }
 
@@ -34,7 +35,7 @@ var YamlFileType = FileType{
 // represent a XML file
 var XmlFileType = FileType{
 	"xml",
-	[]string{"xml"},
+	misc.ArrToMap("xml"),
 	validator.XmlValidator{},
 }
 
@@ -42,7 +43,7 @@ var XmlFileType = FileType{
 // represent a Toml file
 var TomlFileType = FileType{
 	"toml",
-	[]string{"toml"},
+	misc.ArrToMap("toml"),
 	validator.TomlValidator{},
 }
 
@@ -50,7 +51,7 @@ var TomlFileType = FileType{
 // represent a Ini file
 var IniFileType = FileType{
 	"ini",
-	[]string{"ini"},
+	misc.ArrToMap("ini"),
 	validator.IniValidator{},
 }
 
@@ -58,7 +59,7 @@ var IniFileType = FileType{
 // represent a Properties file
 var PropFileType = FileType{
 	"properties",
-	[]string{"properties"},
+	misc.ArrToMap("properties"),
 	validator.PropValidator{},
 }
 
@@ -66,7 +67,7 @@ var PropFileType = FileType{
 // represent a HCL file
 var HclFileType = FileType{
 	"hcl",
-	[]string{"hcl"},
+	misc.ArrToMap("hcl"),
 	validator.HclValidator{},
 }
 
@@ -74,7 +75,7 @@ var HclFileType = FileType{
 // represent a Plist file
 var PlistFileType = FileType{
 	"plist",
-	[]string{"plist"},
+	misc.ArrToMap("plist"),
 	validator.PlistValidator{},
 }
 
@@ -82,7 +83,7 @@ var PlistFileType = FileType{
 // represent a CSV file
 var CsvFileType = FileType{
 	"csv",
-	[]string{"csv"},
+	misc.ArrToMap("csv"),
 	validator.CsvValidator{},
 }
 
@@ -90,7 +91,7 @@ var CsvFileType = FileType{
 // represent a HOCON file
 var HoconFileType = FileType{
 	"hocon",
-	[]string{"hocon"},
+	misc.ArrToMap("hocon"),
 	validator.HoconValidator{},
 }
 

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -2,6 +2,7 @@ package finder
 
 import (
 	"fmt"
+	"github.com/Boeing/config-file-validator/pkg/misc"
 	"path/filepath"
 	"testing"
 
@@ -112,7 +113,7 @@ func Test_fsFinderWithDepth(t *testing.T) {
 func Test_fsFinderCustomTypes(t *testing.T) {
 	jsonFileType := filetype.FileType{
 		Name:       "json",
-		Extensions: []string{"json"},
+		Extensions: misc.ArrToMap("json"),
 		Validator:  validator.JsonValidator{},
 	}
 	fsFinder := FileSystemFinderInit(

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -136,10 +136,9 @@ func (fsf FileSystemFinder) findOne(pathRoot string) ([]FileMetadata, error) {
 				if _, ok := fsf.ExcludeFileTypes[walkFileExtension]; ok {
 					return nil
 				}
-
+				extensionLowerCase := strings.ToLower(walkFileExtension)
 				for _, fileType := range fsf.FileTypes {
-					tmp := strings.ToLower(walkFileExtension)
-					if _, ok := fileType.Extensions[tmp]; ok {
+					if _, ok := fileType.Extensions[extensionLowerCase]; ok {
 						fileMetadata := FileMetadata{dirEntry.Name(), path, fileType}
 						matchingFiles = append(matchingFiles, fileMetadata)
 						break

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -1,12 +1,11 @@
 package finder
 
 import (
+	"github.com/Boeing/config-file-validator/pkg/misc"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"slices"
 
 	"github.com/Boeing/config-file-validator/pkg/filetype"
 )
@@ -14,8 +13,8 @@ import (
 type FileSystemFinder struct {
 	PathRoots        []string
 	FileTypes        []filetype.FileType
-	ExcludeDirs      []string
-	ExcludeFileTypes []string
+	ExcludeDirs      map[string]struct{}
+	ExcludeFileTypes map[string]struct{}
 	Depth            *int
 }
 
@@ -38,14 +37,14 @@ func WithFileTypes(fileTypes []filetype.FileType) FSFinderOptions {
 // Add a custom list of file types to the FSFinder
 func WithExcludeDirs(excludeDirs []string) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.ExcludeDirs = excludeDirs
+		fsf.ExcludeDirs = misc.ArrToMap(excludeDirs)
 	}
 }
 
 // WithExcludeFileTypes adds excluded file types to FSFinder.
 func WithExcludeFileTypes(types []string) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.ExcludeFileTypes = types
+		fsf.ExcludeFileTypes = misc.ArrToMap(types)
 	}
 }
 
@@ -56,7 +55,7 @@ func WithDepth(depthVal int) FSFinderOptions {
 	}
 }
 func FileSystemFinderInit(opts ...FSFinderOptions) *FileSystemFinder {
-	var defaultExcludeDirs []string
+	defaultExcludeDirs := make(map[string]struct{})
 	defaultPathRoots := []string{"."}
 
 	fsfinder := &FileSystemFinder{
@@ -125,20 +124,16 @@ func (fsf FileSystemFinder) findOne(pathRoot string) ([]FileMetadata, error) {
 				return fs.SkipDir // This is not reported as an error by filepath.WalkDir
 			}
 
-			for _, dir := range fsf.ExcludeDirs {
-				if dirEntry.IsDir() && dirEntry.Name() == dir {
-					err := filepath.SkipDir
-					if err != nil {
-						return err
-					}
-				}
+			if _, ok := fsf.ExcludeDirs[dirEntry.Name()]; dirEntry.IsDir() && ok {
+				return filepath.SkipDir
 			}
 
 			if !dirEntry.IsDir() {
 				// filepath.Ext() returns the extension name with a dot so it
 				// needs to be removed.
 				walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
-				if slices.Contains[[]string](fsf.ExcludeFileTypes, walkFileExtension) {
+
+				if _, ok := fsf.ExcludeFileTypes[walkFileExtension]; ok {
 					return nil
 				}
 

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -37,14 +37,14 @@ func WithFileTypes(fileTypes []filetype.FileType) FSFinderOptions {
 // Add a custom list of file types to the FSFinder
 func WithExcludeDirs(excludeDirs []string) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.ExcludeDirs = misc.ArrToMap(excludeDirs)
+		fsf.ExcludeDirs = misc.ArrToMap(excludeDirs...)
 	}
 }
 
 // WithExcludeFileTypes adds excluded file types to FSFinder.
 func WithExcludeFileTypes(types []string) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.ExcludeFileTypes = misc.ArrToMap(types)
+		fsf.ExcludeFileTypes = misc.ArrToMap(types...)
 	}
 }
 
@@ -138,11 +138,11 @@ func (fsf FileSystemFinder) findOne(pathRoot string) ([]FileMetadata, error) {
 				}
 
 				for _, fileType := range fsf.FileTypes {
-					for _, extension := range fileType.Extensions {
-						if strings.EqualFold(extension, walkFileExtension) {
-							fileMetadata := FileMetadata{dirEntry.Name(), path, fileType}
-							matchingFiles = append(matchingFiles, fileMetadata)
-						}
+					tmp := strings.ToLower(walkFileExtension)
+					if _, ok := fileType.Extensions[tmp]; ok {
+						fileMetadata := FileMetadata{dirEntry.Name(), path, fileType}
+						matchingFiles = append(matchingFiles, fileMetadata)
+						break
 					}
 				}
 			}

--- a/pkg/misc/arrToMap.go
+++ b/pkg/misc/arrToMap.go
@@ -1,0 +1,9 @@
+package misc
+
+func ArrToMap(arr []string) map[string]struct{} {
+	m := make(map[string]struct{}, 0)
+	for _, item := range arr {
+		m[item] = struct{}{}
+	}
+	return m
+}

--- a/pkg/misc/arrToMap.go
+++ b/pkg/misc/arrToMap.go
@@ -1,8 +1,11 @@
 package misc
 
-func ArrToMap(arr []string) map[string]struct{} {
+// ArrToMap converts a string array
+// to a map with keys from the array
+// and empty struct values, optimizing string presence checks.
+func ArrToMap(arg ...string) map[string]struct{} {
 	m := make(map[string]struct{}, 0)
-	for _, item := range arr {
+	for _, item := range arg {
 		m[item] = struct{}{}
 	}
 	return m


### PR DESCRIPTION
changed []string to map[string]struct{} in FileSystemFinder struct fields because of optimization (arrays were used only to check the occurrence of an element)