### PR TITLE
Replace text list with logos for supported config file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,20 @@
 
 ## Supported config files formats:
 
-* Apple PList XML
-* CSV
-* EDITORCONFIG
-* ENV
-* HCL
-* HOCON
-* INI
-* JSON
-* Properties
-* TOML
-* XML
-* YAML
+<div align="center">
+  <img src="./img/logos/plist.svg" alt="Apple PList XML" title="Apple PList XML" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/csv.svg" alt="CSV" title="CSV" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/editorconfig.svg" alt="EDITORCONFIG" title="EDITORCONFIG" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/env.svg" alt="ENV" title="ENV" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/hcl.svg" alt="HCL" title="HCL" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/hocon.svg" alt="HOCON" title="HOCON" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/ini.svg" alt="INI" title="INI" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/json.svg" alt="JSON" title="JSON" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/properties.svg" alt="Properties" title="Properties" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/toml.svg" alt="TOML" title="TOML" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/xml.svg" alt="XML" title="XML" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/yaml.svg" alt="YAML" title="YAML" width="40" height="40" style="margin: 5px;">
+</div>
 
 ## Demo
 

--- a/img/logos/csv.svg
+++ b/img/logos/csv.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#ffa500"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">CSV</text>
+</svg>

--- a/img/logos/editorconfig.svg
+++ b/img/logos/editorconfig.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#1e90ff"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">EC</text>
+</svg>

--- a/img/logos/env.svg
+++ b/img/logos/env.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#2c3e50"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">ENV</text>
+</svg>

--- a/img/logos/hcl.svg
+++ b/img/logos/hcl.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#6a5acd"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">HCL</text>
+</svg>

--- a/img/logos/hocon.svg
+++ b/img/logos/hocon.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#ff69b4"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">HOCON</text>
+</svg>

--- a/img/logos/ini.svg
+++ b/img/logos/ini.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#3776ab"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">INI</text>
+</svg>

--- a/img/logos/json.svg
+++ b/img/logos/json.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#000000"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">JSON</text>
+</svg>

--- a/img/logos/plist.svg
+++ b/img/logos/plist.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#8b4513"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">PLIST</text>
+</svg>

--- a/img/logos/properties.svg
+++ b/img/logos/properties.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#32cd32"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">PROP</text>
+</svg>

--- a/img/logos/toml.svg
+++ b/img/logos/toml.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#9c4221"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">TOML</text>
+</svg>

--- a/img/logos/xml.svg
+++ b/img/logos/xml.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#e34c26"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">XML</text>
+</svg>

--- a/img/logos/yaml.svg
+++ b/img/logos/yaml.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="4" fill="#ff6b35"/>
+  <text x="16" y="20" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">YAML</text>
+</svg>

--- a/index.md
+++ b/index.md
@@ -52,18 +52,20 @@
 
 ## Supported config files formats:
 
-* Apple PList XML
-* CSV
-* EDITORCONFIG
-* ENV
-* HCL
-* HOCON
-* INI
-* JSON
-* Properties
-* TOML
-* XML
-* YAML
+<div align="center">
+  <img src="./img/logos/plist.svg" alt="Apple PList XML" title="Apple PList XML" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/csv.svg" alt="CSV" title="CSV" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/editorconfig.svg" alt="EDITORCONFIG" title="EDITORCONFIG" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/env.svg" alt="ENV" title="ENV" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/hcl.svg" alt="HCL" title="HCL" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/hocon.svg" alt="HOCON" title="HOCON" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/ini.svg" alt="INI" title="INI" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/json.svg" alt="JSON" title="JSON" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/properties.svg" alt="Properties" title="Properties" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/toml.svg" alt="TOML" title="TOML" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/xml.svg" alt="XML" title="XML" width="40" height="40" style="margin: 5px;">
+  <img src="./img/logos/yaml.svg" alt="YAML" title="YAML" width="40" height="40" style="margin: 5px;">
+</div>
 
 ## Demo
 


### PR DESCRIPTION
- Add SVG logos for all 12 supported file types (JSON, YAML, TOML, XML, INI, CSV, ENV, HCL, HOCON, Properties, PList, EditorConfig)
- Replace bullet point list with visual logo grid in both README.md and index.md
- Each logo has distinct colors and proper alt/title attributes for accessibility
- Logos are centered and properly spaced for better visual presentation

Fixes #187