### PR TITLE
Bypass summary printing if any of the group is pass-fail

### DIFF
--- a/pkg/reporter/stdout_reporter.go
+++ b/pkg/reporter/stdout_reporter.go
@@ -50,7 +50,9 @@ func PrintSingleGroupStdout(groupReport map[string][]Report) error {
 		totalSuccessCount += stdoutReport.Summary.Passed
 		totalFailureCount += stdoutReport.Summary.Failed
 		fmt.Println(stdoutReport.Text)
-		fmt.Printf("Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
+		if group != "Passed" && group != "Failed" {
+			fmt.Printf("Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
+		}
 	}
 
 	fmt.Printf("Total Summary: %d succeeded, %d failed\n", totalSuccessCount, totalFailureCount)
@@ -70,7 +72,9 @@ func PrintDoubleGroupStdout(groupReport map[string]map[string][]Report) error {
 			totalSuccessCount += stdoutReport.Summary.Passed
 			totalFailureCount += stdoutReport.Summary.Failed
 			fmt.Println(stdoutReport.Text)
-			fmt.Printf("    Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
+			if group != "Passed" && group != "Failed" && group2 != "Passed" && group2 != "Failed" {
+				fmt.Printf("    Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
+			}
 		}
 	}
 
@@ -94,7 +98,9 @@ func PrintTripleGroupStdout(groupReport map[string]map[string]map[string][]Repor
 				totalSuccessCount += stdoutReport.Summary.Passed
 				totalFailureCount += stdoutReport.Summary.Failed
 				fmt.Println(stdoutReport.Text)
-				fmt.Printf("        Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
+				if groupOne != "Passed" && groupOne != "Failed" && groupTwo != "Passed" && groupTwo != "Failed" && groupThree != "Passed" && groupThree != "Failed" {
+					fmt.Printf("        Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
+				}
 			}
 		}
 	}

--- a/pkg/reporter/stdout_reporter.go
+++ b/pkg/reporter/stdout_reporter.go
@@ -50,7 +50,7 @@ func PrintSingleGroupStdout(groupReport map[string][]Report) error {
 		totalSuccessCount += stdoutReport.Summary.Passed
 		totalFailureCount += stdoutReport.Summary.Failed
 		fmt.Println(stdoutReport.Text)
-		if group != "Passed" && group != "Failed" {
+		if checkGroupsForPassFail(group) {
 			fmt.Printf("Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
 		}
 	}
@@ -72,7 +72,7 @@ func PrintDoubleGroupStdout(groupReport map[string]map[string][]Report) error {
 			totalSuccessCount += stdoutReport.Summary.Passed
 			totalFailureCount += stdoutReport.Summary.Failed
 			fmt.Println(stdoutReport.Text)
-			if group != "Passed" && group != "Failed" && group2 != "Passed" && group2 != "Failed" {
+			if checkGroupsForPassFail(group, group2) {
 				fmt.Printf("    Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
 			}
 		}
@@ -98,7 +98,7 @@ func PrintTripleGroupStdout(groupReport map[string]map[string]map[string][]Repor
 				totalSuccessCount += stdoutReport.Summary.Passed
 				totalFailureCount += stdoutReport.Summary.Failed
 				fmt.Println(stdoutReport.Text)
-				if groupOne != "Passed" && groupOne != "Failed" && groupTwo != "Passed" && groupTwo != "Failed" && groupThree != "Passed" && groupThree != "Failed" {
+				if checkGroupsForPassFail(groupOne, groupTwo, groupThree) {
 					fmt.Printf("        Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
 				}
 			}

--- a/pkg/reporter/stdout_reporter.go
+++ b/pkg/reporter/stdout_reporter.go
@@ -109,6 +109,16 @@ func PrintTripleGroupStdout(groupReport map[string]map[string]map[string][]Repor
 	return nil
 }
 
+// Checks if any of the provided groups are "Passed" or "Failed".
+func checkGroupsForPassFail(groups ...string) bool {
+	for _, group := range groups {
+		if group == "Passed" || group == "Failed" {
+			return false
+		}
+	}
+	return true
+}
+
 // Creates the standard text report
 func createStdoutReport(reports []Report, indentSize int) reportStdout {
 	result := reportStdout{}


### PR DESCRIPTION
This PR removes the summary printing when `--groupby` flag contains `pass-fail` as one of the groups. Summary is only printed if `pass-fail` is absent.

Fixes #231 