### PR TITLE
fix(paths): trim leading and trailing whitespaces for file system paths 

### DIFF
--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -249,10 +249,11 @@ func Test_FileFinderBadPath(t *testing.T) {
 	}
 }
 
-func Test_FileFinderPathWithLeadingAndTrailingWhitespaces(t *testing.T) {
+func Test_FileFinderPathWithWhitespaces(t *testing.T) {
 	tests := []struct {
-		name string
-		path string
+		name      string
+		path      string
+		expectErr bool
 	}{
 		{
 			name: "no whitespace",
@@ -270,6 +271,26 @@ func Test_FileFinderPathWithLeadingAndTrailingWhitespaces(t *testing.T) {
 			name: "leading and trailing whitespace",
 			path: "  ../../test/fixtures/subdir  ",
 		},
+		{
+			name:      "whitespace in middle of path",
+			path:      "../../test/  fixtures  /subdir",
+			expectErr: true,
+		},
+		{
+			name:      "leading whitespace + whitespace in middle of path",
+			path:      "  ../../test/  fixtures  /subdir",
+			expectErr: true,
+		},
+		{
+			name:      "trailing whitespace + whitespace in middle of path",
+			path:      "../../test/  fixtures  /subdir  ",
+			expectErr: true,
+		},
+		{
+			name:      "leading and trailing whitespace + whitespace in middle of path",
+			path:      "  ../../test/  fixtures  /subdir  ",
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -280,12 +301,18 @@ func Test_FileFinderPathWithLeadingAndTrailingWhitespaces(t *testing.T) {
 
 			files, err := fsFinder.Find()
 
-			if len(files) < 1 {
-				t.Errorf("Unable to find file")
-			}
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Error should be thrown for bad path")
+				}
+			} else {
+				if len(files) < 1 {
+					t.Errorf("Unable to find file")
+				}
 
-			if err != nil {
-				t.Errorf("Unable to find file")
+				if err != nil {
+					t.Errorf("Unable to find file")
+				}
 			}
 		})
 	}

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -249,6 +249,48 @@ func Test_FileFinderBadPath(t *testing.T) {
 	}
 }
 
+func Test_FileFinderPathWithLeadingAndTrailingWhitespaces(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "no whitespace",
+			path: "../../test/fixtures/subdir",
+		},
+		{
+			name: "leading whitespace",
+			path: "  ../../test/fixtures/subdir",
+		},
+		{
+			name: "trailing whitespace",
+			path: "../../test/fixtures/subdir  ",
+		},
+		{
+			name: "leading and trailing whitespace",
+			path: "  ../../test/fixtures/subdir  ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsFinder := FileSystemFinderInit(
+				WithPathRoots(tt.path),
+			)
+
+			files, err := fsFinder.Find()
+
+			if len(files) < 1 {
+				t.Errorf("Unable to find file")
+			}
+
+			if err != nil {
+				t.Errorf("Unable to find file")
+			}
+		})
+	}
+}
+
 func Benchmark_Finder(b *testing.B) {
 	fsFinder := FileSystemFinderInit(
 		WithPathRoots("../../test/fixtures/"),

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -81,7 +81,9 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 	seen := make(map[string]struct{}, 0)
 	uniqueMatches := make([]FileMetadata, 0)
 	for _, pathRoot := range fsf.PathRoots {
-		matches, err := fsf.findOne(pathRoot, seen)
+		// remove all leading and trailing whitespace
+		trimmedPathRoot := strings.TrimSpace(pathRoot)
+		matches, err := fsf.findOne(trimmedPathRoot, seen)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Remove all leading and trailing whitespaces when searching the file system for a path. This PR fixes #158. 