### PR TITLE
Support env variables for config (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,15 @@ optional flags:
 
 The config-file-validator supports setting options via environment variables. If both command-line flags and environment variables are set, the command-line flags will take precedence. The supported environment variables are as follows:
 
-- `CFV_DEPTH`: Equivalent to the `-depth` flag
-- `CFV_EXCLUDE_DIRS`: Equivalent to the `-exclude-dirs` flag
-- `CFV_EXCLUDE_FILE_TYPES`: Equivalent to the `-exclude-file-types` flag
-- `CFV_OUTPUT`: Equivalent to the `-output` flag
-- `CFV_REPORTER`: Equivalent to the `-reporter` flag
-- `CFV_GROUPBY`: Equivalent to the `-groupby` flag
-- `CFV_QUIET`: Equivalent to the `-quiet` flag
+| Environment Variable | Equivalent Flag |
+|----------------------|-----------------|
+| `CFV_DEPTH`          | `-depth`        |
+| `CFV_EXCLUDE_DIRS`   | `-exclude-dirs` |
+| `CFV_EXCLUDE_FILE_TYPES` | `-exclude-file-types` |
+| `CFV_OUTPUT`         | `-output`       |
+| `CFV_REPORTER`       | `-reporter`     |
+| `CFV_GROUPBY`        | `-groupby`      |
+| `CFV_QUIET`          | `-quiet`        |
 
 ### Examples
 #### Standard Run

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ optional flags:
     	Version prints the release version of validator
 ```
 
+### Environment Variables
+
+The config-file-validator supports setting options via environment variables. If both command-line flags and environment variables are set, the command-line flags will take precedence. The supported environment variables are as follows:
+
+- `CFV_DEPTH`: Equivalent to the `-depth` flag
+- `CFV_EXCLUDE_DIRS`: Equivalent to the `-exclude-dirs` flag
+- `CFV_EXCLUDE_FILE_TYPES`: Equivalent to the `-exclude-file-types` flag
+- `CFV_OUTPUT`: Equivalent to the `-output` flag
+- `CFV_REPORTER`: Equivalent to the `-reporter` flag
+- `CFV_GROUPBY`: Equivalent to the `-groupby` flag
+- `CFV_QUIET`: Equivalent to the `-quiet` flag
+
 ### Examples
 #### Standard Run
 If the search path is omitted it will search the current directory

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -80,6 +80,15 @@ func getFlags() (validatorConfig, error) {
 	versionPtr := flag.Bool("version", false, "Version prints the release version of validator")
 	groupOutputPtr := flag.String("groupby", "", "Group output by filetype, directory, pass-fail. Supported for Standard and JSON reports")
 	quietPrt := flag.Bool("quiet", false, "If quiet flag is set. It doesn't print any output to stdout.")
+
+	setFlagFromEnvIfNotSet("depth", "CSV_DEPTH")
+	setFlagFromEnvIfNotSet("exclude-dirs", "CSV_EXCLUDE_DIRS")
+	setFlagFromEnvIfNotSet("exclude-file-types", "CSV_EXCLUDE_FILE_TYPES")
+	setFlagFromEnvIfNotSet("output", "CSV_OUTPUT")
+	setFlagFromEnvIfNotSet("reporter", "CSV_REPORTER")
+	setFlagFromEnvIfNotSet("groupby", "CSV_GROUPBY")
+	setFlagFromEnvIfNotSet("quiet", "CSV_QUIET")
+
 	flag.Parse()
 
 	searchPaths := make([]string, 0)
@@ -159,6 +168,15 @@ func isFlagSet(flagName string) bool {
 	})
 
 	return isSet
+}
+
+func setFlagFromEnvIfNotSet(flagName string, envVar string) {
+	if !isFlagSet(flagName) {
+		envVarValue, isEnvVarSet := os.LookupEnv(envVar)
+		if isEnvVarSet {
+			flag.Set(flagName, envVarValue)
+		}
+	}
 }
 
 // Return the reporter associated with the

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -82,13 +82,13 @@ func getFlags() (validatorConfig, error) {
 	quietPtr := flag.Bool("quiet", false, "If quiet flag is set. It doesn't print any output to stdout.")
 
 	flagsEnvMap := map[string]string{
-		"depth":              "CSV_DEPTH",
-		"exclude-dirs":       "CSV_EXCLUDE_DIRS",
-		"exclude-file-types": "CSV_EXCLUDE_FILE_TYPES",
-		"output":             "CSV_OUTPUT",
-		"reporter":           "CSV_REPORTER",
-		"groupby":            "CSV_GROUPBY",
-		"quiet":              "CSV_QUIET",
+		"depth":              "CFV_DEPTH",
+		"exclude-dirs":       "CFV_EXCLUDE_DIRS",
+		"exclude-file-types": "CFV_EXCLUDE_FILE_TYPES",
+		"output":             "CFV_OUTPUT",
+		"reporter":           "CFV_REPORTER",
+		"groupby":            "CFV_GROUPBY",
+		"quiet":              "CFV_QUIET",
 	}
 
 	for flagName, envVar := range flagsEnvMap {

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -79,7 +79,7 @@ func getFlags() (validatorConfig, error) {
 	reportTypePtr := flag.String("reporter", "standard", "Format of the printed report. Options are standard and json")
 	versionPtr := flag.Bool("version", false, "Version prints the release version of validator")
 	groupOutputPtr := flag.String("groupby", "", "Group output by filetype, directory, pass-fail. Supported for Standard and JSON reports")
-	quietPrt := flag.Bool("quiet", false, "If quiet flag is set. It doesn't print any output to stdout.")
+	quietPtr := flag.Bool("quiet", false, "If quiet flag is set. It doesn't print any output to stdout.")
 
 	flagsEnvMap := map[string]string{
 		"depth":              "CSV_DEPTH",
@@ -159,7 +159,7 @@ func getFlags() (validatorConfig, error) {
 		versionPtr,
 		outputPtr,
 		groupOutputPtr,
-		quietPrt,
+		quietPtr,
 	}
 
 	return config, nil


### PR DESCRIPTION
closes : https://github.com/Boeing/config-file-validator/issues/111

We could have used os.Getenv() directly as default value for flag.String(). But the are multiple uses of isFlagSet() in the code, which would return false even if the variable is set through the env.