### PR TITLE
Add globbing pattern matching for search_path (Replaces #179)

### DIFF
--- a/cmd/validator/validator_test.go
+++ b/cmd/validator/validator_test.go
@@ -39,6 +39,12 @@ func Test_flags(t *testing.T) {
 		{"grouped sarif", []string{"-groupby=directory", "--reporter=sarif", "."}, 1},
 		{"groupby duplicate", []string{"--groupby=directory,directory", "."}, 1},
 		{"quiet flag", []string{"--quiet=true", "."}, 0},
+		{"globbing flag set", []string{"--globbing=true", "."}, 0},
+		{"globbing flag with a pattern", []string{"--globbing=true", "../../test/**/[m-t]*.json"}, 0},
+		{"globbing flag with no matches", []string{"--globbing=true", "../../test/**/*.nomatch"}, 0},
+		{"globbing flag not set", []string{"test/**/*.json", "."}, 1},
+		{"globbing flag with exclude-dirs", []string{"-globbing", "--exclude-dirs=subdir", "test/**/*.json", "."}, 1},
+		{"globbing flag with exclude-file-types", []string{"-globbing", "--exclude-file-types=hcl", "test/**/*.json", "."}, 1},
 	}
 	for _, tc := range cases {
 		// this call is required because otherwise flags panics,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Boeing/config-file-validator
 go 1.21.0
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.7.1
 	github.com/editorconfig/editorconfig-core-go/v2 v2.6.2
 	github.com/fatih/color v1.13.0
 	github.com/gurkankaymak/hocon v1.2.18

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
+github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/editorconfig/editorconfig-core-go/v2 v2.6.2 h1:dKG8sc7n321deIVRcQtwlMNoBEra7j0qQ8RwxO8RN0w=


### PR DESCRIPTION
Fixes #165

This PR adds support for glob patterns, controlled by a new `globbing` flag. When enabled (`-globbing`), the tool will use glob pattern matching to locate files and directories.

I decided to implement a flag so that the user is aware of the behaviour in case they have some unconventional filenames.

When globbing is enabled, matched paths are dynamically added to the `searchPath` array for further processing.