### PR TITLE
ci(megalinter): add github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "gomod"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,6 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
+---
 name: Go Pipeline
 
 # Enable this workflow to run for pull requests and

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,63 +18,63 @@ jobs:
   download:
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version: '1.22'
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.22"
 
-    - name: Download dependencies
-      run: go mod download
+      - name: Download dependencies
+        run: go mod download
 
   lint:
     needs: download
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version: '1.22'
-        
-    - name: Static Analysis
-      run: go vet ./...
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.22"
 
-    - name: Check Formatting
-      run: test -z "$(gofmt -s -l -e .)"
+      - name: Static Analysis
+        run: go vet ./...
+
+      - name: Check Formatting
+        run: test -z "$(gofmt -s -l -e .)"
 
   build:
     needs: download
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Set up Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version: '1.22'
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.22"
 
-    - name: Build
-      run: |
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-          go build -ldflags='-w -s -extldflags "-static"' -tags netgo -o validator cmd/validator/validator.go
+      - name: Build
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+            go build -ldflags='-w -s -extldflags "-static"' -tags netgo -o validator cmd/validator/validator.go
 
   test:
     needs: download
@@ -83,68 +83,68 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
-    - name: Set up Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version: '1.22'
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.22"
 
-    - name: Unit test
-      run: go test -v -cover -coverprofile coverage.out ./...
+      - name: Unit test
+        run: go test -v -cover -coverprofile coverage.out ./...
 
-    - name: Check coverage
-      id: check-coverage
-      env:
-        COVERAGE_THRESHOLD: 94
-      run: |
-        # Validate that the coverage is above or at the required threshold
-        echo "Checking if test coverage is above threshold ..."
-        echo "Coverage threshold: ${COVERAGE_THRESHOLD} %"
-        totalCoverage=$(go tool cover -func coverage.out | grep 'total' | grep -Eo '[0-9]+\.[0-9]+')
-        echo "Current test coverage : ${totalCoverage} %"
-        if (( $(echo "${COVERAGE_THRESHOLD} <= ${totalCoverage}" | bc -l) )); then
-          echo "Coverage OK"
-        else
-          echo "Current test coverage is below threshold"
-          exit 1
-        fi
-        echo "total_coverage=${totalCoverage}" >> "${GITHUB_OUTPUT}"
-    
-    - name: Create badge img tag and apply to README files
-      id: generate-badge
-      run: |
-        # Create Badge URL
-        # Badge will always be green because of coverage threshold check
-        # so we just have to populate the total coverage
-        totalCoverage=${{ steps.check-coverage.outputs.total_coverage }}
-        BADGE_URL="https://img.shields.io/badge/Coverage-${totalCoverage}%25-brightgreen"
-        BADGE_IMG_TAG="<img id=\"cov\" src=\"${BADGE_URL}\" alt=\"Code Coverage\">"
+      - name: Check coverage
+        id: check-coverage
+        env:
+          COVERAGE_THRESHOLD: 94
+        run: |
+          # Validate that the coverage is above or at the required threshold
+          echo "Checking if test coverage is above threshold ..."
+          echo "Coverage threshold: ${COVERAGE_THRESHOLD} %"
+          totalCoverage=$(go tool cover -func coverage.out | grep 'total' | grep -Eo '[0-9]+\.[0-9]+')
+          echo "Current test coverage : ${totalCoverage} %"
+          if (( $(echo "${COVERAGE_THRESHOLD} <= ${totalCoverage}" | bc -l) )); then
+            echo "Coverage OK"
+          else
+            echo "Current test coverage is below threshold"
+            exit 1
+          fi
+          echo "total_coverage=${totalCoverage}" >> "${GITHUB_OUTPUT}"
 
-        # Update README.md and index.md
-        for markdown_file in README.md index.md; do
-          sed -i "/id=\"cov\"/c\\${BADGE_IMG_TAG}" "${markdown_file}"
-        done
+      - name: Create badge img tag and apply to README files
+        id: generate-badge
+        run: |
+          # Create Badge URL
+          # Badge will always be green because of coverage threshold check
+          # so we just have to populate the total coverage
+          totalCoverage=${{ steps.check-coverage.outputs.total_coverage }}
+          BADGE_URL="https://img.shields.io/badge/Coverage-${totalCoverage}%25-brightgreen"
+          BADGE_IMG_TAG="<img id=\"cov\" src=\"${BADGE_URL}\" alt=\"Code Coverage\">"
 
