### PR TITLE
Add MakefileValidator with unit tests and fixtures

### DIFF
--- a/pkg/filetype/file_type.go
+++ b/pkg/filetype/file_type.go
@@ -111,6 +111,14 @@ var EditorConfigFileType = FileType{
 	validator.EditorConfigValidator{},
 }
 
+// Instance of the FileType object to
+// represent a MAKEFILE file
+var MakefileFileType = FileType{
+	"makefile",
+	tools.ArrToMap("makefile", "Makefile"),
+	validator.MakefileValidator{},
+}
+
 // An array of files types that are supported
 // by the validator
 var FileTypes = []FileType{
@@ -126,4 +134,5 @@ var FileTypes = []FileType{
 	HoconFileType,
 	EnvFileType,
 	EditorConfigFileType,
+	MakefileFileType,
 }

--- a/pkg/validator/makefile.go
+++ b/pkg/validator/makefile.go
@@ -1,0 +1,51 @@
+package validator
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"regexp"
+)
+
+type MakefileValidator struct{}
+
+var makefileTarget = regexp.MustCompile(`^[A-Za-z0-9_.-]+:`)
+var maybeTarget = regexp.MustCompile(`^[A-Za-z0-9_.-]+\s+[A-Za-z0-9_.-]+.*$`)
+var standaloneTarget = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+func (MakefileValidator) Validate(b []byte) (bool, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	inRule := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// skip blank lines and comments
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		// valid target
+		if makefileTarget.MatchString(line) {
+			inRule = true
+			continue
+		}
+
+		// target-like line but missing colon
+		if maybeTarget.MatchString(line) {
+			return false, errors.New("invalid target line: missing colon")
+		}
+
+		// standalone target name without colon
+		if standaloneTarget.MatchString(line) {
+			return false, errors.New("invalid target line: missing colon")
+		}
+
+		// inside a rule, commands must start with TAB
+		if inRule && len(line) > 0 && line[0] != '\t' && !makefileTarget.MatchString(line) {
+			return false, errors.New("command does not start with TAB")
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/validator/makefile_test.go
+++ b/pkg/validator/makefile_test.go
@@ -1,0 +1,130 @@
+package validator
+
+import "testing"
+
+func TestMakefileValidator_Validate(t *testing.T) {
+	v := MakefileValidator{}
+
+	t.Run("valid makefile - single target", func(t *testing.T) {
+		content := []byte(`
+build: main.go
+	go build -o app main.go
+`)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid makefile, got error: %v", err)
+		}
+	})
+
+	t.Run("valid makefile - multiple targets", func(t *testing.T) {
+		content := []byte(`
+build: main.go
+	go build -o app main.go
+
+test: build
+	go test ./...
+`)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid makefile with multiple targets, got error: %v", err)
+		}
+	})
+
+	t.Run("valid makefile - with comments and blank lines", func(t *testing.T) {
+		content := []byte(`
+# this is a comment
+
+build: main.go
+	go build -o app main.go
+`)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid makefile with comments, got error: %v", err)
+		}
+	})
+
+	t.Run("valid makefile - target without commands", func(t *testing.T) {
+		content := []byte(`
+clean:
+`)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid makefile with empty target, got error: %v", err)
+		}
+	})
+
+	t.Run("valid makefile - multiple commands in one target", func(t *testing.T) {
+		content := []byte(`
+build:
+	go build -o app main.go
+	echo "done"
+`)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid makefile with multiple commands, got error: %v", err)
+		}
+	})
+
+	t.Run("invalid makefile - command without TAB", func(t *testing.T) {
+		content := []byte(`
+build: main.go
+go build -o app main.go
+`)
+		ok, err := v.Validate(content)
+		if ok || err == nil {
+			t.Errorf("expected invalid makefile (command without TAB), but got valid")
+		}
+	})
+
+	t.Run("invalid makefile - spaces instead of TAB", func(t *testing.T) {
+		content := []byte(`
+build:
+    go build -o app main.go
+`)
+		ok, err := v.Validate(content)
+		if ok || err == nil {
+			t.Errorf("expected invalid makefile (spaces instead of TAB), but got valid")
+		}
+	})
+
+	t.Run("invalid makefile - target without colon", func(t *testing.T) {
+		content := []byte(`
+build
+	go build -o app main.go
+`)
+		ok, err := v.Validate(content)
+		if ok || err == nil {
+			t.Errorf("expected invalid makefile (missing colon in target), but got valid")
+		}
+	})
+
+	t.Run("invalid makefile - target with dependencies but missing colon", func(t *testing.T) {
+		content := []byte(`
+build main.go
+	go build -o app main.go
+`)
+		ok, err := v.Validate(content)
+		if ok || err == nil {
+			t.Errorf("expected invalid makefile (target with deps missing colon), but got valid")
+		}
+	})
+
+	t.Run("valid makefile - empty file", func(t *testing.T) {
+		content := []byte(``)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid for empty file, got error: %v", err)
+		}
+	})
+
+	t.Run("valid makefile - only comments", func(t *testing.T) {
+		content := []byte(`
+# this is a comment
+# another comment
+`)
+		ok, err := v.Validate(content)
+		if !ok || err != nil {
+			t.Errorf("expected valid makefile with only comments, got error: %v", err)
+		}
+	})
+}

--- a/test/fixtures/bad.makefile
+++ b/test/fixtures/bad.makefile
@@ -1,0 +1,4 @@
+# invalid makefile example
+
+build main.go
+    go build -o app main.go   # <-- missing TAB here

--- a/test/fixtures/good.makefile
+++ b/test/fixtures/good.makefile
@@ -1,0 +1,5 @@
+build: main.go
+	go build -o app main.go
+
+run: build
+	./app


### PR DESCRIPTION
### Summary
This PR introduces support for validating Makefile syntax.

### Changes
- Added `MakefileValidator` in `pkg/validator/makefile.go`.
- Registered new file type in `pkg/filetype/file_type.go`.
- Added unit tests in `pkg/validator/makefile_test.go`.
- Added fixtures: `good.makefile` and `bad.makefile`.

### Validation rules
- Targets must end with `:`.
- Commands inside a target must start with TAB.
- Comments (`#`) and blank lines are ignored.
- Invalid if a line looks like a target with dependencies but is missing the colon.
- Invalid if a command starts with spaces instead of TAB.

### Tests
- `go test ./...` passes for the validator package.
- Fixtures validate as expected (`good.makefile` is VALID, `bad.makefile` is INVALID).

### Notes
This is a **basic validation** aligned with existing validators in the project.
It does not aim to fully parse GNU Makefiles (no support for includes, variables, or line continuations).
