### PR TITLE
Add Makefile and justfile validation support

### DIFF
--- a/pkg/filetype/file_type.go
+++ b/pkg/filetype/file_type.go
@@ -111,6 +111,22 @@ var EditorConfigFileType = FileType{
 	validator.EditorConfigValidator{},
 }
 
+// Instance of the FileType object to
+// represent a Makefile
+var MakefileFileType = FileType{
+	"makefile",
+	tools.ArrToMap("makefile", "Makefile", "mk"),
+	validator.MakefileValidator{},
+}
+
+// Instance of the FileType object to
+// represent a justfile
+var JustfileFileType = FileType{
+	"justfile",
+	tools.ArrToMap("justfile", "Justfile"),
+	validator.JustfileValidator{},
+}
+
 // An array of files types that are supported
 // by the validator
 var FileTypes = []FileType{
@@ -126,4 +142,6 @@ var FileTypes = []FileType{
 	HoconFileType,
 	EnvFileType,
 	EditorConfigFileType,
+	MakefileFileType,
+	JustfileFileType,
 }

--- a/test/justfile/invalid.justfile
+++ b/test/justfile/invalid.justfile
@@ -1,0 +1,31 @@
+# Invalid justfile with syntax errors
+set shell := ["bash", "-c"]
+
+# Missing colon after recipe name
+default:
+    @echo "Hello, World!"
+
+# Invalid recipe name starting with number
+123invalid:
+    @echo "This should fail"
+
+# Invalid variable name
+123invalid-var := "invalid"
+
+# Invalid set directive
+set invalid-directive = "value"
+
+# Recipe with invalid parameter name
+test 123param:
+    @echo "This should fail"
+
+# Invalid import statement
+import "path with spaces"
+
+# Recipe with invalid indentation (2 spaces instead of 4)
+test-indent:
+  @echo "This should fail - wrong indentation"
+
+# Empty recipe name
+:
+    @echo "This should fail"

--- a/test/makefile/invalid.Makefile
+++ b/test/makefile/invalid.Makefile
@@ -1,0 +1,23 @@
+# Invalid Makefile with syntax errors
+.PHONY: all clean test
+
+# Missing colon after target
+all build test:
+	@echo "Building project..."
+	gcc -o main main.c
+
+# Invalid target name with spaces
+invalid target:
+	@echo "This should fail"
+
+# Recipe with spaces instead of tab
+test:
+    @echo "This should fail - spaces instead of tab"
+
+# Empty target
+empty:
+	@echo "This is fine"
+
+# Target with invalid characters
+invalid@target:
+	@echo "This should fail"

--- a/test/makefile/valid.Makefile
+++ b/test/makefile/valid.Makefile
@@ -1,0 +1,35 @@
+# Valid Makefile for testing
+.PHONY: all clean test install
+
+# Variables
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c99
+TARGET = main
+SOURCES = main.c utils.c
+
+# Default target
+all: $(TARGET)
+
+# Build target
+$(TARGET): $(SOURCES)
+	$(CC) $(CFLAGS) -o $(TARGET) $(SOURCES)
+
+# Test target
+test: $(TARGET)
+	./$(TARGET) --test
+
+# Clean target
+clean:
+	rm -f $(TARGET) *.o
+
+# Install target
+install: $(TARGET)
+	cp $(TARGET) /usr/local/bin/
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all     - Build the project"
+	@echo "  test    - Run tests"
+	@echo "  clean   - Remove build artifacts"
+	@echo "  install - Install to system"


### PR DESCRIPTION
- Implement MakefileValidator with comprehensive syntax validation:
  * Validates target definitions with proper colon syntax
  * Checks recipe indentation (must use tabs, not spaces)
  * Validates variable assignments (VAR = value)
  * Supports Makefile variables in targets and dependencies (, )
  * Validates target and variable names
  * Proper error reporting with line numbers

- Implement JustfileValidator with comprehensive syntax validation:
  * Validates recipe definitions (recipe_name:)
  * Supports recipe parameters (recipe param1 param2:)
  * Validates variable assignments (var := value, var = value)
  * Handles set directives (set shell := ["bash", "-c"])
  * Supports import statements (import "path")
  * Validates recipe body indentation (tab or 4 spaces)
  * Validates identifier names (recipe names, variables, parameters)

- Add support for file extensions:
  * Makefile: makefile, Makefile, mk
  * Justfile: justfile, Justfile

- Include comprehensive test cases for both valid and invalid files
- Follow existing validator patterns and interfaces
- Proper error handling and reporting

Fixes #301 - Makefile & justfile validation