-        # Check to see if files were updated
-        if git diff --quiet; then
-          echo "badge_updates=false" >> "${GITHUB_OUTPUT}"
-        else
-          echo "badge_updates=true" >> "${GITHUB_OUTPUT}"
-        fi
+          # Update README.md and index.md
+          for markdown_file in README.md index.md; do
+            sed -i "/id=\"cov\"/c\\${BADGE_IMG_TAG}" "${markdown_file}"
+          done
 
-    - name: Commit changes
-      if: steps.generate-badge.outputs.badge_updates == 'true' && github.event_name == 'push'
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add -- README.md index.md
-        git commit -m "chore: Updated coverage badge."
-        git push
+          # Check to see if files were updated
+          if git diff --quiet; then
+            echo "badge_updates=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "badge_updates=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Commit changes
+        if: steps.generate-badge.outputs.badge_updates == 'true' && github.event_name == 'push'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -- README.md index.md
+          git commit -m "chore: Updated coverage badge."
+          git push

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,4 @@
+---
 name: golangci-lint
 on:
   push:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,12 +15,12 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: ['1.21']
+        go: ["1.21"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     permissions:
       # Optional: Allow write access to checks to allow the action to annotate code in the PR.
       checks: write
-    
+
     name: lint
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/goreportcard.yaml
+++ b/.github/workflows/goreportcard.yaml
@@ -6,53 +6,53 @@ on:
       - main
   pull_request:
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
   goreportcard:
     strategy:
       matrix:
-        go: ['stable']
+        go: ["stable"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
 
-    - name: Setup Go ${{ matrix.go }}
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version: ${{ matrix.go }}
-        cache: false
-    - name: Checkout gojp/goreportcard repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: gojp/goreportcard
-        path: goreportcard
-    - name: Install goreportcard-cli
-      # goreportcard-cli requires the following linters:
-      #  1. gometalinter
-      #  2. golint
-      #  3. gocyclo
-      #  4. ineffassign
-      #  5. misspell
-      # among which, the linter gometalinter is deprecated. However, goreportcard repo has a vendor version of it.
-      # Hence installing from the repo instead of `go install`. Refer https://github.com/gojp/goreportcard/issues/301
-      run: |
-        cd goreportcard
+      - name: Setup Go ${{ matrix.go }}
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ matrix.go }}
+          cache: false
+      - name: Checkout gojp/goreportcard repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: gojp/goreportcard
+          path: goreportcard
+      - name: Install goreportcard-cli
+        # goreportcard-cli requires the following linters:
+        #  1. gometalinter
+        #  2. golint
+        #  3. gocyclo
+        #  4. ineffassign
+        #  5. misspell
+        # among which, the linter gometalinter is deprecated. However, goreportcard repo has a vendor version of it.
+        # Hence installing from the repo instead of `go install`. Refer https://github.com/gojp/goreportcard/issues/301
+        run: |
+          cd goreportcard
 
-        # Install prerequisite linter binaries: gometalinter, golint, gocyclo, ineffassign & misspell
-        # Refer: https://github.com/gojp/goreportcard?tab=readme-ov-file#command-line-interface
-        make install
+          # Install prerequisite linter binaries: gometalinter, golint, gocyclo, ineffassign & misspell
+          # Refer: https://github.com/gojp/goreportcard?tab=readme-ov-file#command-line-interface
+          make install
 
-        # Install goreportcard-cli binary
-        go install ./cmd/goreportcard-cli
-    - name: Checkout Boeing/config-file-validator repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Run goreportcard
-      run: |
-        # Failure threshold is set to 95% to fail at any errors. Default is 75%.
-        goreportcard-cli -t 95
+          # Install goreportcard-cli binary
+          go install ./cmd/goreportcard-cli
+      - name: Checkout Boeing/config-file-validator repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run goreportcard
+        run: |
+          # Failure threshold is set to 95% to fail at any errors. Default is 75%.
+          goreportcard-cli -t 95

--- a/.github/workflows/goreportcard.yaml
+++ b/.github/workflows/goreportcard.yaml
@@ -1,3 +1,4 @@
+---
 name: Go Report Card
 
 on:

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,12 +36,6 @@ jobs:
         id: megalinter
         env:
           VALIDATE_ALL_CODEBASE: true
