### PR TITLE
 Add support for .env config files #110 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,13 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/hashicorp/go-envparse v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/zclconf/go-cty v1.13.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gurkankaymak/hocon v1.2.18 h1:/COj3okWh58himiYO0R7PrPX+iE7PbuzTn2cEv7fPsw=
 github.com/gurkankaymak/hocon v1.2.18/go.mod h1:dQCfhnuDKlLqAZRGhFTd81HkAfMx7STHv0w2JkJ6iq4=
+github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdmPSDFPY=
+github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/hashicorp/hcl/v2 v2.18.1 h1:6nxnOJFku1EuSawSD81fuviYUV8DxFr3fp2dUi3ZYSo=
 github.com/hashicorp/hcl/v2 v2.18.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -46,6 +48,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/zclconf/go-cty v1.13.0 h1:It5dfKTTZHe9aeppbNOda3mN7Ag7sg6QkBNm6TkyFa0=
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/filetype/file_type.go
+++ b/pkg/filetype/file_type.go
@@ -95,6 +95,14 @@ var HoconFileType = FileType{
 	validator.HoconValidator{},
 }
 
+// Instance of the FileType object to
+// represent a ENV file
+var EnvFileType = FileType{
+	"env",
+	misc.ArrToMap("env"),
+	validator.EnvValidator{},
+}
+
 // An array of files types that are supported
 // by the validator
 var FileTypes = []FileType{
@@ -108,4 +116,5 @@ var FileTypes = []FileType{
 	PlistFileType,
 	CsvFileType,
 	HoconFileType,
+	EnvFileType,
 }

--- a/pkg/validator/env.go
+++ b/pkg/validator/env.go
@@ -1,0 +1,22 @@
+package validator
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hashicorp/go-envparse"
+)
+
+type EnvValidator struct{}
+
+// Validate implements the Validator interface by attempting to
+// parse a byte array of a env file using envparse package
+func (envv EnvValidator) Validate(b []byte) (bool, error) {
+	r := bytes.NewReader(b)
+	_, err := envparse.Parse(r)
+	if err != nil {
+		customError := err.(*envparse.ParseError)
+		return false, fmt.Errorf("Error at line %v: %v", customError.Line, customError.Err)
+	}
+	return true, nil
+}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -64,6 +64,8 @@ var testData = []struct {
 	{"invalidPlist", invalidPlistBytes, false, PlistValidator{}},
 	{"validHocon", []byte(`test = [1, 2, 3]`), true, HoconValidator{}},
 	{"invalidHocon", []byte(`test = [1, 2,, 3]`), false, HoconValidator{}},
+	{"validEnv", []byte("KEY=VALUE"), true, EnvValidator{}},
+	{"invalidEnv", []byte("=TEST"), false, EnvValidator{}},
 }
 
 func Test_ValidationInput(t *testing.T) {

--- a/test/fixtures/good.env
+++ b/test/fixtures/good.env
@@ -1,0 +1,1 @@
+TEST=True

--- a/test/fixtures/good.env
+++ b/test/fixtures/good.env
@@ -1,1 +1,0 @@
-TEST=True

--- a/test/fixtures/subdir2/bad.env
+++ b/test/fixtures/subdir2/bad.env
@@ -1,0 +1,2 @@
+TEST=True
+DEMO="\a"

--- a/test/fixtures/subdir2/bad.env
+++ b/test/fixtures/subdir2/bad.env
@@ -1,2 +1,0 @@
-TEST=True
-DEMO="\a"


### PR DESCRIPTION
I implemented a env validator using go-envparse package, also added a good.env and bad.env to test the env validator.

Closes #110 