### PR TITLE
Update package versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Download dependencies
       run: go mod download
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
         
     - name: Static Analysis
       run: go vet ./...
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Build
       run: |
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Unit test
       run: go test -v -cover -coverprofile coverage.out ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        go_version: 1.21
+        go_version: 1.22
         binary_name: "validator"
         ldflags: -w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=${{ github.event.release.tag_name }}
         build_tags: -tags netgo
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - base: "alpine:3.18"
+          - base: "alpine:3.19"
             postfix: ""
           - base: "scratch"
             postfix: "-scratch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE=alpine:3.18
+ARG BASE_IMAGE=alpine:3.19
 
-FROM golang:1.21 as go-builder
+FROM golang:1.22 as go-builder
 ARG VALIDATOR_VERSION=unknown
 COPY . /build/
 WORKDIR /build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Boeing/config-file-validator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/fatih/color v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Boeing/config-file-validator
 
-go 1.22
+go 1.21
 
 require (
 	github.com/fatih/color v1.13.0

--- a/index.md
+++ b/index.md
@@ -186,7 +186,7 @@ docker run -it --rm -v /path/to/config/files:/test config-file-validator:1.5.0 /
 ![Docker Standard Run](./img/docker_run.png)
 
 ## Build
-The project can be downloaded and built from source using an environment with golang 1.21 installed. After a successful build, the binary can be moved to a location on your operating system PATH.
+The project can be downloaded and built from source using an environment with golang 1.21+ installed. After a successful build, the binary can be moved to a location on your operating system PATH.
 
 ### MacOS
 #### Build


### PR DESCRIPTION
Time to update package versions:

- Update go to 1.22 (but leave the required version in `go.mod` at 1.21)
- Update alpine version to 1.19