-          EXCLUDED_DIRECTORIES: test/fixtures/
-
-          DISABLE_LINTERS: REPOSITORY_KICS, GO_GOLANGCI_LINT, GO_REVIVE
-          SPELL_CSPELL_DISABLE_ERRORS: true
-          COPYPASTE_JSCPD_DISABLE_ERRORS: true
-
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Upload MegaLinter artifacts

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -28,7 +28,7 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           egress-policy: audit
-      
+
       # Git Checkout
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -3,11 +3,7 @@
 ---
 name: MegaLinter
 
-# Trigger mega-linter at every push. Action will also be visible from Pull
-# Requests to main
 on: # yamllint disable-line rule:truthy - false positive
-  # Comment this line to trigger action only on pull-requests
-  # (not recommended if you don't pay for GH Actions)
   push:
 
   pull_request:
@@ -15,27 +11,11 @@ on: # yamllint disable-line rule:truthy - false positive
       - main
       - master
 
-# # Comment env block if you do not want to apply fixes
-# env:
-#   # Apply linter fixes configuration
-#   #
-#   # When active, APPLY_FIXES must also be defined as environment variable
-#   # (in github/workflows/mega-linter.yml or other CI tool)
-#   APPLY_FIXES: all
-
-#   # Decide which event triggers application of fixes in a commit or a PR
-#   # (pull_request, push, all)
-#   APPLY_FIXES_EVENT: pull_request
-
-#   # If APPLY_FIXES is used, defines if the fixes are directly committed (commit)
-#   # or posted in a PR (pull_request)
-#   APPLY_FIXES_MODE: commit
-
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
@@ -43,67 +23,26 @@ jobs:
     name: MegaLinter
     runs-on: ubuntu-latest
 
-    # Give the default GITHUB_TOKEN write permission to commit and push, comment
-    # issues & post new PR; remove the ones you do not need
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-
     steps:
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
       # Git Checkout
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
-          # # If you use VALIDATE_ALL_CODEBASE = true, you can remove this line to
-          # # improve performance
-          # fetch-depth: 0
-
       # MegaLinter
       - name: MegaLinter
-
-        # You can override MegaLinter flavor used to have faster performances
-        # More info at https://megalinter.io/latest/flavors/
         uses: oxsecurity/megalinter@v8
-
-        id: ml
-
-        # All available variables are described in documentation
-        # https://megalinter.io/latest/configuration/
+        id: megalinter
         env:
-          # Validates all source when push on main, else just the git diff with
-          # main. Override with true if you always want to lint all sources
-          #
-          # To validate the entire codebase, set to:
           VALIDATE_ALL_CODEBASE: true
-          #
-          # To validate only diff with main, set to:
-          # VALIDATE_ALL_CODEBASE: >-
-          #   ${{
-          #     github.event_name == 'push' &&
-          #     contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
-          #   }}
+          EXCLUDED_DIRECTORIES: test/fixtures/
 
-          EXCLUDED_DIRECTORIES: >-
-            .git,
-            .github,
-            .test/fixtures,
+          DISABLE_LINTERS: REPOSITORY_KICS, GO_GOLANGCI_LINT, GO_REVIVE
+          SPELL_CSPELL_DISABLE_ERRORS: true
+          COPYPASTE_JSCPD_DISABLE_ERRORS: true
 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE
-          # .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
-
-          # Uncomment to disable copy-paste and spell checks
-          # DISABLE: COPYPASTE,SPELL
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
@@ -114,69 +53,3 @@ jobs:
           path: |
             megalinter-reports
             mega-linter.log
