### PR TITLE
ci: add the permission to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
     permissions:
       packages: write
+      contents: write
 
     steps:
     - name: Harden Runner


### PR DESCRIPTION
- https://github.com/Boeing/config-file-validator/issues/161

The release v1.7.0 failed due to the permission error.

https://github.com/Boeing/config-file-validator/actions/runs/10362649156/job/28684983356#step:6:284

```
+ github-assets-uploader -logtostderr -f ../validator-v1.7.0-linux-amd64.tar.gz -mediatype application/gzip -repo Boeing/config-file-validator -token *** -tag=v1.7.0 -releasename= -retry 3
W0813 02:34:38.260789    1654 main.go:48] Upload asset error, will retry in 4s: POST https://uploads.github.com/repos/Boeing/config-file-validator/releases/169879682/assets?name=validator-v1.7.0-linux-amd64.tar.gz: 403 Resource not accessible by integration []
W0813 02:34:42.775738    1654 main.go:48] Upload asset error, will retry in 9s: POST https://uploads.github.com/repos/Boeing/config-file-validator/releases/169879682/assets?name=validator-v1.7.0-linux-amd64.tar.gz: 403 Resource not accessible by integration []
E0813 02:34:52.242572    1654 err_exit.go:11] POST https://uploads.github.com/repos/Boeing/config-file-validator/releases/169879682/assets?name=validator-v1.7.0-linux-amd64.tar.gz: 403 Resource not accessible by integration []
```

The permission `contents: write` is required, but it was removed by https://github.com/Boeing/config-file-validator/commit/f28a04d0ded38ef3689afb9080d13278e8caf8f1 .

- https://github.com/Boeing/config-file-validator/pull/152

This pull request adds the permission to resolve the issue.

## Test

I tested this pull request by creating a release at my fork and running the release workflow.
Then I confirmed releasing assets succeeded.

https://github.com/suzuki-shunsuke/config-file-validator/releases/tag/v1.7.1-0
https://github.com/suzuki-shunsuke/config-file-validator/actions/runs/10366714973/job/28696585997