### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,20 @@ jobs:
         build_tags: -tags netgo
         project_path: cmd/validator
         extra_files: LICENSE README.md
+
+  winget:
+    name: Publish to Winget
+    needs: [releases-matrix]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
+
+      - uses: vedantmgoyal9/winget-releaser@b87a066d9e624db1394edcd947f8c4e5a7e30cd7 # main
+        with:
+          identifier: Boeing.config-file-validator
+          installers-regex: '-windows-\w+\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
[This action](https://github.com/vedantmgoyal9/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

config-file-validator is being added to Winget (https://github.com/microsoft/winget-pkgs/pull/169511), and this workflow will be used to update it.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @Boeing (Or a `fork-user` input and set it to the PAT owner). The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).