-
-      # # Set APPLY_FIXES_IF var for use in future steps
-      # - name: Set APPLY_FIXES_IF var
-      #   run: |
-      #     printf 'APPLY_FIXES_IF=%s\n' "${{
-      #       steps.ml.outputs.has_updated_sources == 1 &&
-      #       (
-      #         env.APPLY_FIXES_EVENT == 'all' ||
-      #         env.APPLY_FIXES_EVENT == github.event_name
-      #       ) &&
-      #       (
-      #         github.event_name == 'push' ||
-      #         github.event.pull_request.head.repo.full_name == github.repository
-      #       )
-      #     }}" >> "${GITHUB_ENV}"
-
-      # # Set APPLY_FIXES_IF_* vars for use in future steps
-      # - name: Set APPLY_FIXES_IF_* vars
-      #   run: |
-      #     printf 'APPLY_FIXES_IF_PR=%s\n' "${{
-      #       env.APPLY_FIXES_IF == 'true' &&
-      #       env.APPLY_FIXES_MODE == 'pull_request'
-      #     }}" >> "${GITHUB_ENV}"
-      #     printf 'APPLY_FIXES_IF_COMMIT=%s\n' "${{
-      #       env.APPLY_FIXES_IF == 'true' &&
-      #       env.APPLY_FIXES_MODE == 'commit' &&
-      #       (!contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref))
-      #     }}" >> "${GITHUB_ENV}"
-
-      # # Create pull request if applicable
-      # # (for now works only on PR from same repository, not from forks)
-      # - name: Create Pull Request with applied fixes
-      #   uses: peter-evans/create-pull-request@v6
-      #   id: cpr
-      #   if: env.APPLY_FIXES_IF_PR == 'true'
-      #   with:
-      #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-      #     commit-message: "[MegaLinter] Apply linters automatic fixes"
-      #     title: "[MegaLinter] Apply linters automatic fixes"
-      #     labels: bot
-
-      # - name: Create PR output
-      #   if: env.APPLY_FIXES_IF_PR == 'true'
-      #   run: |
-      #     echo "PR Number - ${{ steps.cpr.outputs.pull-request-number }}"
-      #     echo "PR URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
-      # # Push new commit if applicable
-      # # (for now works only on PR from same repository, not from forks)
-      # - name: Prepare commit
-      #   if: env.APPLY_FIXES_IF_COMMIT == 'true'
-      #   run: sudo chown -Rc $UID .git/
-
-      # - name: Commit and push applied linter fixes
-      #   uses: stefanzweifel/git-auto-commit-action@v4
-      #   if: env.APPLY_FIXES_IF_COMMIT == 'true'
-      #   with:
-      #     branch: >-
-      #       ${{
-      #         github.event.pull_request.head.ref ||
-      #         github.head_ref ||
-      #         github.ref
-      #       }}
-      #     commit_message: "[MegaLinter] Apply linters fixes"
-      #     commit_user_name: megalinter-bot
-      #     commit_user_email: nicolas.vuillamy@ox.security

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -31,13 +31,13 @@ jobs:
 
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
       # MegaLinter
       - name: MegaLinter
-        uses: oxsecurity/megalinter@v8
+        uses: oxsecurity/megalinter@1fc052d03c7a43c78fe0fee19c9d648b749e0c01 # v8.3.0
         id: megalinter
         env:
           VALIDATE_ALL_CODEBASE: true
