### PR TITLE
update golangci-lint version and fix any lint warnings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,12 +36,12 @@ jobs:
           go-version: ${{ matrix.go }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.57.2
+          version: v2.3.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,5 @@
----
+version: "2"
+
 # Options for analysis running.
 issues:
   # Maximum issues count per one linter.
@@ -12,150 +13,171 @@ issues:
 
 linters:
   enable:
+    # detect duplicated words in code
+    - dupword
+
     # check when errors are compared without errors.Is
     - errorlint
-
-    # check imports order and makes it always deterministic.
-    - gci
-
-    # linter to detect errors invalid key values count
-    - loggercheck
 
     # report functions we don't want (println for example)
     # see linter-settings.forbidigo for more explanations
     # - forbidigo
 
+    # simple security check
+    - gosec
+
+    # linter to detect errors invalid key values count
+    - loggercheck
+
+    # mirror suggests rewrites to avoid unnecessary []byte/string conversion
+    - mirror
+
     # Very Basic spell error checker
     - misspell
 
-    # simple security check
-    - gosec
+    # Finds sending http request without context.Context
+    - noctx
+
+    # ensure that lint exceptions have explanations. Consider the case below:
+    - nolintlint
 
     # Fast, configurable, extensible, flexible, and beautiful linter for Go.
     # Drop-in replacement of golint.
     - revive
 
-    # Finds sending http request without context.Context
-    - noctx
-
-    # make sure to use t.Helper() when needed
-    - thelper
-
     # make sure that error are checked after a rows.Next()
     - rowserrcheck
-
-    # ensure that lint exceptions have explanations. Consider the case below:
-    - nolintlint
-
-    # detect duplicated words in code
-    - dupword
-
-    # detect the possibility to use variables/constants from the Go standard library.
-    - usestdlibvars
-
-    # mirror suggests rewrites to avoid unnecessary []byte/string conversion
-    - mirror
 
     # testify checks good usage of github.com/stretchr/testify.
     - testifylint
 
-linters-settings:
-  usestdlibvars:
-    # Suggest the use of http.MethodXX.
-    # Default: true
-    http-method: true
-    # Suggest the use of http.StatusXX.
-    # Default: true
-    http-status-code: true
-    # Suggest the use of time.Weekday.String().
-    # Default: true
-    # We don't want this
-    time-weekday: false
-    # Suggest the use of constants available in time package
-    # Default: false
-    time-layout: true
+    # make sure to use t.Helper() when needed
+    - thelper
 
-  nolintlint:
-    # Disable to ensure that all nolint directives actually have an effect.
-    # Default: false
-    allow-unused: true # too many false positive reported
-    # Exclude following linters from requiring an explanation.
-    # Default: []
-    allow-no-explanation: []
-    # Enable to require an explanation of nonzero length
-    # after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific
-    # linter being suppressed.
-    # Default: false
-    require-specific: true
+    # detect the possibility to use variables/constants from the Go standard library.
+    - usestdlibvars
 
-  # define the import orders
-  gci:
-    sections:
-      # Standard section: captures all standard packages.
-      - standard
-      # Default section: catchall that is not standard or custom
-      - default
-      # Custom section: groups all imports with the specified Prefix.
-      - prefix(github.com/Boeing/config-file-validator)
+  settings:
+    nolintlint:
+      # Enable to require an explanation of nonzero length
+      # after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific
+      # linter being suppressed.
+      # Default: false
+      require-specific: true
+      # Disable to ensure that all nolint directives actually have an effect.
+      # Default: false
+      allow-unused: true # too many false positive reported
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: []
 
-  staticcheck:
-    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
-    checks: ["all"]
+    revive:
+      enable-all-rules: true
+      rules:
+        # we must provide configuration for linter that requires them
+        # enable-all-rules is OK, but many revive linters expect configuration
+        # and cannot work without them
 
-  revive:
-    enable-all-rules: true
-    rules:
-      # we must provide configuration for linter that requires them
-      # enable-all-rules is OK, but many revive linters expect configuration
-      # and cannot work without them
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: '*testing.T'
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+        - name: exported
+          arguments:
+            # enables checking public methods of private types
+            - checkPrivateReceivers
+            # make error messages clearer
+            - sayRepetitiveInsteadOfStutters
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        arguments:
-          # enables checking public methods of private types
-          - "checkPrivateReceivers"
-          # make error messages clearer
-          - "sayRepetitiveInsteadOfStutters"
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+        - name: unhandled-error
+          arguments: # here are the exceptions we don't want to be reported
+            - fmt.Print.*
+            - fmt.Fprint.*
+            - bytes.Buffer.Write
+            - bytes.Buffer.WriteByte
+            - bytes.Buffer.WriteString
+            - strings.Builder.WriteString
+            - strings.Builder.WriteRune
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
-      - name: unhandled-error
-        arguments: # here are the exceptions we don't want to be reported
-          - "fmt.Print.*"
-          - "fmt.Fprint.*"
-          - "bytes.Buffer.Write"
-          - "bytes.Buffer.WriteByte"
-          - "bytes.Buffer.WriteString"
-          - "strings.Builder.WriteString"
-          - "strings.Builder.WriteRune"
+        # disable everything we don't want
+        - name: add-constant
+          disabled: true # too noisy
+        - name: line-length-limit
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: banned-characters
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: file-header
+          disabled: true
+        - name: empty-lines
+          disabled: true
 
-      # disable everything we don't want
-      - name: add-constant
-        disabled: true # too noisy
-      - name: line-length-limit
-        disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: cognitive-complexity
-        disabled: true
-      - name: banned-characters
-        disabled: true
-      - name: cyclomatic
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      - name: function-result-limit
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: file-header
-        disabled: true
-      - name: empty-lines
-        disabled: true
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+      checks:
+        - all
+
+    usestdlibvars:
+      # Suggest the use of http.MethodXX.
+      # Default: true
+      http-method: true
+      # Suggest the use of http.StatusXX.
+      # Default: true
+      http-status-code: true
+      # Suggest the use of time.Weekday.String().
+      # Default: true
+      # We don't want this
+      time-weekday: false
+      # Suggest the use of constants available in time package
+      # Default: false
+      time-layout: true
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - gci
+
+  settings:
+    gci:
+      sections:
+        # Standard section: captures all standard packages.
+        - standard
+        # Default section: catchall that is not standard or custom
+        - default
+        # Custom section: groups all imports with the specified Prefix.
+        - prefix(github.com/Boeing/config-file-validator)
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -47,8 +47,8 @@ import (
 	"github.com/Boeing/config-file-validator/pkg/cli"
 	"github.com/Boeing/config-file-validator/pkg/filetype"
 	"github.com/Boeing/config-file-validator/pkg/finder"
-	"github.com/Boeing/config-file-validator/pkg/misc"
 	"github.com/Boeing/config-file-validator/pkg/reporter"
+	"github.com/Boeing/config-file-validator/pkg/tools"
 )
 
 type validatorConfig struct {
@@ -76,12 +76,13 @@ func (rf *reporterFlags) Set(value string) error {
 
 // Custom Usage function to cover
 func validatorUsage() {
-	fmt.Printf("Usage: validator [OPTIONS] [<search_path>...]\n\n")
-	fmt.Printf("positional arguments:\n")
+	fmt.Println("Usage: validator [OPTIONS] [<search_path>...]")
+	fmt.Println()
+	fmt.Println("positional arguments:")
 	fmt.Printf(
 		"    search_path: The search path on the filesystem for configuration files. " +
 			"Defaults to the current working directory if no search_path provided\n\n")
-	fmt.Printf("optional flags:\n")
+	fmt.Println("optional flags:")
 	flag.PrintDefaults()
 }
 
@@ -166,13 +167,13 @@ Supported formats: standard, json, junit, and sarif (default: "standard")`,
 	}
 
 	if depthPtr != nil && isFlagSet("depth") && *depthPtr < 0 {
-		return validatorConfig{}, errors.New("Wrong parameter value for depth, value cannot be negative")
+		return validatorConfig{}, errors.New("wrong parameter value for depth, value cannot be negative")
 	}
 
 	if *excludeFileTypesPtr != "" {
 		*excludeFileTypesPtr = strings.ToLower(*excludeFileTypesPtr)
 		if !validateFileTypeList(strings.Split(*excludeFileTypesPtr, ",")) {
-			return validatorConfig{}, errors.New("Invalid exclude file type")
+			return validatorConfig{}, errors.New("invalid exclude file type")
 		}
 	}
 
@@ -203,11 +204,11 @@ func validateReporterConf(conf map[string]string, groupBy *string) error {
 	for reportType := range conf {
 		_, ok := acceptedReportTypes[reportType]
 		if !ok {
-			return errors.New("Wrong parameter value for reporter, only supports standard, json, junit, or sarif")
+			return errors.New("wrong parameter value for reporter, only supports standard, json, junit, or sarif")
 		}
 
 		if !groupOutputReportTypes[reportType] && groupBy != nil && *groupBy != "" {
-			return errors.New("Wrong parameter value for reporter, groupby is only supported for standard and JSON reports")
+			return errors.New("wrong parameter value for reporter, groupby is only supported for standard and JSON reports")
 		}
 	}
 
@@ -224,10 +225,10 @@ func validateGroupByConf(groupBy *string) error {
 	if groupBy != nil && isFlagSet("groupby") {
 		for _, groupBy := range groupByUserInput {
 			if !slices.Contains(groupByAllowedValues, groupBy) {
-				return errors.New("Wrong parameter value for groupby, only supports filetype, directory, pass-fail")
+				return errors.New("wrong parameter value for groupby, only supports filetype, directory, pass-fail")
 			}
 			if _, ok := seenValues[groupBy]; ok {
-				return errors.New("Wrong parameter value for groupby, duplicate values are not allowed")
+				return errors.New("wrong parameter value for groupby, duplicate values are not allowed")
 			}
 			seenValues[groupBy] = true
 		}
@@ -262,7 +263,7 @@ func handleGlobbing(searchPaths []string) ([]string, error) {
 		if isGlobPattern(flagArg) {
 			matches, err := doublestar.Glob(os.DirFS("."), flagArg)
 			if err != nil {
-				return nil, errors.New("Glob matching error")
+				return nil, errors.New("glob matching error")
 			}
 			searchPaths = append(searchPaths, matches...)
 		} else {
@@ -286,7 +287,7 @@ func parseReporterFlags(flags reporterFlags) (map[string]string, error) {
 				conf[parts[0]] = parts[1]
 			}
 		default:
-			return nil, errors.New("Wrong parameter value format for reporter, expected format is `report_type:optional_file_path`")
+			return nil, errors.New("wrong parameter value format for reporter, expected format is `report_type:optional_file_path`")
 		}
 	}
 
@@ -432,7 +433,7 @@ func mainInit() int {
 
 func getExcludeFileTypes(configExcludeFileTypes string) []string {
 	excludeFileTypes := strings.Split(strings.ToLower(configExcludeFileTypes), ",")
-	uniqueFileTypes := misc.ArrToMap(excludeFileTypes...)
+	uniqueFileTypes := tools.ArrToMap(excludeFileTypes...)
 
 	for _, ft := range filetype.FileTypes {
 		for ext := range ft.Extensions {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -84,7 +84,7 @@ func (c CLI) Run() (int, error) {
 	var reports []reporter.Report
 	foundFiles, err := c.Finder.Find()
 	if err != nil {
-		return 1, fmt.Errorf("Unable to find files: %w", err)
+		return 1, fmt.Errorf("unable to find files: %w", err)
 	}
 
 	for _, fileToValidate := range foundFiles {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -31,7 +31,7 @@ func Test_CLI(t *testing.T) {
 	}
 
 	if exitStatus != 0 {
-		t.Errorf("Exit status was not 0")
+		t.Error("Exit status was not 0")
 	}
 }
 
@@ -60,7 +60,7 @@ func Test_CLIWithMultipleReporters(t *testing.T) {
 	}
 
 	if exitStatus != 0 {
-		t.Errorf("Exit status was not 0")
+		t.Error("Exit status was not 0")
 	}
 
 	err = os.Remove(output)
@@ -83,7 +83,7 @@ func Test_CLIWithFailedValidation(t *testing.T) {
 	}
 
 	if exitStatus != 1 {
-		t.Errorf("Exit status was not 1")
+		t.Error("Exit status was not 1")
 	}
 }
 
@@ -98,11 +98,11 @@ func Test_CLIBadPath(t *testing.T) {
 	exitStatus, err := cli.Run()
 
 	if err == nil {
-		t.Errorf("A nil error was returned")
+		t.Error("A nil error was returned")
 	}
 
 	if exitStatus == 0 {
-		t.Errorf("Exit status was not 1")
+		t.Error("Exit status was not 1")
 	}
 }
 
@@ -127,7 +127,7 @@ func Test_CLIWithGroup(t *testing.T) {
 	}
 
 	if exitStatus != 0 {
-		t.Errorf("Exit status was not 0")
+		t.Error("Exit status was not 0")
 	}
 }
 

--- a/pkg/cli/group_output_test.go
+++ b/pkg/cli/group_output_test.go
@@ -33,7 +33,7 @@ func Test_NoGroupOutput(t *testing.T) {
 		}
 
 		if exitStatus != 0 {
-			t.Errorf("Exit status was not 0")
+			t.Error("Exit status was not 0")
 		}
 	}
 }
@@ -64,7 +64,7 @@ func Test_SingleGroupOutput(t *testing.T) {
 		}
 
 		if exitStatus != 0 {
-			t.Errorf("Exit status was not 0")
+			t.Error("Exit status was not 0")
 		}
 	}
 }
@@ -84,7 +84,7 @@ func Test_WindowsDirectoryGroupBy(t *testing.T) {
 	groupDirectory := GroupByDirectory(reports)
 
 	if len(groupDirectory) != 2 {
-		t.Errorf("GroupByDirectory did not group correctly")
+		t.Error("GroupByDirectory did not group correctly")
 	}
 }
 
@@ -103,7 +103,7 @@ func Test_DirectoryGroupBy(t *testing.T) {
 	groupDirectory := GroupByDirectory(reports)
 
 	if len(groupDirectory) != 2 {
-		t.Errorf("GroupByDirectory did not group correctly")
+		t.Error("GroupByDirectory did not group correctly")
 	}
 }
 
@@ -133,7 +133,7 @@ func Test_DoubleGroupOutput(t *testing.T) {
 		}
 
 		if exitStatus != 0 {
-			t.Errorf("Exit status was not 0")
+			t.Error("Exit status was not 0")
 		}
 	}
 }
@@ -164,7 +164,7 @@ func Test_TripleGroupOutput(t *testing.T) {
 		}
 
 		if exitStatus != 0 {
-			t.Errorf("Exit status was not 0")
+			t.Error("Exit status was not 0")
 		}
 	}
 }
@@ -192,11 +192,11 @@ func Test_IncorrectSingleGroupOutput(t *testing.T) {
 		exitStatus, err := cli.Run()
 
 		if err == nil {
-			t.Errorf("An error was not returned")
+			t.Error("An error was not returned")
 		}
 
 		if exitStatus != 1 {
-			t.Errorf("Exit status was not 1")
+			t.Error("Exit status was not 1")
 		}
 	}
 }
@@ -224,11 +224,11 @@ func Test_IncorrectDoubleGroupOutput(t *testing.T) {
 		exitStatus, err := cli.Run()
 
 		if err == nil {
-			t.Errorf("An error was not returned")
+			t.Error("An error was not returned")
 		}
 
 		if exitStatus != 1 {
-			t.Errorf("Exit status was not 1")
+			t.Error("Exit status was not 1")
 		}
 	}
 }
@@ -256,11 +256,11 @@ func Test_IncorrectTripleGroupOutput(t *testing.T) {
 		exitStatus, err := cli.Run()
 
 		if err == nil {
-			t.Errorf("An error was not returned")
+			t.Error("An error was not returned")
 		}
 
 		if exitStatus != 1 {
-			t.Errorf("Exit status was not 0")
+			t.Error("Exit status was not 0")
 		}
 	}
 }

--- a/pkg/filetype/file_type.go
+++ b/pkg/filetype/file_type.go
@@ -1,7 +1,7 @@
 package filetype
 
 import (
-	"github.com/Boeing/config-file-validator/pkg/misc"
+	"github.com/Boeing/config-file-validator/pkg/tools"
 	"github.com/Boeing/config-file-validator/pkg/validator"
 )
 
@@ -19,7 +19,7 @@ type FileType struct {
 // represent a JSON file
 var JSONFileType = FileType{
 	"json",
-	misc.ArrToMap("json"),
+	tools.ArrToMap("json"),
 	validator.JSONValidator{},
 }
 
@@ -27,7 +27,7 @@ var JSONFileType = FileType{
 // represent a YAML file
 var YAMLFileType = FileType{
 	"yaml",
-	misc.ArrToMap("yml", "yaml"),
+	tools.ArrToMap("yml", "yaml"),
 	validator.YAMLValidator{},
 }
 
@@ -35,7 +35,7 @@ var YAMLFileType = FileType{
 // represent a XML file
 var XMLFileType = FileType{
 	"xml",
-	misc.ArrToMap("xml"),
+	tools.ArrToMap("xml"),
 	validator.XMLValidator{},
 }
 
@@ -43,7 +43,7 @@ var XMLFileType = FileType{
 // represent a Toml file
 var TomlFileType = FileType{
 	"toml",
-	misc.ArrToMap("toml"),
+	tools.ArrToMap("toml"),
 	validator.TomlValidator{},
 }
 
@@ -51,7 +51,7 @@ var TomlFileType = FileType{
 // represent a Ini file
 var IniFileType = FileType{
 	"ini",
-	misc.ArrToMap("ini"),
+	tools.ArrToMap("ini"),
 	validator.IniValidator{},
 }
 
@@ -59,7 +59,7 @@ var IniFileType = FileType{
 // represent a Properties file
 var PropFileType = FileType{
 	"properties",
-	misc.ArrToMap("properties"),
+	tools.ArrToMap("properties"),
 	validator.PropValidator{},
 }
 
@@ -67,7 +67,7 @@ var PropFileType = FileType{
 // represent a HCL file
 var HclFileType = FileType{
 	"hcl",
-	misc.ArrToMap("hcl"),
+	tools.ArrToMap("hcl"),
 	validator.HclValidator{},
 }
 
@@ -75,7 +75,7 @@ var HclFileType = FileType{
 // represent a Plist file
 var PlistFileType = FileType{
 	"plist",
-	misc.ArrToMap("plist"),
+	tools.ArrToMap("plist"),
 	validator.PlistValidator{},
 }
 
@@ -83,7 +83,7 @@ var PlistFileType = FileType{
 // represent a CSV file
 var CsvFileType = FileType{
 	"csv",
-	misc.ArrToMap("csv"),
+	tools.ArrToMap("csv"),
 	validator.CsvValidator{},
 }
 
@@ -91,7 +91,7 @@ var CsvFileType = FileType{
 // represent a HOCON file
 var HoconFileType = FileType{
 	"hocon",
-	misc.ArrToMap("hocon"),
+	tools.ArrToMap("hocon"),
 	validator.HoconValidator{},
 }
 
@@ -99,7 +99,7 @@ var HoconFileType = FileType{
 // represent a ENV file
 var EnvFileType = FileType{
 	"env",
-	misc.ArrToMap("env"),
+	tools.ArrToMap("env"),
 	validator.EnvValidator{},
 }
 
@@ -107,7 +107,7 @@ var EnvFileType = FileType{
 // represent an EDITORCONFIG file
 var EditorConfigFileType = FileType{
 	"editorconfig",
-	misc.ArrToMap("editorconfig"),
+	tools.ArrToMap("editorconfig"),
 	validator.EditorConfigValidator{},
 }
 

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/Boeing/config-file-validator/pkg/filetype"
-	"github.com/Boeing/config-file-validator/pkg/misc"
+	"github.com/Boeing/config-file-validator/pkg/tools"
 	"github.com/Boeing/config-file-validator/pkg/validator"
 )
 
@@ -18,11 +18,11 @@ func Test_fsFinder(t *testing.T) {
 	files, err := fsFinder.Find()
 
 	if len(files) < 1 {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -35,11 +35,11 @@ func Test_fsFinderExcludeDirs(t *testing.T) {
 	files, err := fsFinder.Find()
 
 	if len(files) < 1 {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -57,7 +57,7 @@ func Test_fsFinderExcludeFileTypes(t *testing.T) {
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -103,7 +103,7 @@ func Test_fsFinderWithDepth(t *testing.T) {
 		}
 
 		if err != nil {
-			t.Errorf("Unable to find files")
+			t.Error("Unable to find files")
 		}
 	}
 }
@@ -111,7 +111,7 @@ func Test_fsFinderWithDepth(t *testing.T) {
 func Test_fsFinderCustomTypes(t *testing.T) {
 	jsonFileType := filetype.FileType{
 		Name:       "json",
-		Extensions: misc.ArrToMap("json"),
+		Extensions: tools.ArrToMap("json"),
 		Validator:  validator.JSONValidator{},
 	}
 	fsFinder := FileSystemFinderInit(
@@ -123,11 +123,11 @@ func Test_fsFinderCustomTypes(t *testing.T) {
 	files, err := fsFinder.Find()
 
 	if len(files) < 1 {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -139,7 +139,7 @@ func Test_fsFinderPathNoExist(t *testing.T) {
 	_, err := fsFinder.Find()
 
 	if err == nil {
-		t.Errorf("Error not returned")
+		t.Error("Error not returned")
 	}
 }
 
@@ -159,7 +159,7 @@ func Test_FileSystemFinderMultipleFinder(t *testing.T) {
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -177,7 +177,7 @@ func Test_FileSystemFinderDuplicateFiles(t *testing.T) {
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -198,7 +198,7 @@ func Test_FileSystemFinderAbsPath(t *testing.T) {
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -210,11 +210,11 @@ func Test_FileSystemFinderUpperCaseExtension(t *testing.T) {
 	files, err := fsFinder.Find()
 
 	if len(files) < 1 {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -226,11 +226,11 @@ func Test_FileSystemFinderMixedCaseExtension(t *testing.T) {
 	files, err := fsFinder.Find()
 
 	if len(files) < 1 {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 
 	if err != nil {
-		t.Errorf("Unable to find files")
+		t.Error("Unable to find files")
 	}
 }
 
@@ -245,7 +245,7 @@ func Test_FileFinderBadPath(t *testing.T) {
 	_, err := fsFinder.Find()
 
 	if err == nil {
-		t.Errorf("Error should be thrown for bad path")
+		t.Error("Error should be thrown for bad path")
 	}
 }
 
@@ -303,15 +303,15 @@ func Test_FileFinderPathWithWhitespaces(t *testing.T) {
 
 			if tt.expectErr {
 				if err == nil {
-					t.Errorf("Error should be thrown for bad path")
+					t.Error("Error should be thrown for bad path")
 				}
 			} else {
 				if len(files) < 1 {
-					t.Errorf("Unable to find file")
+					t.Error("Unable to find file")
 				}
 
 				if err != nil {
-					t.Errorf("Unable to find file")
+					t.Error("Unable to find file")
 				}
 			}
 		})

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Boeing/config-file-validator/pkg/filetype"
-	"github.com/Boeing/config-file-validator/pkg/misc"
+	"github.com/Boeing/config-file-validator/pkg/tools"
 )
 
 type FileSystemFinder struct {
@@ -37,14 +37,14 @@ func WithFileTypes(fileTypes []filetype.FileType) FSFinderOptions {
 // Add a custom list of file types to the FSFinder
 func WithExcludeDirs(excludeDirs []string) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.ExcludeDirs = misc.ArrToMap(excludeDirs...)
+		fsf.ExcludeDirs = tools.ArrToMap(excludeDirs...)
 	}
 }
 
 // WithExcludeFileTypes adds excluded file types to FSFinder.
 func WithExcludeFileTypes(types []string) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.ExcludeFileTypes = misc.ArrToMap(types...)
+		fsf.ExcludeFileTypes = tools.ArrToMap(types...)
 	}
 }
 

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -40,7 +40,7 @@ func Test_stdoutReport(t *testing.T) {
 	stdoutReporter := NewStdoutReporter("")
 	err := stdoutReporter.Print(reports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -74,7 +74,7 @@ func Test_jsonReport(t *testing.T) {
 	jsonReporter := JSONReporter{}
 	err := jsonReporter.Print(reports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -87,7 +87,7 @@ func Test_junitReport(t *testing.T) {
 
 	_, err := ts.getReport()
 	if err == nil {
-		t.Errorf("Reporting failed on getReport")
+		t.Error("reporting failed on getReport")
 	}
 
 	prop2 := Property{Name: "property2", Value: "value"}
@@ -98,7 +98,7 @@ func Test_junitReport(t *testing.T) {
 
 	_, err = ts.getReport()
 	if err != nil {
-		t.Errorf("Reporting failed on getReport")
+		t.Error("reporting failed on getReport")
 	}
 
 	tc1 := Testcase{Name: "testcase2", ClassName: "config-file-validator", Properties: &properties}
@@ -109,7 +109,7 @@ func Test_junitReport(t *testing.T) {
 
 	_, err = ts3.getReport()
 	if err == nil {
-		t.Errorf("Reporting failed on getReport")
+		t.Error("reporting failed on getReport")
 	}
 
 	reportNoValidationError := Report{
@@ -141,7 +141,7 @@ func Test_junitReport(t *testing.T) {
 	junitReporter := JunitReporter{}
 	err = junitReporter.Print(reports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -175,7 +175,7 @@ func Test_sarifReport(t *testing.T) {
 	sarifReporter := SARIFReporter{}
 	err := sarifReporter.Print(reports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -562,7 +562,7 @@ func Test_stdoutReportSingleGroup(t *testing.T) {
 
 	err := PrintSingleGroupStdout(groupReports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -597,7 +597,7 @@ func Test_stdoutReportDoubleGroup(t *testing.T) {
 
 	err := PrintDoubleGroupStdout(groupReports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -636,7 +636,7 @@ func Test_stdoutReportTripleGroup(t *testing.T) {
 
 	err := PrintTripleGroupStdout(groupReports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -671,7 +671,7 @@ func Test_jsonReportSingleGroup(t *testing.T) {
 
 	err := PrintSingleGroupJSON(groupReports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -706,7 +706,7 @@ func Test_jsonReportDoubleGroup(t *testing.T) {
 
 	err := PrintDoubleGroupJSON(groupReports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }
 
@@ -745,6 +745,6 @@ func Test_jsonReportTripleGroup(t *testing.T) {
 
 	err := PrintTripleGroupJSON(groupReports)
 	if err != nil {
-		t.Errorf("Reporting failed")
+		t.Error("reporting failed")
 	}
 }

--- a/pkg/tools/arrToMap.go
+++ b/pkg/tools/arrToMap.go
@@ -1,4 +1,4 @@
-package misc
+package tools
 
 // ArrToMap converts a string array
 // to a map with keys from the array

--- a/pkg/validator/env.go
+++ b/pkg/validator/env.go
@@ -19,7 +19,7 @@ func (EnvValidator) Validate(b []byte) (bool, error) {
 		var customError *envparse.ParseError
 		if errors.As(err, &customError) {
 			// we can wrap some useful information with the error
-			err = fmt.Errorf("Error at line %v: %w", customError.Line, customError.Err)
+			err = fmt.Errorf("error at line %v: %w", customError.Line, customError.Err)
 		}
 		return false, err
 	}

--- a/pkg/validator/json.go
+++ b/pkg/validator/json.go
@@ -23,7 +23,7 @@ func getCustomErr(input []byte, err error) error {
 	offset := int(jsonError.Offset)
 	line := 1 + strings.Count(string(input)[:offset], "\n")
 	column := 1 + offset - (strings.LastIndex(string(input)[:offset], "\n") + len("\n"))
-	return fmt.Errorf("Error at line %v column %v: %w", line, column, jsonError)
+	return fmt.Errorf("error at line %v column %v: %w", line, column, jsonError)
 }
 
 // Validate implements the Validator interface by attempting to

--- a/pkg/validator/toml.go
+++ b/pkg/validator/toml.go
@@ -15,7 +15,7 @@ func (TomlValidator) Validate(b []byte) (bool, error) {
 	var derr *toml.DecodeError
 	if errors.As(err, &derr) {
 		row, col := derr.Position()
-		return false, fmt.Errorf("Error at line %v column %v: %w", row, col, err)
+		return false, fmt.Errorf("error at line %v column %v: %w", row, col, err)
 	}
 	return true, nil
 }


### PR DESCRIPTION
- Update .golangci-lint.yaml configuration file for version 2 of golangci-lint
- Fix lint warnings for uppercase error strings
- Fix lint warnings for "meaningless" package name (misc package)
- Fix lint warnings related to unnecessary use of formatting functions (i.e. t.Errorf)
- Update golangci-lint-action to version 8.0.0 to support newer version of golangci-lint