### PR TITLE
Add function to dynamically determine package version for PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,6 +12,11 @@ makedepends=('go>=1.21')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
+pkgver() {
+  cd "$pkgname"
+  git describe --tags | sed 's/^v//;s/-.*//'
+}
+
 build() {
   cd "$pkgname-$pkgver"
   CGO_ENABLED=0 \


### PR DESCRIPTION
**Description:**
This pull request resolves issue #176 by enhancing the `PKGBUILD` file to dynamically set the `pkgver` based on Git tags.

**Changes:**
1. **PKGBUILD:**
   - Implemented a `pkgver()` function that dynamically retrieves the latest Git tag using `git describe --tags`.
   - The function uses `sed 's/^v//;s/-.*//'` to format the version string, ensuring it adheres to the `pkgver` format by:
     - Stripping the leading `v` from the tag (e.g., `v1.7.1` becomes `1.7.1`).
     - Removing any additional commit metadata (e.g., `-3-ge168780`).