@@ -46,7 +46,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: MegaLinter reports
           path: |

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+      
       # Git Checkout
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -1,0 +1,182 @@
+# MegaLinter GitHub Action configuration file
+# More info at https://megalinter.io
+---
+name: MegaLinter
+
+# Trigger mega-linter at every push. Action will also be visible from Pull
+# Requests to main
+on: # yamllint disable-line rule:truthy - false positive
+  # Comment this line to trigger action only on pull-requests
+  # (not recommended if you don't pay for GH Actions)
+  push:
+
+  pull_request:
+    branches:
+      - main
+      - master
+
+# # Comment env block if you do not want to apply fixes
+# env:
+#   # Apply linter fixes configuration
+#   #
+#   # When active, APPLY_FIXES must also be defined as environment variable
+#   # (in github/workflows/mega-linter.yml or other CI tool)
+#   APPLY_FIXES: all
+
+#   # Decide which event triggers application of fixes in a commit or a PR
+#   # (pull_request, push, all)
+#   APPLY_FIXES_EVENT: pull_request
+
+#   # If APPLY_FIXES is used, defines if the fixes are directly committed (commit)
+#   # or posted in a PR (pull_request)
+#   APPLY_FIXES_MODE: commit
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  megalinter:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+
+    # Give the default GITHUB_TOKEN write permission to commit and push, comment
+    # issues & post new PR; remove the ones you do not need
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      # Git Checkout
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+
+          # # If you use VALIDATE_ALL_CODEBASE = true, you can remove this line to
+          # # improve performance
+          # fetch-depth: 0
+
+      # MegaLinter
+      - name: MegaLinter
+
+        # You can override MegaLinter flavor used to have faster performances
+        # More info at https://megalinter.io/latest/flavors/
+        uses: oxsecurity/megalinter@v8
+
+        id: ml
+
+        # All available variables are described in documentation
+        # https://megalinter.io/latest/configuration/
+        env:
+          # Validates all source when push on main, else just the git diff with
+          # main. Override with true if you always want to lint all sources
+          #
+          # To validate the entire codebase, set to:
+          VALIDATE_ALL_CODEBASE: true
+          #
+          # To validate only diff with main, set to:
+          # VALIDATE_ALL_CODEBASE: >-
+          #   ${{
+          #     github.event_name == 'push' &&
+          #     contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
+          #   }}
+
+          EXCLUDED_DIRECTORIES: >-
+            .git,
+            .github,
+            .test/fixtures,
+
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE
+          # .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
+
+          # Uncomment to disable copy-paste and spell checks
+          # DISABLE: COPYPASTE,SPELL
+
+      # Upload MegaLinter artifacts
+      - name: Archive production artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: MegaLinter reports
+          path: |
+            megalinter-reports
+            mega-linter.log
+
+      # # Set APPLY_FIXES_IF var for use in future steps
+      # - name: Set APPLY_FIXES_IF var
+      #   run: |
+      #     printf 'APPLY_FIXES_IF=%s\n' "${{
+      #       steps.ml.outputs.has_updated_sources == 1 &&
+      #       (
+      #         env.APPLY_FIXES_EVENT == 'all' ||
+      #         env.APPLY_FIXES_EVENT == github.event_name
+      #       ) &&
+      #       (
+      #         github.event_name == 'push' ||
+      #         github.event.pull_request.head.repo.full_name == github.repository
+      #       )
+      #     }}" >> "${GITHUB_ENV}"
+
+      # # Set APPLY_FIXES_IF_* vars for use in future steps
+      # - name: Set APPLY_FIXES_IF_* vars
+      #   run: |
+      #     printf 'APPLY_FIXES_IF_PR=%s\n' "${{
+      #       env.APPLY_FIXES_IF == 'true' &&
+      #       env.APPLY_FIXES_MODE == 'pull_request'
+      #     }}" >> "${GITHUB_ENV}"
+      #     printf 'APPLY_FIXES_IF_COMMIT=%s\n' "${{
+      #       env.APPLY_FIXES_IF == 'true' &&
+      #       env.APPLY_FIXES_MODE == 'commit' &&
+      #       (!contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref))
+      #     }}" >> "${GITHUB_ENV}"
+
+      # # Create pull request if applicable
+      # # (for now works only on PR from same repository, not from forks)
+      # - name: Create Pull Request with applied fixes
+      #   uses: peter-evans/create-pull-request@v6
+      #   id: cpr
+      #   if: env.APPLY_FIXES_IF_PR == 'true'
+      #   with:
+      #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+      #     commit-message: "[MegaLinter] Apply linters automatic fixes"
+      #     title: "[MegaLinter] Apply linters automatic fixes"
+      #     labels: bot
+
+      # - name: Create PR output
+      #   if: env.APPLY_FIXES_IF_PR == 'true'
+      #   run: |
+      #     echo "PR Number - ${{ steps.cpr.outputs.pull-request-number }}"
+      #     echo "PR URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+      # # Push new commit if applicable
+      # # (for now works only on PR from same repository, not from forks)
+      # - name: Prepare commit
+      #   if: env.APPLY_FIXES_IF_COMMIT == 'true'
+      #   run: sudo chown -Rc $UID .git/
+
+      # - name: Commit and push applied linter fixes
+      #   uses: stefanzweifel/git-auto-commit-action@v4
+      #   if: env.APPLY_FIXES_IF_COMMIT == 'true'
+      #   with:
+      #     branch: >-
+      #       ${{
+      #         github.event.pull_request.head.ref ||
+      #         github.head_ref ||
+      #         github.ref
+      #       }}
+      #     commit_message: "[MegaLinter] Apply linters fixes"
+      #     commit_user_name: megalinter-bot
+      #     commit_user_email: nicolas.vuillamy@ox.security

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: Release Pipeline
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,7 @@
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
-
+---
 name: Scorecard supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,9 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '43 11 * * 5'
+    - cron: "43 11 * * 5"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
 
 # Declare default permissions as read only.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@ bin/
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 .vscode
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/
 vendor/
 .vscode
 .idea
+megalinter-reports/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -78,7 +78,7 @@ linters-settings:
   nolintlint:
     # Disable to ensure that all nolint directives actually have an effect.
     # Default: false
