### PR TITLE
exclude-file-types flag exludes aliases

### DIFF
--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -390,7 +390,7 @@ func mainInit() int {
 }
 
 func getExcludeFileTypes(configExcludeFileTypes string) []string {
-	excludeFileTypes := strings.Split(configExcludeFileTypes, ",")
+	excludeFileTypes := strings.Split(strings.ToLower(configExcludeFileTypes), ",")
 	uniqueFileTypes := misc.ArrToMap(excludeFileTypes...)
 
 	for _, ft := range filetype.FileTypes {

--- a/cmd/validator/validator_test.go
+++ b/cmd/validator/validator_test.go
@@ -84,6 +84,11 @@ func Test_getExcludeFileTypes(t *testing.T) {
 			input:                    "json,yaml",
 			expectedExcludeFileTypes: []string{"json", "yaml", "yml"},
 		},
+		{
+			name:                     "exclude jSon and YamL",
+			input:                    "jSon,YamL",
+			expectedExcludeFileTypes: []string{"json", "yaml", "yml"},
+		},
 	}
 
 	for _, tcase := range tcases {

--- a/cmd/validator/validator_test.go
+++ b/cmd/validator/validator_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_flags(t *testing.T) {
@@ -26,7 +28,7 @@ func Test_flags(t *testing.T) {
 		{"flags set, junit reporter", []string{"--exclude-dirs=subdir", "--reporter=junit", "."}, 0},
 		{"flags set, sarif reporter", []string{"--exclude-dirs=subdir", "--reporter=sarif", "."}, 0},
 		{"bad path", []string{"/path/does/not/exit"}, 1},
-		{"exclude file types set", []string{"--exclude-file-types=json", "."}, 0},
+		{"exclude file types set", []string{"--exclude-file-types=json,yaml", "."}, 0},
 		{"multiple paths", []string{"../../test/fixtures/subdir/good.json", "../../test/fixtures/good.json"}, 0},
 		{"version", []string{"--version"}, 0},
 		{"output set", []string{"--reporter=json:../../test/output", "."}, 0},
@@ -51,5 +53,43 @@ func Test_flags(t *testing.T) {
 		if tc.ExpectedExit != actualExit {
 			t.Errorf("Wrong exit code, expected: %v, got: %v", tc.ExpectedExit, actualExit)
 		}
+	}
+}
+
+func Test_getExcludeFileTypes(t *testing.T) {
+	type testCase struct {
+		name                     string
+		input                    string
+		expectedExcludeFileTypes []string
+	}
+
+	tcases := []testCase{
+		{
+			name:                     "exclude yaml",
+			input:                    "yaml",
+			expectedExcludeFileTypes: []string{"yaml", "yml"},
+		},
+		{
+			name:                     "exclude yml",
+			input:                    "yml",
+			expectedExcludeFileTypes: []string{"yaml", "yml"},
+		},
+		{
+			name:                     "exclude json",
+			input:                    "json",
+			expectedExcludeFileTypes: []string{"json"},
+		},
+		{
+			name:                     "exclude json and yaml",
+			input:                    "json,yaml",
+			expectedExcludeFileTypes: []string{"json", "yaml", "yml"},
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			actual := getExcludeFileTypes(tcase.input)
+			require.ElementsMatch(t, tcase.expectedExcludeFileTypes, actual)
+		})
 	}
 }


### PR DESCRIPTION
fix for [#214](https://github.com/Boeing/config-file-validator/issues/214)

If file type is similar to one of extensions, then exclude all extensions

Before fix:
<img width="774" alt="Screenshot 2024-11-09 at 19 46 30" src="https://github.com/user-attachments/assets/3c2ef41b-4ad2-400e-80ca-32c40fffe31d">

After fix:
<img width="945" alt="Screenshot 2024-11-09 at 19 48 17" src="https://github.com/user-attachments/assets/4fbdda36-b795-4584-badc-236706eacfac">