-    allow-unused: true  # too many false positive reported
+    allow-unused: true # too many false positive reported
     # Exclude following linters from requiring an explanation.
     # Default: []
     allow-no-explanation: []

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,7 @@ linters:
 
     # report functions we don't want (println for example)
     # see linter-settings.forbidigo for more explanations
-    #- forbidigo
+    # - forbidigo
 
     # Very Basic spell error checker
     - misspell

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -4,15 +4,23 @@
 EXCLUDED_DIRECTORIES:
   - test/fixtures/
 
+# Disabled certain linters due to duplication and or redundancy.
 DISABLE_LINTERS:
+  # https://megalinter.io/latest/descriptors/repository_kics/
   - REPOSITORY_KICS
+  # already enabled as a dedicated linter for this repo
   - GO_GOLANGCI_LINT
+  # another linter, https://megalinter.io/latest/descriptors/go_revive/
   - GO_REVIVE
+  # Another vulnerability scanner, https://megalinter.io/latest/descriptors/repository_grype/
   - REPOSITORY_GRYPE
+  # Spell checker, https://megalinter.io/latest/descriptors/spell_lychee/
   - SPELL_LYCHEE
 
 DISABLE_ERRORS_LINTERS:
+  # To prevent unnecessary spelling errors (will spit out warnings)
   - SPELL_CSPELL
+  # copypaste checker (JSCPD), can be added in a separate PR as this will need test refactor
   - COPYPASTE_JSCPD
 
 FILTER_REGEX_EXCLUDE: "(test/)"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,7 +1,7 @@
 # Configuration file for MegaLinter
 # See all available variables at https://megalinter.io/configuration/ and in linters documentation
 ---
-EXCLUDED_DIRECTORIES: 
+EXCLUDED_DIRECTORIES:
   - test/fixtures/
 
 DISABLE_LINTERS:
@@ -15,9 +15,9 @@ DISABLE_ERRORS_LINTERS:
   - SPELL_CSPELL
   - COPYPASTE_JSCPD
 
-FILTER_REGEX_EXCLUDE: '(test/)'
-JSON_JSONLINT_FILTER_REGEX_EXCLUDE: '(test/)'
-YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: '(test/)'
-YAML_PRETTIER_FILTER_REGEX_EXCLUDE: '(test/)'
+FILTER_REGEX_EXCLUDE: "(test/)"
+JSON_JSONLINT_FILTER_REGEX_EXCLUDE: "(test/)"
+YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: "(test/)"
+YAML_PRETTIER_FILTER_REGEX_EXCLUDE: "(test/)"
 SHOW_ELAPSED_TIME: true
 REPORT_OUTPUT_FOLDER: megalinter-reports

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,0 +1,22 @@
+# Configuration file for MegaLinter
+# See all available variables at https://megalinter.io/configuration/ and in linters documentation
+
+EXCLUDED_DIRECTORIES: 
+  - test/fixtures/
+
+DISABLE_LINTERS:
+  - REPOSITORY_KICS
+  - GO_GOLANGCI_LINT
+  - GO_REVIVE
+  - REPOSITORY_GRYPE
+
+DISABLE_ERRORS_LINTERS:
+  - SPELL_CSPELL
+  - COPYPASTE_JSCPD
+
+FILTER_REGEX_EXCLUDE: '(test/)'
+JSON_JSONLINT_FILTER_REGEX_EXCLUDE: '(test/)'
+YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: '(test/)'
+YAML_PRETTIER_FILTER_REGEX_EXCLUDE: '(test/)'
+SHOW_ELAPSED_TIME: true
+REPORT_OUTPUT_FOLDER: megalinter-reports

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,6 +1,6 @@
 # Configuration file for MegaLinter
 # See all available variables at https://megalinter.io/configuration/ and in linters documentation
-
+---
 EXCLUDED_DIRECTORIES: 
   - test/fixtures/
 
@@ -9,6 +9,7 @@ DISABLE_LINTERS:
   - GO_GOLANGCI_LINT
   - GO_REVIVE
   - REPOSITORY_GRYPE
+  - SPELL_LYCHEE
 
 DISABLE_ERRORS_LINTERS:
   - SPELL_CSPELL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ Pull requests are the best way to propose changes to the codebase (we use [GitHu
 1. Fork the repository and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. Ensure the test suite passes.
-4. Submit that pull request!
+4. Ensure linters are happy, a CI pipeline will be run for your changes.
+5. Submit that pull request!
 
 ## Report bugs using GitHub's [issues](https://github.com/boeing/config-file-validator/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Boeing/config-file-validator/issues/new);

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG BASE_IMAGE_TAG=3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
-
 FROM golang:1.23@sha256:70031844b8c225351d0bb63e2c383f80db85d92ba894e3da7e13bcf80efa9a37 AS go-builder
 ARG VALIDATOR_VERSION=unknown
 COPY . /build/
@@ -13,7 +11,7 @@ RUN CGO_ENABLED=0 \
   -o validator \
   cmd/validator/validator.go
 
-FROM alpine:$BASE_IMAGE_TAG
+FROM alpine:3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 USER user
 COPY --from=go-builder /build/validator /
 HEALTHCHECK NONE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.21@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45
+ARG BASE_IMAGE_TAG=3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 
 FROM golang:1.23@sha256:70031844b8c225351d0bb63e2c383f80db85d92ba894e3da7e13bcf80efa9a37 AS go-builder
 ARG VALIDATOR_VERSION=unknown
@@ -13,7 +13,8 @@ RUN CGO_ENABLED=0 \
   -o validator \
   cmd/validator/validator.go
 
-FROM $BASE_IMAGE as base
+FROM alpine:$BASE_IMAGE_TAG
 USER user
 COPY --from=go-builder /build/validator /
+HEALTHCHECK NONE
 ENTRYPOINT [ "/validator" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=0 \
   -o validator \
   cmd/validator/validator.go
 
-FROM $BASE_IMAGE
+FROM $BASE_IMAGE as base
+USER user
 COPY --from=go-builder /build/validator /
 ENTRYPOINT [ "/validator" ]

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ docker build . -t config-file-validator:v1.8.0
 </a>
 
 ## Contributing
-We welcome contributions! Please refer to our [contributing guide](/CONTRIBUTING.md)
+We welcome contributions! Please refer to our [contributing guide](./CONTRIBUTING.md)
 
 ## License
-The Config File Validator is released under the [Apache 2.0](/LICENSE) License
+The Config File Validator is released under the [Apache 2.0](./LICENSE) License

--- a/index.md
+++ b/index.md
@@ -220,6 +220,13 @@ validator -groupby directory,pass-fail
 
 ![Groupby File Type and Pass/Fail](./img/gb-filetype-and-pass-fail.gif)
 
+### Output results to a file
+Output report results to a file (default name is `result.{extension}`). Must provide reporter flag with a supported extension format. Available options are `junit` and `json`. If an existing directory is provided, create a file named default name in the given directory. If a file name is provided, create a file named the given name at the current working directory.
+
+```
+validator --reporter=json --output=/path/to/dir
+```
+
 ### Suppress output
 Passing the `--quiet` flag suppresses all output to stdout. If there are invalid config files the validator tool will exit with 1. Any errors in execution such as an invalid path will still be displayed.
 
@@ -318,7 +325,7 @@ docker build . -t config-file-validator:v1.8.0
 </a>
 
 ## Contributing
-We welcome contributions! Please refer to our [contributing guide](/CONTRIBUTING.md)
+We welcome contributions! Please refer to our [contributing guide](./CONTRIBUTING.md)
 
 ## License
-The Config File Validator is released under the [Apache 2.0](/LICENSE) License
+The Config File Validator is released under the [Apache 2.0](./LICENSE) License


### PR DESCRIPTION
PR for issue #188 

Changes:

1. Added megalinter github action
   1. Added  .mega-linter.yml in the root directory for mega linter configuration
      1. No specific [flavor](https://github.com/marketplace/actions/megalinter#flavors) chosen for the mega linter as the project contains files of all formats. We can potentially update this in the future. 
      2. Disabled certain linters due to duplication and or redundancy.
      3. Disabled errors for spell checker (will spit out warnings)
      4. Disabled copypaste checker ([JSCPD](https://megalinter.io/latest/descriptors/copypaste_jscpd/)), can be added in a separate PR as this will need test refactor
   5. Updated contributing doc 
3. Linted code
   1. Updated repo wide yaml files to confirm to linter expectations
   2. Update Dockerfile 
   3. Fixed broken links in markdown files
4. Updated .gitignore 

 