### PR TITLE
Add Justfile validation using custom parser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,10 +50,14 @@ jobs:
           go-version: "1.26"
 
       - name: Static Analysis
-        run: go vet ./...
+        run: |
+          go vet ./...
+          cd pkg/validator/justfile && go vet ./...
 
       - name: Check Formatting
-        run: test -z "$(gofmt -s -l -e .)"
+        run: |
+          test -z "$(gofmt -s -l -e .)"
+          cd pkg/validator/justfile && test -z "$(gofmt -s -l -e .)"
 
       - name: Check generated files are up to date
         run: |
@@ -106,7 +110,9 @@ jobs:
           go-version: "1.26"
 
       - name: Unit test
-        run: go test -v -cover -coverprofile coverage.out ./...
+        run: |
+          go test -v -cover -coverprofile coverage.out ./...
+          cd pkg/validator/justfile && go test -v -count=1 ./...
 
       - name: Check coverage
         id: check-coverage

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -52,8 +52,12 @@ jobs:
           # The location of the configuration file can be changed by using `--config=`
           args: --timeout=10m
 
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          install-mode: "goinstall"
 
-          # Optional:The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+      - name: golangci-lint (go-just nested module)
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
+          working-directory: pkg/validator/justfile
+          args: --timeout=10m
           install-mode: "goinstall"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Justfile syntax validation (`.just`, `justfile`, `Justfile`, `.justfile`) via embedded [go-just](https://github.com/Boeing/go-just) parser
 - `--gitignore` flag to skip files and directories matched by `.gitignore` patterns, including nested `.gitignore` files, `.git/info/exclude`, and global git ignore config. Supported via CLI flag, `CFV_GITIGNORE` env var, and `gitignore = true` in `.cfv.toml`.
 - Automatic file type detection from GitHub Linguist's `languages.yml` via `go generate`
 - ~90 known filenames auto-detected (`.babelrc`, `tsconfig.json`, `Pipfile`, `pom.xml`, `.gitconfig`, etc.)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 Config File Validator is a cross-platform CLI tool that validates configuration files in your project. Catch syntax errors, schema violations, and misconfigurations across all your config files — with one tool.
 
 - **Single binary, zero dependencies** — no runtimes, no package managers, just one executable
-- **15 file formats** — JSON, JSONC, YAML, TOML, XML, HCL, INI, HOCON, ENV, CSV, Properties, EDITORCONFIG, PList, SARIF, and TOON
+- **16 file formats** — JSON, JSONC, YAML, TOML, XML, HCL, INI, HOCON, ENV, CSV, Properties, EDITORCONFIG, Justfile, PList, SARIF, and TOON
 - **Syntax + schema validation** — validates structure with [JSON Schema](https://json-schema.org/) and XSD, with automatic [SchemaStore](https://www.schemastore.org/) integration
 - **CI/CD ready** — JSON, JUnit, and SARIF output for GitHub Actions, GitLab CI, Jenkins, and more
 - **Configurable** — project-level `.cfv.toml` config files, glob patterns, schema mappings, and environment variables
@@ -74,6 +74,7 @@ Config File Validator is a cross-platform CLI tool that validates configuration 
 | HCL | ✅ | ❌ |
 | HOCON | ✅ | ❌ |
 | INI | ✅ | ❌ |
+| Justfile | ✅ | ❌ |
 | JSON | ✅ | ✅ |
 | JSONC | ✅ | ✅ |
 | Properties | ✅ | ❌ |

--- a/cmd/validator/testdata/justfile.txtar
+++ b/cmd/validator/testdata/justfile.txtar
@@ -1,0 +1,20 @@
+# Justfile syntax validation
+! exec validator project
+stdout '✓.*valid.just'
+stdout '×.*invalid.just'
+
+# Known filenames detected without extension
+exec validator knownfile
+stdout '✓.*justfile'
+
+-- project/valid.just --
+default:
+    echo "hello"
+
+build:
+    echo "building"
+-- project/invalid.just --
+this is not valid {{{
+-- knownfile/justfile --
+greet name:
+    echo "hi {{name}}"

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	github.com/Boeing/go-just v0.0.0
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
@@ -50,3 +51,5 @@ require (
 	golang.org/x/tools v0.43.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
+
+replace github.com/Boeing/go-just => ./pkg/validator/justfile

--- a/index.md
+++ b/index.md
@@ -41,7 +41,7 @@ canonical_url: https://boeing.github.io/config-file-validator/
 Config File Validator is a cross-platform CLI tool that validates configuration files in your project. Catch syntax errors, schema violations, and misconfigurations across all your config files — with one tool.
 
 - **Single binary, zero dependencies** — no runtimes, no package managers, just one executable
-- **15 file formats** — JSON, JSONC, YAML, TOML, XML, HCL, INI, HOCON, ENV, CSV, Properties, EDITORCONFIG, PList, SARIF, and TOON
+- **16 file formats** — JSON, JSONC, YAML, TOML, XML, HCL, INI, HOCON, ENV, CSV, Properties, EDITORCONFIG, Justfile, PList, SARIF, and TOON
 - **Syntax + schema validation** — validates structure with [JSON Schema](https://json-schema.org/) and XSD, with automatic [SchemaStore](https://www.schemastore.org/) integration
 - **CI/CD ready** — JSON, JUnit, and SARIF output for GitHub Actions, GitLab CI, Jenkins, and more
 - **Configurable** — project-level `.cfv.toml` config files, glob patterns, schema mappings, and environment variables
@@ -74,6 +74,7 @@ Config File Validator is a cross-platform CLI tool that validates configuration 
 | HCL | ✅ | ❌ |
 | HOCON | ✅ | ❌ |
 | INI | ✅ | ❌ |
+| Justfile | ✅ | ❌ |
 | JSON | ✅ | ✅ |
 | JSONC | ✅ | ✅ |
 | Properties | ✅ | ❌ |

--- a/pkg/filetype/file_type.go
+++ b/pkg/filetype/file_type.go
@@ -147,10 +147,21 @@ var JSONCFileType = FileType{
 	Validator:  validator.JSONCValidator{},
 }
 
+var JustfileFileType = FileType{
+	Name:       "justfile",
+	Extensions: arrToMap("just"),
+	Validator:  validator.JustfileValidator{},
+}
+
 // extraKnownFiles contains manual entries not covered by Linguist.
 var extraKnownFiles = map[string][]string{
 	"ini": {
 		".shellcheckrc",
+	},
+	"justfile": {
+		"justfile",
+		"Justfile",
+		".justfile",
 	},
 }
 
@@ -170,6 +181,7 @@ var fileTypeRegistry = map[string]*FileType{
 	"env":        &EnvFileType,
 	"toon":       &ToonFileType,
 	"sarif":      &SarifFileType,
+	"justfile":   &JustfileFileType,
 }
 
 // excludeKnownFiles lists Linguist entries to skip because we have
@@ -240,6 +252,7 @@ func init() {
 		ToonFileType,
 		SarifFileType,
 		JSONCFileType,
+		JustfileFileType,
 	}
 }
 

--- a/pkg/validator/justfile.go
+++ b/pkg/validator/justfile.go
@@ -1,0 +1,39 @@
+package validator
+
+import (
+	"errors"
+
+	"github.com/Boeing/go-just"
+)
+
+type JustfileValidator struct{}
+
+var _ Validator = JustfileValidator{}
+
+func (JustfileValidator) ValidateSyntax(b []byte) (bool, error) {
+	jf, err := gojust.Parse(b)
+	if err != nil {
+		var pe *gojust.ParseError
+		if errors.As(err, &pe) {
+			return false, &ValidationError{
+				Err:    errors.New(pe.Message),
+				Line:   pe.Pos.Line,
+				Column: pe.Pos.Column,
+			}
+		}
+		return false, err
+	}
+
+	diags := jf.Validate()
+	for _, d := range diags {
+		if d.Severity == gojust.SeverityError {
+			return false, &ValidationError{
+				Err:    errors.New(d.Message),
+				Line:   d.Pos.Line,
+				Column: d.Pos.Column,
+			}
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/validator/justfile/.golangci.yml
+++ b/pkg/validator/justfile/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+linters:
+  settings:
+    gosec:
+      excludes:
+        - G101

--- a/pkg/validator/justfile/adversarial_test.go
+++ b/pkg/validator/justfile/adversarial_test.go
@@ -1,0 +1,286 @@
+package gojust
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAdversarial tries to break the parser with pathological inputs.
+// Each test targets a specific parser boundary or ambiguity.
+func TestAdversarial(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// === Minimal and empty inputs ===
+		{"empty", "", false},
+		{"just_newline", "\n", false},
+		{"just_spaces", "   \n", false},
+		{"just_tabs", "\t\t\t\n", false},
+		{"just_comment", "# nothing\n", false},
+		{"only_shebang", "#!/usr/bin/env just\n", false},
+		{"shebang_no_newline", "#!/usr/bin/env just", false},
+
+		// === Single character edge cases ===
+		{"lone_colon", ":", true},
+		{"lone_at", "@", true},
+		{"lone_plus", "+", true},
+		{"lone_star", "*", true},
+		{"lone_dollar", "$", true},
+		{"lone_equals", "=", true},
+		{"lone_bang", "!", true},
+		{"lone_lbrace", "{", true},
+		{"lone_rbrace", "}", true},
+		{"lone_lparen", "(", true},
+		{"lone_rparen", ")", true},
+		{"lone_lbracket", "[", true},
+		{"lone_rbracket", "]", true},
+
+		// === Recipe name edge cases ===
+		{"recipe_underscore", "_:\n    echo done\n", false},
+		{"recipe_single_char", "a:\n    echo done\n", false},
+		{"recipe_with_dashes", "my-long-recipe-name:\n    echo done\n", false},
+		{"recipe_with_numbers", "build123:\n    echo done\n", false},
+		{"recipe_keyword_import", "import:\n    echo done\n", false},
+		{"recipe_starts_with_underscore", "_private_recipe:\n    echo done\n", false},
+
+		// === Assignment edge cases ===
+		{"assign_empty_string", `v := ""` + "\n", false},
+		{"assign_empty_raw", "v := ''\n", false},
+		{"assign_single_char_string", `v := "x"` + "\n", false},
+		{"assign_just_backtick", "v := `true`\n", false},
+		{"assign_nested_parens", `v := ((("deep")))` + "\n", false},
+		{"assign_many_concats", `v := "a" + "b" + "c" + "d" + "e" + "f" + "g" + "h" + "i" + "j" + "k" + "l" + "m" + "n" + "o" + "p"` + "\n", false},
+		{"assign_many_paths", `v := "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h"` + "\n", false},
+		{"assign_mixed_ops", `v := "a" + "b" / "c" + "d" / "e"` + "\n", false},
+		{"assign_leading_slash", `v := / "absolute"` + "\n", false},
+		{"assign_leading_slash_chain", `v := / "a" / "b" / "c"` + "\n", false},
+
+		// === String edge cases ===
+		{"string_with_single_quote_inside", `v := "it's"` + "\n", false},
+		{"raw_string_with_double_quote", "v := 'say \"hello\"'\n", false},
+		{"string_with_backslash_at_end", `v := "path\\"` + "\n", false},
+		{"string_unicode_emoji", `v := "\u{1F600}"` + "\n", false},
+		{"string_unicode_null", `v := "\u{0000}"` + "\n", false},
+		{"string_unicode_max_bmp", `v := "\u{FFFF}"` + "\n", false},
+		{"empty_indented_string", "v := \"\"\"\n\"\"\"\n", false},
+		{"empty_indented_raw", "v := '''\n'''\n", false},
+		{"empty_backtick", "v := ``\n", false},
+		{"multiline_raw_many_lines", "v := '\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n'\n", false},
+		{"string_with_braces", `v := "hello { world }"` + "\n", false},
+		{"string_with_double_braces", `v := "hello {{ world }}"` + "\n", false},
+
+		// === Conditional edge cases ===
+		{"cond_same_values", `v := if "a" == "a" { "same" } else { "diff" }` + "\n", false},
+		{"cond_empty_strings", `v := if "" == "" { "empty" } else { "not" }` + "\n", false},
+		{"cond_nested_3_deep", `v := if "a" == "b" { "1" } else if "c" == "d" { "2" } else if "e" == "f" { "3" } else { "4" }` + "\n", false},
+		{"cond_with_function", `v := if arch() == "x86_64" { "64" } else { "other" }` + "\n", false},
+		{"cond_with_concat", `v := if "a" + "b" == "ab" { "yes" } else { "no" }` + "\n", false},
+		{"cond_regex", `v := if "hello" =~ "^h" { "match" } else { "no" }` + "\n", false},
+		{"cond_regex_mismatch", `v := if "hello" !~ "^z" { "good" } else { "bad" }` + "\n", false},
+		{"cond_multiline", "v := if \"a\" == \"b\" {\n  \"yes\"\n} else {\n  \"no\"\n}\n", false},
+
+		// === Recipe body edge cases ===
+		{"body_empty_interpolation_var", "v := \"x\"\nbuild:\n    echo {{v}}\n", false},
+		{"body_interpolation_function", "build:\n    echo {{arch()}}\n", false},
+		{"body_interpolation_conditional", "build:\n    echo {{ if \"a\" == \"b\" { \"y\" } else { \"n\" } }}\n", false},
+		{"body_interpolation_concat", "build:\n    echo {{\"a\" + \"b\" + \"c\"}}\n", false},
+		{"body_interpolation_path", "build:\n    echo {{\"a\" / \"b\"}}\n", false},
+		{"body_brace_escape", "build:\n    echo {{{{literal}}\n", false},
+		{"body_only_interpolation", "build:\n    {{\"hello\"}}\n", false},
+		{"body_text_then_interp", "build:\n    prefix {{\"middle\"}} suffix\n", false},
+		{"body_multiple_interps", "build:\n    {{\"a\"}} {{\"b\"}} {{\"c\"}}\n", false},
+		{"body_line_prefix_at", "build:\n    @echo quiet\n", false},
+		{"body_line_prefix_dash", "build:\n    -echo may_fail\n", false},
+		{"body_line_prefix_at_dash", "build:\n    @-echo both\n", false},
+		{"body_line_prefix_dash_at", "build:\n    -@echo both\n", false},
+		{"body_shebang_bash", "build:\n    #!/usr/bin/env bash\n    set -e\n    echo done\n", false},
+		{"body_shebang_python", "build:\n    #!/usr/bin/env python3\n    print('hello')\n", false},
+		{"body_shebang_node", "build:\n    #!/usr/bin/env node\n    console.log('hello')\n", false},
+		{"body_many_lines", "build:\n" + strings.Repeat("    echo line\n", 50), false},
+		{"body_empty_lines_between", "build:\n    echo start\n\n\n\n    echo end\n", false},
+		{"body_tab_indent", "build:\n\techo done\n", false},
+
+		// === Parameter edge cases ===
+		{"param_all_types", "build a b='default' $c +d:\n    echo done\n", false},
+		{"param_star_variadic", "build *args:\n    echo done\n", false},
+		{"param_plus_variadic", "build +args:\n    echo done\n", false},
+		{"param_dollar_export", "build $VAR:\n    echo done\n", false},
+		{"param_dollar_variadic", "build +$VAR:\n    echo done\n", false},
+		{"param_default_string", "build mode=\"release\":\n    echo done\n", false},
+		{"param_default_raw", "build mode='release':\n    echo done\n", false},
+		{"param_default_backtick", "build mode=`echo release`:\n    echo done\n", false},
+		{"param_default_function", "build mode=arch():\n    echo done\n", false},
+		{"param_many", "build a b c d e f g h:\n    echo done\n", false},
+
+		// === Dependency edge cases ===
+		{"dep_simple", "a:\n    echo a\nb: a\n    echo b\n", false},
+		{"dep_multiple", "a:\n    echo a\nb:\n    echo b\nc: a b\n    echo c\n", false},
+		{"dep_with_arg", "a x:\n    echo done\nb: (a \"hello\")\n    echo done\n", false},
+		{"dep_with_multiple_args", "a x y:\n    echo done\nb: (a \"hello\" \"world\")\n    echo done\n", false},
+		{"dep_subsequent", "a:\n    echo a\nb:\n    echo b\nc: a && b\n    echo c\n", false},
+		{"dep_subsequent_with_args", "a x:\n    echo a\nb: && (a \"hello\")\n    echo b\n", false},
+		{"dep_many", "a:\n    echo a\nb:\n    echo b\nc:\n    echo c\nd:\n    echo d\ne: a b c d\n    echo e\n", false},
+
+		// === Attribute edge cases ===
+		{"attr_private", "[private]\nbuild:\n    echo done\n", false},
+		{"attr_no_cd", "[no-cd]\nbuild:\n    echo done\n", false},
+		{"attr_confirm_no_arg", "[confirm]\nbuild:\n    echo done\n", false},
+		{"attr_confirm_with_arg", "[confirm('sure?')]\nbuild:\n    echo done\n", false},
+		{"attr_group_shorthand", "[group: 'ci']\nbuild:\n    echo done\n", false},
+		{"attr_doc", "[doc('Build the project')]\nbuild:\n    echo done\n", false},
+		{"attr_multiple_on_lines", "[private]\n[no-cd]\n[linux]\nbuild:\n    echo done\n", false},
+		{"attr_multiple_inline", "[private, no-cd, linux]\nbuild:\n    echo done\n", false},
+		{"attr_with_kv", "[env(name=\"FOO\", value=\"bar\")]\nbuild:\n    echo done\n", false},
+		{"attr_os_linux", "[linux]\nbuild:\n    echo done\n", false},
+		{"attr_os_macos", "[macos]\nbuild:\n    echo done\n", false},
+		{"attr_os_windows", "[windows]\nbuild:\n    echo done\n", false},
+		{"attr_script", "[script('bash')]\nbuild:\n    echo done\n", false},
+
+		// === Setting edge cases ===
+		{"setting_bare_bool", "set dotenv-load\n", false},
+		{"setting_true", "set dotenv-load := true\n", false},
+		{"setting_false", "set dotenv-load := false\n", false},
+		{"setting_string", "set tempdir := '/tmp'\n", false},
+		{"setting_list", "set shell := ['bash', '-cu']\n", false},
+		{"setting_list_trailing_comma", "set shell := ['bash', '-cu',]\n", false},
+		{"setting_keyword_export", "set export\n", false},
+		{"setting_keyword_quiet", "set quiet\n", false},
+		{"setting_all_bools", "set dotenv-load\nset export\nset positional-arguments\nset quiet\nset fallback\nset unstable\n", false},
+
+		// === Import/module edge cases ===
+		{"import_simple", "import 'foo.just'\nbuild:\n    echo done\n", false},
+		{"import_optional", "import? 'maybe.just'\nbuild:\n    echo done\n", false},
+		{"mod_simple", "mod foo\nbuild:\n    echo done\n", false},
+		{"mod_optional", "mod? foo\nbuild:\n    echo done\n", false},
+		{"mod_with_path", "mod foo 'path/to/foo.just'\nbuild:\n    echo done\n", false},
+		{"multiple_imports", "import 'a.just'\nimport 'b.just'\nimport? 'c.just'\nbuild:\n    echo done\n", false},
+
+		// === Function call edge cases ===
+		{"func_no_args", "v := arch()\n", false},
+		{"func_one_arg", "v := env_var(\"HOME\")\n", false},
+		{"func_two_args", "v := env_var_or_default(\"X\", \"y\")\n", false},
+		{"func_three_args", "v := replace(\"a.b\", \".\", \"-\")\n", false},
+		{"func_nested", "v := replace(replace(\"a.b.c\", \".\", \"-\"), \"-\", \"_\")\n", false},
+		{"func_in_concat", "v := arch() + \"-\" + os()\n", false},
+		{"func_in_path", "v := justfile_directory() / \"src\"\n", false},
+		{"func_in_conditional", "v := if arch() == \"x86_64\" { \"64\" } else { \"32\" }\n", false},
+
+		// === Eager/export edge cases ===
+		{"export_simple", "export FOO := \"bar\"\n", false},
+		{"eager_simple", "eager val := `cmd`\n", false},
+		{"eager_export", "eager export TOKEN := `cmd`\n", false},
+		{"export_eager", "export eager TOKEN := `cmd`\n", false},
+		{"unexport", "export FOO := \"bar\"\nunexport FOO\n", false},
+
+		// === Function definition edge cases ===
+		{"funcdef_one_param", "f(x) := x\n", false},
+		{"funcdef_two_params", "f(x, y) := x + y\n", false},
+		{"funcdef_three_params", "f(a, b, c) := a + b + c\n", false},
+		{"funcdef_with_conditional", "f(x) := if x == \"a\" { \"yes\" } else { \"no\" }\n", false},
+		{"funcdef_multiline", "f(x) := if x == \"a\" {\n  \"yes\"\n} else {\n  \"no\"\n}\n", false},
+
+		// === Alias edge cases ===
+		{"alias_simple", "build:\n    echo done\nalias b := build\n", false},
+		{"alias_with_attr", "[private]\nbuild:\n    echo done\nalias b := build\n", false},
+
+		// === Comment edge cases ===
+		{"comment_only", "# just a comment\n", false},
+		{"comment_before_recipe", "# docs\nbuild:\n    echo done\n", false},
+		{"comment_between_recipes", "a:\n    echo a\n# between\nb:\n    echo b\n", false},
+		{"comment_after_setting", "set dotenv-load # not a comment in just but we handle it\n", false},
+		{"comment_with_special_chars", "# !@#$%^&*(){}[]|\\:;\"'<>,.?/~`\n", false},
+
+		// === Whitespace edge cases ===
+		{"trailing_newlines", "build:\n    echo done\n\n\n\n", false},
+		{"leading_newlines", "\n\n\nbuild:\n    echo done\n", false},
+		{"blank_lines_everywhere", "\n\nv := \"x\"\n\n\nbuild:\n    echo done\n\n\n", false},
+		{"spaces_in_expressions", "v  :=  \"a\"  +  \"b\"\n", false},
+
+		// === Line continuation ===
+		{"line_cont_in_assign", "v := \"a\" + \\\n  \"b\"\n", false},
+		{"line_cont_crlf", "v := \"a\" + \\\r\n  \"b\"\n", false},
+
+		// === Combination stress ===
+		{"everything_together", `#!/usr/bin/env just
+set shell := ['bash', '-cu']
+set dotenv-load
+set export
+
+version := "1.0.0"
+export DB := "postgres"
+eager token := ` + "`echo secret`" + `
+
+greeting(name) := "Hello, " + name + "!"
+
+# Build the project
+[group: 'build']
+[doc('Build everything')]
+build target='all' mode="debug":
+    #!/usr/bin/env bash
+    echo "Building {{target}} in {{mode}}"
+    echo "Version: {{version}}"
+
+[private]
+test +args: build
+    echo {{args}}
+
+deploy env='staging': build (test "integration")
+    echo "Deploying to {{env}}"
+
+all: build && test deploy
+    echo "All done"
+
+@quiet-recipe:
+    echo quiet
+
+alias b := build
+alias t := test
+
+import? 'extra.just'
+mod? tools
+`,
+			false,
+		},
+
+		// === Should-fail cases ===
+		{"unterminated_string", `v := "unterminated`, true},
+		{"unterminated_raw", "v := 'unterminated", true},
+		{"unterminated_backtick", "v := `unterminated", true},
+		{"unterminated_indented_string", "v := \"\"\"\nunterminated", true},
+		{"unterminated_indented_raw", "v := '''\nunterminated", true},
+		{"unterminated_indented_backtick", "v := ```\nunterminated", true},
+		{"missing_colon", "build\n    echo done\n", true},
+		{"bad_escape", `v := "\q"`, true},
+		{"bad_unicode_no_brace", `v := "\u0041"`, true},
+		{"bad_unicode_invalid", `v := "\u{ZZZZ}"`, true},
+		{"bad_attribute", "[123]\nbuild:\n    echo done\n", true},
+		{"unclosed_attribute", "[private\nbuild:\n    echo done\n", true},
+		{"missing_assign_value", "v :=\n", true},
+		{"export_no_assign", "export FOO\n", true},
+		{"unexpected_token", "??? bad\n", true},
+		{"unclosed_paren_dep", "build: (dep \"arg\"\n    echo done\n", true},
+		{"unclosed_function", "v := env_var(\"HOME\"\n", true},
+		{"cond_missing_else", `v := if "a" == "b" { "y" }`, true},
+		{"cond_missing_operator", `v := if "a" { "y" } else { "n" }`, true},
+		{"cond_missing_brace", `v := if "a" == "b" "y" } else { "n" }`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jf, err := Parse([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Validate shouldn't panic
+			_ = jf.Validate()
+		})
+	}
+}

--- a/pkg/validator/justfile/analyzer.go
+++ b/pkg/validator/justfile/analyzer.go
@@ -1,0 +1,361 @@
+package gojust
+
+import "fmt"
+
+// Validate performs semantic analysis on a parsed justfile and returns
+// any diagnostics found. It checks for duplicate definitions, undefined
+// references, and invalid configurations.
+func (jf *Justfile) Validate() []Diagnostic {
+	a := &analyzer{
+		file:      jf.File,
+		recipes:   make(map[string]Position),
+		variables: make(map[string]Position),
+		aliases:   make(map[string]Position),
+	}
+	a.analyze(jf)
+	return a.diagnostics
+}
+
+type analyzer struct {
+	file                    string
+	diagnostics             []Diagnostic
+	recipes                 map[string]Position
+	variables               map[string]Position
+	aliases                 map[string]Position
+	allowDuplicateRecipes   bool
+	allowDuplicateVariables bool
+}
+
+func (a *analyzer) analyze(jf *Justfile) {
+	for _, s := range jf.Settings {
+		if s.Name == "allow-duplicate-recipes" && s.Value.Bool != nil && *s.Value.Bool {
+			a.allowDuplicateRecipes = true
+		}
+		if s.Name == "allow-duplicate-variables" && s.Value.Bool != nil && *s.Value.Bool {
+			a.allowDuplicateVariables = true
+		}
+	}
+
+	a.collectDefinitions(jf)
+	a.checkRecipes(jf)
+	a.checkAliases(jf)
+	a.checkSettings(jf)
+	a.checkVariableRefs(jf)
+	a.checkExportUnexportConflicts(jf)
+}
+
+func (a *analyzer) collectDefinitions(jf *Justfile) {
+	for _, r := range jf.Recipes {
+		if prev, ok := a.recipes[r.Name]; ok && !a.allowDuplicateRecipes {
+			a.error(r.Pos, "recipe '%s' is defined multiple times (first defined at %s)", r.Name, prev)
+		}
+		a.recipes[r.Name] = r.Pos
+	}
+
+	for _, v := range jf.Assignments {
+		if prev, ok := a.variables[v.Name]; ok && !a.allowDuplicateVariables {
+			a.error(v.Pos, "variable '%s' is defined multiple times (first defined at %s)", v.Name, prev)
+		}
+		a.variables[v.Name] = v.Pos
+	}
+
+	for _, al := range jf.Aliases {
+		if prev, ok := a.aliases[al.Name]; ok {
+			a.error(al.Pos, "alias '%s' is defined multiple times (first defined at %s)", al.Name, prev)
+		}
+		a.aliases[al.Name] = al.Pos
+	}
+
+	// Collect from resolved imports
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			a.collectDefinitions(imp.Justfile)
+		}
+	}
+}
+
+func (a *analyzer) checkRecipes(jf *Justfile) {
+	for _, r := range jf.Recipes {
+		a.checkDependencies(r)
+		a.checkParameters(r)
+	}
+	a.checkCircularDeps(jf)
+}
+
+func (a *analyzer) checkDependencies(r *Recipe) {
+	for _, dep := range r.Dependencies {
+		if _, ok := a.recipes[dep.Name]; !ok {
+			a.error(dep.Pos, "recipe '%s' depends on undefined recipe '%s'", r.Name, dep.Name)
+		}
+	}
+}
+
+func (a *analyzer) checkParameters(r *Recipe) {
+	seen := make(map[string]bool)
+	foundVariadic := false
+	for _, p := range r.Parameters {
+		if seen[p.Name] {
+			a.error(p.Pos, "recipe '%s' has duplicate parameter '%s'", r.Name, p.Name)
+		}
+		seen[p.Name] = true
+
+		if foundVariadic {
+			a.error(p.Pos, "recipe '%s' has parameters after variadic parameter", r.Name)
+		}
+		if p.Variadic != "" {
+			foundVariadic = true
+		}
+	}
+}
+
+func (a *analyzer) checkCircularDeps(jf *Justfile) {
+	depGraph := make(map[string][]string)
+	a.buildDepGraph(jf, depGraph)
+
+	visited := make(map[string]bool)
+	inStack := make(map[string]bool)
+
+	var visit func(name string) bool
+	visit = func(name string) bool {
+		if inStack[name] {
+			return true
+		}
+		if visited[name] {
+			return false
+		}
+		visited[name] = true
+		inStack[name] = true
+		for _, dep := range depGraph[name] {
+			if visit(dep) {
+				if pos, ok := a.recipes[name]; ok {
+					a.error(pos, "recipe '%s' has a circular dependency", name)
+				}
+				return true
+			}
+		}
+		inStack[name] = false
+		return false
+	}
+
+	for name := range depGraph {
+		visit(name)
+	}
+}
+
+// buildDepGraph collects recipe dependencies including from imports.
+func (a *analyzer) buildDepGraph(jf *Justfile, graph map[string][]string) {
+	for _, r := range jf.Recipes {
+		for _, dep := range r.Dependencies {
+			graph[r.Name] = append(graph[r.Name], dep.Name)
+		}
+	}
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			a.buildDepGraph(imp.Justfile, graph)
+		}
+	}
+}
+
+func (a *analyzer) checkAliases(jf *Justfile) {
+	for _, al := range jf.Aliases {
+		if _, ok := a.recipes[al.Target]; !ok {
+			a.error(al.Pos, "alias '%s' targets undefined recipe '%s'", al.Name, al.Target)
+		}
+	}
+}
+
+var knownSettings = func() map[string]bool {
+	m := make(map[string]bool, len(knownSettingsList))
+	for _, s := range knownSettingsList {
+		m[s.Name] = true
+	}
+	return m
+}()
+
+func (a *analyzer) checkSettings(jf *Justfile) {
+	seen := make(map[string]bool)
+	for _, s := range jf.Settings {
+		if !knownSettings[s.Name] {
+			a.warn(s.Pos, "unknown setting '%s'", s.Name)
+		}
+		if seen[s.Name] {
+			a.error(s.Pos, "setting '%s' is set multiple times", s.Name)
+		}
+		seen[s.Name] = true
+	}
+}
+
+// walkExpr calls fn for every sub-expression in expr, depth-first.
+func walkExpr(expr Expression, fn func(Expression)) {
+	if expr == nil {
+		return
+	}
+	fn(expr)
+	switch e := expr.(type) {
+	case *Concatenation:
+		walkExpr(e.Left, fn)
+		walkExpr(e.Right, fn)
+	case *PathJoin:
+		walkExpr(e.Left, fn)
+		walkExpr(e.Right, fn)
+	case *LogicalOp:
+		walkExpr(e.Left, fn)
+		walkExpr(e.Right, fn)
+	case *Comparison:
+		walkExpr(e.Left, fn)
+		walkExpr(e.Right, fn)
+	case *Conditional:
+		walkExpr(e.Condition.Left, fn)
+		walkExpr(e.Condition.Right, fn)
+		walkExpr(e.Then, fn)
+		walkExpr(e.Otherwise, fn)
+	case *FunctionCall:
+		for _, arg := range e.Arguments {
+			walkExpr(arg, fn)
+		}
+	case *ParenExpr:
+		walkExpr(e.Inner, fn)
+	default:
+		// leaf nodes: StringLiteral, Variable, BacktickExpr
+	}
+}
+
+// builtinFunctions is the set of functions built into just.
+var builtinFunctions = map[string]bool{
+	"absolute_path": true, "arch": true, "blake3": true, "blake3_file": true,
+	"cache_directory": true, "canonicalize": true, "capitalize": true,
+	"choose": true, "clean": true, "config_directory": true,
+	"config_local_directory": true, "data_directory": true,
+	"data_local_directory": true, "datetime": true, "datetime_utc": true,
+	"encode_uri_component": true, "env": true, "env_var": true,
+	"env_var_or_default": true, "error": true, "executable_directory": true,
+	"extension": true, "file_name": true, "file_stem": true,
+	"home_directory": true, "invocation_directory": true,
+	"invocation_directory_native": true, "is_dependency": true,
+	"join": true, "just_executable": true, "just_pid": true,
+	"justfile": true, "justfile_directory": true, "kebabcase": true,
+	"lowercamelcase": true, "lowercase": true, "module_directory": true,
+	"module_file": true, "num_cpus": true, "os": true, "os_family": true,
+	"parent_directory": true, "path_exists": true, "prepend": true,
+	"quote": true, "read": true, "read_to_string": true, "replace": true,
+	"replace_regex": true, "require": true, "semver_matches": true,
+	"sha256": true, "sha256_file": true, "shell": true, "shoutykebabcase": true,
+	"shoutysnakecase": true, "snakecase": true, "source_directory": true,
+	"source_file": true, "style": true, "titlecase": true, "trim": true,
+	"trim_end": true, "trim_end_match": true, "trim_end_matches": true,
+	"trim_start": true, "trim_start_match": true, "trim_start_matches": true,
+	"uppercamelcase": true, "uppercase": true, "uuid": true, "which": true,
+	"without_extension": true,
+}
+
+func (a *analyzer) checkVariableRefs(jf *Justfile) {
+	// Check variable references in assignment expressions
+	for _, assign := range jf.Assignments {
+		// Function definition parameters are local scope
+		locals := make(map[string]bool)
+		for _, p := range assign.Parameters {
+			locals[p] = true
+		}
+		a.checkExprVarRefs(assign.Value, locals)
+	}
+
+	// Check variable references in recipe bodies and dependency args
+	for _, r := range jf.Recipes {
+		locals := make(map[string]bool)
+		for _, p := range r.Parameters {
+			locals[p.Name] = true
+		}
+
+		for _, dep := range r.Dependencies {
+			for _, arg := range dep.Arguments {
+				a.checkExprVarRefs(arg, locals)
+			}
+		}
+
+		for _, line := range r.Body {
+			for _, frag := range line.Fragments {
+				if interp, ok := frag.(*InterpolationFragment); ok {
+					a.checkExprVarRefs(interp.Expression, locals)
+				}
+			}
+		}
+	}
+}
+
+func (a *analyzer) checkExprVarRefs(expr Expression, locals map[string]bool) {
+	walkExpr(expr, func(e Expression) {
+		switch v := e.(type) {
+		case *Variable:
+			if len(locals) > 0 && locals[v.Name] {
+				return
+			}
+			if _, ok := a.variables[v.Name]; ok {
+				return
+			}
+			a.error(v.Pos, "undefined variable '%s'", v.Name)
+		case *FunctionCall:
+			if !builtinFunctions[v.Name] {
+				if _, ok := a.variables[v.Name]; !ok {
+					a.error(v.Pos, "undefined function '%s'", v.Name)
+				}
+			}
+		default:
+		}
+	})
+}
+
+func (a *analyzer) checkExportUnexportConflicts(jf *Justfile) {
+	exported := make(map[string]Position)
+	a.collectExports(jf, exported)
+
+	unexported := make(map[string]Position)
+	a.collectUnexports(jf, unexported)
+
+	for name, unexportPos := range unexported {
+		if exportPos, ok := exported[name]; ok {
+			a.error(unexportPos, "variable '%s' is both exported (at %s) and unexported", name, exportPos)
+		}
+	}
+}
+
+func (a *analyzer) collectExports(jf *Justfile, exported map[string]Position) {
+	for _, v := range jf.Assignments {
+		if v.Export {
+			exported[v.Name] = v.Pos
+		}
+	}
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			a.collectExports(imp.Justfile, exported)
+		}
+	}
+}
+
+func (a *analyzer) collectUnexports(jf *Justfile, unexported map[string]Position) {
+	for _, u := range jf.Unexports {
+		unexported[u.Name] = u.Pos
+	}
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			a.collectUnexports(imp.Justfile, unexported)
+		}
+	}
+}
+
+func (a *analyzer) error(pos Position, format string, args ...any) {
+	a.diagnostics = append(a.diagnostics, Diagnostic{
+		Pos:      pos,
+		Severity: SeverityError,
+		Message:  fmt.Sprintf(format, args...),
+		File:     a.file,
+	})
+}
+
+func (a *analyzer) warn(pos Position, format string, args ...any) {
+	a.diagnostics = append(a.diagnostics, Diagnostic{
+		Pos:      pos,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf(format, args...),
+		File:     a.file,
+	})
+}

--- a/pkg/validator/justfile/analyzer_test.go
+++ b/pkg/validator/justfile/analyzer_test.go
@@ -1,0 +1,248 @@
+package gojust
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAllowDuplicateRecipes(t *testing.T) {
+	input := "set allow-duplicate-recipes\n\nbuild:\n    echo a\nbuild:\n    echo b\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if d.Severity == SeverityError && strings.Contains(d.Message, "recipe") && strings.Contains(d.Message, "multiple times") {
+			t.Error("should not report duplicate recipe when allow-duplicate-recipes is set")
+		}
+	}
+}
+
+func TestValidateAllowDuplicateVariables(t *testing.T) {
+	input := "set allow-duplicate-variables\n\nx := \"a\"\nx := \"b\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if d.Severity == SeverityError && strings.Contains(d.Message, "variable") && strings.Contains(d.Message, "multiple times") {
+			t.Error("should not report duplicate variable when allow-duplicate-variables is set")
+		}
+	}
+}
+
+// --- circular dependency detection ---
+
+func TestValidateCircularDependency(t *testing.T) {
+	input := "a: b\n    echo a\nb: a\n    echo b\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "circular") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected circular dependency diagnostic")
+	}
+}
+
+func TestValidateCircularDependencyThreeWay(t *testing.T) {
+	input := "a: b\n    echo a\nb: c\n    echo b\nc: a\n    echo c\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "circular") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected circular dependency diagnostic")
+	}
+}
+
+func TestValidateNonCircularDeps(t *testing.T) {
+	input := "a: b\n    echo a\nb: c\n    echo b\nc:\n    echo c\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if strings.Contains(d.Message, "circular") {
+			t.Errorf("unexpected circular dependency diagnostic: %s", d.Message)
+		}
+	}
+}
+
+// --- {{{{ escape ---
+
+func TestValidateUndefinedVariable(t *testing.T) {
+	input := "val := undefined_var + \"suffix\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined variable 'undefined_var'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected undefined variable diagnostic")
+	}
+}
+
+func TestValidateDefinedVariable(t *testing.T) {
+	input := "name := \"world\"\ngreeting := \"hello \" + name\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined variable") {
+			t.Errorf("unexpected: %s", d.Message)
+		}
+	}
+}
+
+func TestValidateRecipeParamNotUndefined(t *testing.T) {
+	input := "build target:\n    echo {{target}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined variable 'target'") {
+			t.Error("recipe parameter should not be flagged as undefined")
+		}
+	}
+}
+
+func TestValidateUndefinedVarInRecipeBody(t *testing.T) {
+	input := "build:\n    echo {{missing}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined variable 'missing'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected undefined variable diagnostic in recipe body")
+	}
+}
+
+func TestValidateBuiltinFunction(t *testing.T) {
+	input := "val := arch() + \"/\" + os()\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined function") {
+			t.Errorf("builtin function should not be flagged: %s", d.Message)
+		}
+	}
+}
+
+func TestValidateUndefinedFunction(t *testing.T) {
+	input := "val := not_a_function(\"arg\")\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined function 'not_a_function'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected undefined function diagnostic")
+	}
+}
+
+func TestValidateUserDefinedFunction(t *testing.T) {
+	input := "myfunc(x) := x + \"!\"\nval := myfunc(\"hello\")\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined function 'myfunc'") {
+			t.Error("user-defined function should not be flagged as undefined")
+		}
+	}
+}
+
+func TestValidateUndefinedVarInDepArgs(t *testing.T) {
+	input := "build:\n    echo done\ndeploy: (build missing_var)\n    echo deploying\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "undefined variable 'missing_var'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected undefined variable in dependency args")
+	}
+}
+
+func TestValidateExportUnexportConflict(t *testing.T) {
+	input := "export FOO := \"bar\"\nunexport FOO\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "both exported") && strings.Contains(d.Message, "unexported") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected export/unexport conflict diagnostic")
+	}
+}
+
+func TestValidateUnexportWithoutExport(t *testing.T) {
+	input := "FOO := \"bar\"\nunexport FOO\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	for _, d := range diags {
+		if strings.Contains(d.Message, "both exported") {
+			t.Error("should not flag non-exported variable")
+		}
+	}
+}

--- a/pkg/validator/justfile/ast.go
+++ b/pkg/validator/justfile/ast.go
@@ -1,0 +1,284 @@
+package gojust
+
+// Justfile is the root AST node representing a parsed justfile.
+type Justfile struct {
+	Recipes     []*Recipe
+	Assignments []*Assignment
+	Unexports   []*Unexport
+	Aliases     []*Alias
+	Settings    []*Setting
+	Imports     []*Import
+	Modules     []*Module
+	Comments    []*Comment
+	File        string // source filename, empty for Parse()
+}
+
+type Comment struct {
+	Value string
+	Pos   Position
+}
+
+type Assignment struct {
+	Name       string
+	Value      Expression
+	Export     bool
+	Eager      bool
+	Private    bool
+	Parameters []string // non-empty for function definitions: name(params) := expr
+	Pos        Position
+}
+
+type Alias struct {
+	Name       string
+	Target     string
+	Attributes []*Attribute
+	Pos        Position
+}
+
+type Unexport struct {
+	Name string
+	Pos  Position
+}
+
+type Setting struct {
+	Name  string
+	Value SettingValue
+	Pos   Position
+}
+
+type SettingValue struct {
+	Bool   *bool
+	String *string
+	List   []string
+}
+
+// Kind returns which type of value this setting holds: "bool", "string", "list", or "" if unset.
+func (sv SettingValue) Kind() string {
+	if sv.Bool != nil {
+		return "bool"
+	}
+	if sv.String != nil {
+		return "string"
+	}
+	if sv.List != nil {
+		return "list"
+	}
+	return ""
+}
+
+// settingDefault describes a known justfile setting and its default value
+// for JSON dump output. The Name uses kebab-case (justfile syntax);
+// buildSettings converts to snake_case for JSON keys.
+type settingDefault struct {
+	Name    string
+	Default any // false for bool settings, nil for string/list settings
+}
+
+// knownSettingsList is the single source of truth for all recognized settings.
+// Both the analyzer (unknown-setting warnings) and the dump builder (JSON
+// defaults) derive from this list.
+var knownSettingsList = []settingDefault{
+	{"allow-duplicate-recipes", false},
+	{"allow-duplicate-variables", false},
+	{"dotenv-filename", nil},
+	{"dotenv-load", false},
+	{"dotenv-override", false},
+	{"dotenv-path", nil},
+	{"dotenv-required", false},
+	{"export", false},
+	{"fallback", false},
+	{"guards", false},
+	{"ignore-comments", false},
+	{"lazy", false},
+	{"no-exit-message", false},
+	{"positional-arguments", false},
+	{"quiet", false},
+	{"script-interpreter", nil},
+	{"shell", nil},
+	{"tempdir", nil},
+	{"unstable", false},
+	{"windows-powershell", false},
+	{"windows-shell", nil},
+	{"working-directory", nil},
+}
+
+type Import struct {
+	Path     string
+	Optional bool
+	Justfile *Justfile // resolved by ParseFile, nil from Parse
+	Pos      Position
+}
+
+type Module struct {
+	Name       string
+	Path       string // explicit path, empty if auto-discovered
+	Optional   bool
+	Justfile   *Justfile // resolved by ParseFile, nil from Parse
+	Attributes []*Attribute
+	Pos        Position
+}
+
+type Recipe struct {
+	Name         string
+	Parameters   []*Parameter
+	Dependencies []*Dependency
+	Body         []*RecipeLine
+	Attributes   []*Attribute
+	Shebang      string // e.g. "#!/usr/bin/env bash", empty if none
+	Quiet        bool   // prefixed with @
+	Comment      string
+	Pos          Position
+}
+
+type Parameter struct {
+	Name     string
+	Default  Expression // nil if no default
+	Export   bool       // prefixed with $
+	Variadic string     // "", "*", or "+"
+	Pos      Position
+}
+
+type Dependency struct {
+	Name       string
+	Arguments  []Expression
+	Subsequent bool // after &&
+	Pos        Position
+}
+
+type RecipeLine struct {
+	Fragments   []Fragment
+	Quiet       bool   // @
+	NoError     bool   // -
+	PrefixOrder string // "@-" or "-@" when both Quiet and NoError; empty otherwise
+	Pos         Position
+}
+
+// Fragment is a piece of a recipe line — either text or an interpolation.
+type Fragment interface {
+	fragmentNode()
+	GetPos() Position
+}
+
+type TextFragment struct {
+	Value string
+	Pos   Position
+}
+
+func (*TextFragment) fragmentNode()      {}
+func (t *TextFragment) GetPos() Position { return t.Pos }
+
+type InterpolationFragment struct {
+	Expression Expression
+	Pos        Position
+}
+
+func (*InterpolationFragment) fragmentNode()      {}
+func (i *InterpolationFragment) GetPos() Position { return i.Pos }
+
+// Expression represents any expression in a justfile.
+type Expression interface {
+	exprNode()
+	GetPos() Position
+}
+
+type StringLiteral struct {
+	Value string
+	Kind  string // StringKind* constant identifying the string type
+	Pos   Position
+}
+
+func (*StringLiteral) exprNode()          {}
+func (s *StringLiteral) GetPos() Position { return s.Pos }
+
+type Variable struct {
+	Name string
+	Pos  Position
+}
+
+func (*Variable) exprNode()          {}
+func (v *Variable) GetPos() Position { return v.Pos }
+
+type Concatenation struct {
+	Left  Expression
+	Right Expression
+	Pos   Position
+}
+
+func (*Concatenation) exprNode()          {}
+func (c *Concatenation) GetPos() Position { return c.Pos }
+
+type PathJoin struct {
+	Left  Expression
+	Right Expression
+	Pos   Position
+}
+
+func (*PathJoin) exprNode()          {}
+func (p *PathJoin) GetPos() Position { return p.Pos }
+
+type FunctionCall struct {
+	Name      string
+	Arguments []Expression
+	Pos       Position
+}
+
+func (*FunctionCall) exprNode()          {}
+func (f *FunctionCall) GetPos() Position { return f.Pos }
+
+type Conditional struct {
+	Condition Comparison
+	Then      Expression
+	Otherwise Expression
+	Pos       Position
+}
+
+func (*Conditional) exprNode()          {}
+func (c *Conditional) GetPos() Position { return c.Pos }
+
+type BacktickExpr struct {
+	Command  string
+	Indented bool
+	Pos      Position
+}
+
+func (*BacktickExpr) exprNode()          {}
+func (b *BacktickExpr) GetPos() Position { return b.Pos }
+
+type ParenExpr struct {
+	Inner Expression
+	Pos   Position
+}
+
+func (*ParenExpr) exprNode()          {}
+func (p *ParenExpr) GetPos() Position { return p.Pos }
+
+type LogicalOp struct {
+	Left     Expression
+	Right    Expression
+	Operator string // "&&", "||"
+	Pos      Position
+}
+
+func (*LogicalOp) exprNode()          {}
+func (l *LogicalOp) GetPos() Position { return l.Pos }
+
+type Comparison struct {
+	Left     Expression
+	Right    Expression
+	Operator string // "==", "!=", "=~", "!~"
+	Pos      Position
+}
+
+func (*Comparison) exprNode()          {}
+func (c *Comparison) GetPos() Position { return c.Pos }
+
+type Attribute struct {
+	Name      string
+	Arguments []AttributeArg
+	Pos       Position
+}
+
+type AttributeArg struct {
+	Key   string // empty for positional args
+	Value string
+}

--- a/pkg/validator/justfile/ast_test.go
+++ b/pkg/validator/justfile/ast_test.go
@@ -1,0 +1,205 @@
+package gojust
+
+import (
+	"testing"
+)
+
+func TestTokenTypeString(t *testing.T) {
+	if s := tokenIdentifier.String(); s != "identifier" {
+		t.Errorf("expected 'identifier', got %q", s)
+	}
+	// Unknown token type
+	if s := tokenType(999).String(); s != "token(999)" {
+		t.Errorf("expected 'token(999)', got %q", s)
+	}
+}
+
+func TestTokenString(t *testing.T) {
+	tok := token{Type: tokenIdentifier, Value: "foo", Pos: Position{Line: 1, Column: 1}}
+	s := tok.String()
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func TestPositionString(t *testing.T) {
+	p := Position{Line: 10, Column: 5}
+	if s := p.String(); s != "10:5" {
+		t.Errorf("expected '10:5', got %q", s)
+	}
+}
+
+func TestSeverityString(t *testing.T) {
+	if s := SeverityError.String(); s != "error" {
+		t.Errorf("expected 'error', got %q", s)
+	}
+	if s := SeverityWarning.String(); s != "warning" {
+		t.Errorf("expected 'warning', got %q", s)
+	}
+	if s := Severity(99).String(); s != "unknown" {
+		t.Errorf("expected 'unknown', got %q", s)
+	}
+}
+
+func TestDiagnosticStringNoFile(t *testing.T) {
+	d := Diagnostic{
+		Pos:      Position{Line: 1, Column: 1},
+		Severity: SeverityWarning,
+		Message:  "test",
+	}
+	s := d.String()
+	if s != "<input>:1:1: warning: test" {
+		t.Errorf("unexpected: %q", s)
+	}
+}
+
+func TestParseErrorStringNoFile(t *testing.T) {
+	e := &ParseError{
+		Pos:     Position{Line: 5, Column: 3},
+		Message: "bad",
+	}
+	s := e.Error()
+	if s != "<input>:5:3: bad" {
+		t.Errorf("unexpected: %q", s)
+	}
+}
+
+// --- Parser error paths ---
+
+func TestParseErrorUnexpectedToken(t *testing.T) {
+	_, err := Parse([]byte("+ bad"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseErrorBadExportMissingAssign(t *testing.T) {
+	_, err := Parse([]byte("export FOO\n"))
+	if err == nil {
+		t.Fatal("expected error for export without :=")
+	}
+}
+
+func TestParseErrorBadSettingValue(t *testing.T) {
+	_, err := Parse([]byte("set shell := bad\n"))
+	if err == nil {
+		t.Fatal("expected error for bad setting value")
+	}
+}
+
+func TestParseErrorBadImportPath(t *testing.T) {
+	_, err := Parse([]byte("import bad\n"))
+	if err == nil {
+		t.Fatal("expected error for import without string")
+	}
+}
+
+// --- Escape sequence edge cases ---
+
+func TestAllExpressionTypes(t *testing.T) {
+	// Build expressions that cover every Expression implementation
+	exprs := []Expression{
+		&StringLiteral{Value: "a", Pos: Position{1, 1, 0}},
+		&Variable{Name: "x", Pos: Position{1, 1, 0}},
+		&Concatenation{Left: &StringLiteral{}, Right: &StringLiteral{}, Pos: Position{1, 1, 0}},
+		&PathJoin{Left: &StringLiteral{}, Right: &StringLiteral{}, Pos: Position{1, 1, 0}},
+		&FunctionCall{Name: "f", Pos: Position{1, 1, 0}},
+		&Conditional{Pos: Position{1, 1, 0}},
+		&BacktickExpr{Command: "echo", Pos: Position{1, 1, 0}},
+		&ParenExpr{Inner: &StringLiteral{}, Pos: Position{1, 1, 0}},
+		&LogicalOp{Left: &StringLiteral{}, Right: &StringLiteral{}, Operator: "&&", Pos: Position{1, 1, 0}},
+		&Comparison{Left: &StringLiteral{}, Right: &StringLiteral{}, Operator: "==", Pos: Position{1, 1, 0}},
+	}
+	for _, e := range exprs {
+		e.exprNode()
+		p := e.GetPos()
+		if p.Line != 1 {
+			t.Errorf("expected line 1, got %d for %T", p.Line, e)
+		}
+	}
+
+	frags := []Fragment{
+		&TextFragment{Value: "hi", Pos: Position{1, 1, 0}},
+		&InterpolationFragment{Expression: &StringLiteral{}, Pos: Position{1, 1, 0}},
+	}
+	for _, f := range frags {
+		f.fragmentNode()
+		p := f.GetPos()
+		if p.Line != 1 {
+			t.Errorf("expected line 1, got %d for %T", p.Line, f)
+		}
+	}
+}
+
+// --- Remaining lexer gaps ---
+
+func TestParseErrorAliasMissingAssign(t *testing.T) {
+	_, err := Parse([]byte("alias b bad\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseErrorAliasMissingTarget(t *testing.T) {
+	_, err := Parse([]byte("alias b :=\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseErrorDependencyUnclosedParen(t *testing.T) {
+	_, err := Parse([]byte("build: (dep \"arg\"\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for unclosed dependency paren")
+	}
+}
+
+func TestParseErrorFunctionCallUnclosed(t *testing.T) {
+	_, err := Parse([]byte("val := env_var(\"HOME\"\n"))
+	if err == nil {
+		t.Fatal("expected error for unclosed function call")
+	}
+}
+
+func TestParseErrorSettingBadList(t *testing.T) {
+	_, err := Parse([]byte("set shell := [bad]\n"))
+	if err == nil {
+		t.Fatal("expected error for bad list value")
+	}
+}
+
+func TestParseErrorConditionalMissingCloseBrace(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" == "b" { "y" else { "n" }`))
+	if err == nil {
+		t.Fatal("expected error for missing close brace")
+	}
+}
+
+func TestParseErrorConditionalMissingElseCloseBrace(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" == "b" { "y" } else { "n"`))
+	if err == nil {
+		t.Fatal("expected error for missing else close brace")
+	}
+}
+
+func TestSettingValueKind(t *testing.T) {
+	b := true
+	s := "hello"
+	tests := []struct {
+		name string
+		sv   SettingValue
+		want string
+	}{
+		{"bool", SettingValue{Bool: &b}, "bool"},
+		{"string", SettingValue{String: &s}, "string"},
+		{"list", SettingValue{List: []string{"a"}}, "list"},
+		{"empty", SettingValue{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sv.Kind(); got != tt.want {
+				t.Errorf("Kind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/validator/justfile/diagnostic.go
+++ b/pkg/validator/justfile/diagnostic.go
@@ -1,0 +1,55 @@
+package gojust
+
+import "fmt"
+
+type ParseError struct {
+	Pos     Position
+	Message string
+	File    string
+	Err     error // underlying error, if any
+}
+
+func (e *ParseError) Error() string {
+	file := e.File
+	if file == "" {
+		file = "<input>"
+	}
+	return fmt.Sprintf("%s:%d:%d: %s", file, e.Pos.Line, e.Pos.Column, e.Message)
+}
+
+func (e *ParseError) Unwrap() error {
+	return e.Err
+}
+
+type Severity int
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	default:
+		return "unknown"
+	}
+}
+
+type Diagnostic struct {
+	Pos      Position
+	Severity Severity
+	Message  string
+	File     string
+}
+
+func (d Diagnostic) String() string {
+	file := d.File
+	if file == "" {
+		file = "<input>"
+	}
+	return fmt.Sprintf("%s:%d:%d: %s: %s", file, d.Pos.Line, d.Pos.Column, d.Severity, d.Message)
+}

--- a/pkg/validator/justfile/doc.go
+++ b/pkg/validator/justfile/doc.go
@@ -1,0 +1,6 @@
+// Package gojust parses and validates justfiles.
+//
+// Use [Parse] to parse justfile content from bytes, or [ParseFile] to
+// parse from disk with automatic import and module resolution.
+// Call [Justfile.Validate] to run semantic analysis and get diagnostics.
+package gojust

--- a/pkg/validator/justfile/fuzz_test.go
+++ b/pkg/validator/justfile/fuzz_test.go
@@ -1,0 +1,70 @@
+package gojust
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FuzzParse feeds random bytes to Parse and asserts it never panics.
+// It either returns a valid AST or an error — never crashes.
+func FuzzParse(f *testing.F) {
+	// Seed with all testdata files
+	entries, err := os.ReadDir("testdata")
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".just") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join("testdata", e.Name()))
+			if err == nil {
+				f.Add(data)
+			}
+		}
+	}
+
+	// Seed with minimal valid inputs
+	f.Add([]byte(""))
+	f.Add([]byte("build:\n    echo done\n"))
+	f.Add([]byte("v := \"hello\"\n"))
+	f.Add([]byte("set dotenv-load\n"))
+	f.Add([]byte("alias b := build\nbuild:\n    echo done\n"))
+	f.Add([]byte("import 'foo.just'\n"))
+	f.Add([]byte("mod bar\n"))
+	f.Add([]byte("export FOO := \"bar\"\n"))
+	f.Add([]byte("eager val := `cmd`\n"))
+	f.Add([]byte("[private]\nbuild:\n    echo done\n"))
+	f.Add([]byte("build target='all':\n    echo {{target}}\n"))
+	f.Add([]byte("f(x) := x + \"!\"\n"))
+	f.Add([]byte("v := if \"a\" == \"b\" { \"y\" } else { \"n\" }\n"))
+	f.Add([]byte("v := \"a\" + \"b\" / \"c\"\n"))
+	f.Add([]byte("v := / \"absolute\"\n"))
+	f.Add([]byte("build:\n    echo '{{{{literal}}'\n"))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		jf, err := Parse(data)
+		if err != nil {
+			return // parse errors are fine
+		}
+		// If it parsed, validate shouldn't panic
+		_ = jf.Validate()
+	})
+}
+
+// FuzzLexer feeds random bytes directly to the lexer.
+func FuzzLexer(f *testing.F) {
+	f.Add([]byte("build:\n    echo done\n"))
+	f.Add([]byte("v := \"hello\\nworld\"\n"))
+	f.Add([]byte("v := '\\u{1F600}'\n"))
+	f.Add([]byte("build:\n    echo {{\"a\" + \"b\"}}\n"))
+	f.Add([]byte("build:\n    echo '{{{{literal}}'\n"))
+	f.Add([]byte("#!/usr/bin/env just\n"))
+	f.Add([]byte("set shell := ['bash', '-cu']\n"))
+	f.Add([]byte("[private, no-cd]\nbuild:\n    @-echo done\n"))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		l := newLexer(data)
+		_, _ = l.lex() // must not panic
+	})
+}

--- a/pkg/validator/justfile/generated_test.go
+++ b/pkg/validator/justfile/generated_test.go
@@ -1,0 +1,315 @@
+package gojust
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"testing"
+)
+
+// gen is a justfile generator that produces random but grammatically
+// plausible justfiles by combining productions from the just grammar.
+type gen struct {
+	rng   *rand.Rand
+	depth int
+}
+
+func newGen(seed int64) *gen {
+	return &gen{rng: rand.New(rand.NewPCG(uint64(seed), uint64(seed)))}
+}
+
+func (g *gen) pick(choices ...string) string {
+	return choices[g.rng.IntN(len(choices))]
+}
+
+func (g *gen) ident() string {
+	prefixes := []string{"foo", "bar", "baz", "build", "test", "deploy", "lint", "check", "run", "clean", "install", "update", "my-task", "do_thing", "_private"}
+	suffix := fmt.Sprintf("_%d", g.rng.IntN(100))
+	return prefixes[g.rng.IntN(len(prefixes))] + suffix
+}
+
+func (g *gen) stringLit() string {
+	switch g.rng.IntN(4) {
+	case 0:
+		return fmt.Sprintf(`"hello_%d"`, g.rng.IntN(100))
+	case 1:
+		return fmt.Sprintf(`'raw_%d'`, g.rng.IntN(100))
+	case 2:
+		return `"with\nescaped"`
+	default:
+		// Multi-line raw string — valid in assignments, dep args, interpolations
+		return "'multi\nline\nraw'"
+	}
+}
+
+func (g *gen) expr() string {
+	g.depth++
+	defer func() { g.depth-- }()
+	if g.depth > 3 {
+		return g.stringLit()
+	}
+	switch g.rng.IntN(8) {
+	case 0:
+		return g.stringLit()
+	case 1:
+		return g.ident()
+	case 2:
+		return g.expr() + " + " + g.expr()
+	case 3:
+		return g.expr() + " / " + g.expr()
+	case 4:
+		return g.pick("arch", "os", "os_family", "num_cpus", "justfile_directory") + "()"
+	case 5:
+		return fmt.Sprintf(`env_var_or_default("%s", %s)`, g.ident(), g.stringLit())
+	case 6:
+		return fmt.Sprintf(`replace(%s, ".", "-")`, g.stringLit())
+	case 7:
+		return fmt.Sprintf(`if %s == %s { %s } else { %s }`,
+			g.stringLit(), g.stringLit(), g.stringLit(), g.stringLit())
+	}
+	return g.stringLit()
+}
+
+func (g *gen) assignment() string {
+	prefix := g.pick("", "export ", "eager ", "eager export ")
+	return fmt.Sprintf("%s%s := %s\n", prefix, g.ident(), g.expr())
+}
+
+func (g *gen) setting() string {
+	switch g.rng.IntN(4) {
+	case 0:
+		return fmt.Sprintf("set %s\n", g.pick("dotenv-load", "export", "positional-arguments", "quiet"))
+	case 1:
+		return fmt.Sprintf("set %s := %s\n", g.pick("dotenv-load", "fallback"), g.pick("true", "false"))
+	case 2:
+		return fmt.Sprintf("set shell := [%s, %s]\n", g.stringLit(), g.stringLit())
+	default:
+		return fmt.Sprintf("set tempdir := %s\n", g.stringLit())
+	}
+}
+
+func (g *gen) param() string {
+	variadic := g.pick("", "", "", "*", "+")
+	export := g.pick("", "", "$")
+	name := g.ident()
+	dflt := ""
+	if g.rng.IntN(3) == 0 && variadic == "" {
+		dflt = "=" + g.stringLit()
+	}
+	return variadic + export + name + dflt
+}
+
+func (g *gen) dep(recipes []string) string {
+	if len(recipes) == 0 {
+		return ""
+	}
+	name := recipes[g.rng.IntN(len(recipes))]
+	if g.rng.IntN(3) == 0 {
+		return fmt.Sprintf("(%s %s)", name, g.stringLit())
+	}
+	return name
+}
+
+func (g *gen) singleLineStringLit() string {
+	switch g.rng.IntN(2) {
+	case 0:
+		return fmt.Sprintf(`"hello_%d"`, g.rng.IntN(100))
+	default:
+		return fmt.Sprintf(`'raw_%d'`, g.rng.IntN(100))
+	}
+}
+
+func (g *gen) recipeLine() string {
+	prefix := g.pick("", "", "@", "-", "@-", "-@")
+	switch g.rng.IntN(4) {
+	case 0:
+		// Shell text — use single-line strings (shell quotes, not justfile strings)
+		return fmt.Sprintf("    %secho %s\n", prefix, g.singleLineStringLit())
+	case 1:
+		// Interpolation — justfile expressions, multi-line strings OK
+		return fmt.Sprintf("    %secho {{%s}}\n", prefix, g.ident())
+	case 2:
+		return fmt.Sprintf("    %secho {{%s + %s}}\n", prefix, g.stringLit(), g.stringLit())
+	default:
+		return fmt.Sprintf("    %secho done\n", prefix)
+	}
+}
+
+func (g *gen) attribute() string {
+	switch g.rng.IntN(6) {
+	case 0:
+		return "[private]\n"
+	case 1:
+		return fmt.Sprintf("[group: %s]\n", g.stringLit())
+	case 2:
+		return "[no-cd]\n"
+	case 3:
+		return fmt.Sprintf("[confirm(%s)]\n", g.stringLit())
+	case 4:
+		return "[linux]\n"
+	default:
+		return fmt.Sprintf("[doc(%s)]\n", g.stringLit())
+	}
+}
+
+func (g *gen) recipe(existingRecipes []string) (name string, body string) {
+	name = g.ident()
+	var b strings.Builder
+
+	// Attributes
+	if g.rng.IntN(3) == 0 {
+		b.WriteString(g.attribute())
+	}
+
+	// Quiet prefix
+	if g.rng.IntN(4) == 0 {
+		b.WriteString("@")
+	}
+
+	b.WriteString(name)
+
+	// Params
+	nParams := g.rng.IntN(3)
+	for i := 0; i < nParams; i++ {
+		b.WriteString(" " + g.param())
+	}
+
+	b.WriteString(":")
+
+	// Deps
+	nDeps := g.rng.IntN(3)
+	for i := 0; i < nDeps; i++ {
+		d := g.dep(existingRecipes)
+		if d != "" {
+			b.WriteString(" " + d)
+		}
+	}
+
+	// Subsequent deps
+	if g.rng.IntN(4) == 0 && len(existingRecipes) > 0 {
+		b.WriteString(" && " + g.dep(existingRecipes))
+	}
+
+	b.WriteString("\n")
+
+	// Body
+	nLines := 1 + g.rng.IntN(3)
+	for i := 0; i < nLines; i++ {
+		b.WriteString(g.recipeLine())
+	}
+
+	return name, b.String()
+}
+
+func (g *gen) justfile() string {
+	var b strings.Builder
+
+	// Settings
+	nSettings := g.rng.IntN(4)
+	for i := 0; i < nSettings; i++ {
+		b.WriteString(g.setting())
+	}
+	if nSettings > 0 {
+		b.WriteString("\n")
+	}
+
+	// Assignments
+	nAssignments := 1 + g.rng.IntN(5)
+	for i := 0; i < nAssignments; i++ {
+		b.WriteString(g.assignment())
+	}
+	b.WriteString("\n")
+
+	// Recipes
+	var recipeNames []string
+	nRecipes := 2 + g.rng.IntN(6)
+	for i := 0; i < nRecipes; i++ {
+		name, recipe := g.recipe(recipeNames)
+		recipeNames = append(recipeNames, name)
+		b.WriteString(recipe)
+		b.WriteString("\n")
+	}
+
+	// Aliases
+	if len(recipeNames) > 1 && g.rng.IntN(2) == 0 {
+		target := recipeNames[g.rng.IntN(len(recipeNames))]
+		fmt.Fprintf(&b, "alias a_%d := %s\n", g.rng.IntN(100), target)
+	}
+
+	return b.String()
+}
+
+func TestGeneratedJustfiles(t *testing.T) {
+	const numFiles = 1000
+
+	for seed := int64(0); seed < numFiles; seed++ {
+		t.Run(fmt.Sprintf("seed_%d", seed), func(t *testing.T) {
+			g := newGen(seed)
+			content := g.justfile()
+
+			jf, err := Parse([]byte(content))
+			if err != nil {
+				t.Fatalf("seed %d: Parse failed: %v\n\nContent:\n%s", seed, err, content)
+			}
+
+			// Also run validation — shouldn't panic
+			_ = jf.Validate()
+		})
+	}
+}
+
+func TestGeneratedEdgeCases(t *testing.T) {
+	// Specific patterns that combine grammar features in unusual ways
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty recipe", "build:\n"},
+		{"recipe no newline at end", "build:\n    echo done"},
+		{"multiple blank lines", "\n\n\nbuild:\n    echo done\n\n\n"},
+		{"comment between attrs", "[private]\n# comment\n[no-cd]\nbuild:\n    echo done\n"},
+		{"all string types in assignments", `
+a := "quoted"
+b := 'raw'
+c := ` + "`backtick`" + `
+d := f"format"
+e := f'format_raw'
+f := x"shell"
+g := x'shell_raw'
+`},
+		{"deeply nested expression", `val := "a" + "b" + "c" + "d" + "e" + "f" + "g"` + "\n"},
+		{"deeply nested path", `val := "a" / "b" / "c" / "d" / "e"` + "\n"},
+		{"conditional in conditional", `val := if "a" == "b" { if "c" == "d" { "e" } else { "f" } } else { "g" }` + "\n"},
+		{"recipe with all param types", "build target mode=\"debug\" $ENV +rest:\n    echo done\n"},
+		{"subsequent deps with args", "all: build && (test \"integration\") deploy\n    echo done\nbuild:\n    echo build\ntest x:\n    echo test\ndeploy:\n    echo deploy\n"},
+		{"shebang recipe", "build:\n    #!/usr/bin/env bash\n    set -euo pipefail\n    echo done\n"},
+		{"multiline conditional assignment", "val := if \"a\" == \"b\" {\n  \"yes\"\n} else {\n  \"no\"\n}\n"},
+		{"function def multiline", "myfn(a, b) := if a == b {\n  'same'\n} else {\n  'diff'\n}\n"},
+		{"recipe named import", "import:\n    echo importing\n"},
+		{"eager export", "eager export TOKEN := `echo secret`\n"},
+		{"setting with keyword name", "set export\nset quiet\n"},
+		{"attribute with multiple args", "[env(name=\"FOO\", value=\"bar\")]\nbuild:\n    echo done\n"},
+		{"brace escape", "build:\n    echo '{{{{literal braces}}'\n"},
+		{"recipe with empty lines in body", "build:\n    echo start\n\n    echo end\n"},
+		{"absolute path expression", "val := / \"usr\" / \"local\" / \"bin\"\n"},
+		{"backtick in expression", "val := `echo hello` + \" world\"\n"},
+		{"complex deps", "all: (build \"release\") && (test \"unit\") (deploy \"prod\")\n    echo done\nbuild x:\n    echo build\ntest x:\n    echo test\ndeploy x:\n    echo deploy\n"},
+		{"optional import and mod", "import? 'maybe.just'\nmod? optional\nbuild:\n    echo done\n"},
+		{"unexport", "export FOO := \"bar\"\nunexport FOO\nbuild:\n    echo done\n"},
+		{"private assignment", "[private]\n_internal := \"secret\"\nbuild:\n    echo done\n"},
+		{"string operators", "a := 'hello' && 'world'\nb := '' || 'fallback'\n"},
+		{"regex in conditional", "val := if arch() =~ \"x86\" { \"intel\" } else { \"other\" }\n"},
+		{"many settings", "set dotenv-load\nset export\nset positional-arguments\nset quiet\nset fallback\n"},
+		{"long recipe body", "build:\n    echo line1\n    echo line2\n    echo line3\n    echo line4\n    echo line5\n    echo line6\n    echo line7\n    echo line8\n    echo line9\n    echo line10\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			jf, err := Parse([]byte(tc.content))
+			if err != nil {
+				t.Fatalf("Parse failed: %v\n\nContent:\n%s", err, tc.content)
+			}
+			_ = jf.Validate()
+		})
+	}
+}

--- a/pkg/validator/justfile/go.mod
+++ b/pkg/validator/justfile/go.mod
@@ -1,0 +1,3 @@
+module github.com/Boeing/go-just
+
+go 1.23

--- a/pkg/validator/justfile/gojust.go
+++ b/pkg/validator/justfile/gojust.go
@@ -1,0 +1,152 @@
+package gojust
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Parse parses justfile content from bytes. Import and module statements
+// are represented as AST nodes but not resolved — use ParseFile to
+// automatically resolve imports and modules from disk.
+func Parse(content []byte) (*Justfile, error) {
+	l := newLexer(content)
+	tokens, err := l.lex()
+	if err != nil {
+		return nil, err
+	}
+
+	p := newParser(tokens, "")
+	return p.parse()
+}
+
+// ParseFile reads and parses a justfile from disk. Imports and modules
+// are resolved recursively relative to the file's directory.
+//
+// Security note: ParseFile follows import and module paths specified in
+// the justfile, which may reference files outside the justfile's directory
+// (including absolute paths and ~/). Do not use ParseFile on untrusted
+// justfiles if file read side effects are a concern. Use [Parse] instead
+// to parse without filesystem access.
+func ParseFile(filename string) (*Justfile, error) {
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseFileRecursive(absPath, make(map[string]bool), 0)
+}
+
+const maxImportDepth = 100
+
+func parseFileRecursive(absPath string, inProgress map[string]bool, depth int) (*Justfile, error) {
+	if depth > maxImportDepth {
+		return nil, &ParseError{
+			Message: "import depth limit exceeded (possible import chain too deep)",
+		}
+	}
+	if inProgress[absPath] {
+		return nil, &ParseError{
+			Message: "circular import: " + absPath,
+		}
+	}
+	inProgress[absPath] = true
+	defer delete(inProgress, absPath)
+
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, err
+	}
+
+	l := newLexer(content)
+	tokens, err := l.lex()
+	if err != nil {
+		var pe *ParseError
+		if errors.As(err, &pe) {
+			pe.File = absPath
+		}
+		return nil, err
+	}
+
+	p := newParser(tokens, absPath)
+	jf, err := p.parse()
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Dir(absPath)
+
+	// Resolve imports
+	for _, imp := range jf.Imports {
+		impPath := resolveImportPath(dir, imp.Path)
+		resolved, err := parseFileRecursive(impPath, inProgress, depth+1)
+		if err != nil {
+			if imp.Optional && os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		imp.Justfile = resolved
+	}
+
+	// Resolve modules
+	for _, mod := range jf.Modules {
+		modPath, err := resolveModulePath(dir, mod)
+		if err != nil {
+			if mod.Optional {
+				continue
+			}
+			return nil, err
+		}
+		resolved, err := parseFileRecursive(modPath, inProgress, depth+1)
+		if err != nil {
+			if mod.Optional && os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		mod.Justfile = resolved
+	}
+
+	return jf, nil
+}
+
+func resolveImportPath(dir, path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(dir, path)
+}
+
+func resolveModulePath(dir string, mod *Module) (string, error) {
+	if mod.Path != "" {
+		return resolveImportPath(dir, mod.Path), nil
+	}
+
+	// Search order: name.just, name/mod.just, name/justfile, name/.justfile
+	candidates := []string{
+		filepath.Join(dir, mod.Name+".just"),
+		filepath.Join(dir, mod.Name, "mod.just"),
+		filepath.Join(dir, mod.Name, "justfile"),
+		filepath.Join(dir, mod.Name, "Justfile"),
+		filepath.Join(dir, mod.Name, ".justfile"),
+	}
+
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c, nil
+		}
+	}
+
+	return "", &ParseError{
+		Pos:     mod.Pos,
+		Message: "could not find module file for '" + mod.Name + "'",
+	}
+}

--- a/pkg/validator/justfile/gojust_test.go
+++ b/pkg/validator/justfile/gojust_test.go
@@ -1,0 +1,743 @@
+package gojust
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseBasicJustfile(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("testdata", "basic.just"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jf, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(jf.Assignments) != 4 {
+		t.Errorf("expected 4 assignments, got %d", len(jf.Assignments))
+	}
+	if len(jf.Recipes) != 4 {
+		t.Errorf("expected 4 recipes, got %d", len(jf.Recipes))
+	}
+	if len(jf.Aliases) != 2 {
+		t.Errorf("expected 2 aliases, got %d", len(jf.Aliases))
+	}
+	if len(jf.Settings) != 2 {
+		t.Errorf("expected 2 settings, got %d", len(jf.Settings))
+	}
+}
+
+func TestParseAdvancedJustfile(t *testing.T) {
+	content, err := os.ReadFile(filepath.Join("testdata", "advanced.just"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jf, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	// Count items
+	if len(jf.Settings) != 4 {
+		t.Errorf("expected 4 settings, got %d", len(jf.Settings))
+	}
+	if len(jf.Aliases) != 3 {
+		t.Errorf("expected 3 aliases, got %d", len(jf.Aliases))
+	}
+
+	// Find specific recipes
+	recipeNames := make(map[string]*Recipe)
+	for _, r := range jf.Recipes {
+		recipeNames[r.Name] = r
+	}
+
+	// Variadic params
+	if r, ok := recipeNames["test"]; ok {
+		if len(r.Parameters) != 1 || r.Parameters[0].Variadic != "+" {
+			t.Error("expected test recipe to have + variadic param")
+		}
+	} else {
+		t.Error("missing recipe 'test'")
+	}
+
+	if r, ok := recipeNames["test-optional"]; ok {
+		if len(r.Parameters) != 1 || r.Parameters[0].Variadic != "*" {
+			t.Error("expected test-optional recipe to have * variadic param")
+		}
+	} else {
+		t.Error("missing recipe 'test-optional'")
+	}
+
+	// Export param
+	if r, ok := recipeNames["run-with-env"]; ok {
+		if len(r.Parameters) != 1 || !r.Parameters[0].Export {
+			t.Error("expected run-with-env to have exported param")
+		}
+	} else {
+		t.Error("missing recipe 'run-with-env'")
+	}
+
+	// Quiet recipe
+	if r, ok := recipeNames["quiet-recipe"]; ok {
+		if !r.Quiet {
+			t.Error("expected quiet-recipe to be quiet")
+		}
+	} else {
+		t.Error("missing recipe 'quiet-recipe'")
+	}
+
+	// Attributes
+	if r, ok := recipeNames["ci"]; ok {
+		if len(r.Attributes) != 2 {
+			t.Errorf("expected 2 attributes on ci, got %d", len(r.Attributes))
+		}
+	} else {
+		t.Error("missing recipe 'ci'")
+	}
+
+	if r, ok := recipeNames["unix-only"]; ok {
+		if len(r.Attributes) != 2 {
+			t.Errorf("expected 2 attributes on unix-only, got %d", len(r.Attributes))
+		}
+	} else {
+		t.Error("missing recipe 'unix-only'")
+	}
+}
+
+// --- Assignment tests ---
+
+func TestParseAssignment(t *testing.T) {
+	jf, err := Parse([]byte(`name := "world"`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+	if jf.Assignments[0].Name != "name" {
+		t.Errorf("expected name 'name', got %q", jf.Assignments[0].Name)
+	}
+}
+
+func TestParseExportAssignment(t *testing.T) {
+	jf, err := Parse([]byte(`export FOO := "bar"`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+	if !jf.Assignments[0].Export {
+		t.Error("expected assignment to be exported")
+	}
+}
+
+func TestParseFunctionCallAssignment(t *testing.T) {
+	jf, err := Parse([]byte(`home := env_var("HOME")`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+	fc, ok := jf.Assignments[0].Value.(*FunctionCall)
+	if !ok {
+		t.Fatalf("expected FunctionCall, got %T", jf.Assignments[0].Value)
+	}
+	if fc.Name != "env_var" {
+		t.Errorf("expected function name 'env_var', got %q", fc.Name)
+	}
+}
+
+func TestParseConcatenation(t *testing.T) {
+	jf, err := Parse([]byte(`full := "a" + "b" + "c"`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	_, ok := jf.Assignments[0].Value.(*Concatenation)
+	if !ok {
+		t.Fatalf("expected Concatenation, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestParsePathJoin(t *testing.T) {
+	jf, err := Parse([]byte(`p := "a" / "b" / "c"`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	_, ok := jf.Assignments[0].Value.(*PathJoin)
+	if !ok {
+		t.Fatalf("expected PathJoin, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestParseConditional(t *testing.T) {
+	input := `val := if "a" == "b" { "yes" } else { "no" }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	cond, ok := jf.Assignments[0].Value.(*Conditional)
+	if !ok {
+		t.Fatalf("expected Conditional, got %T", jf.Assignments[0].Value)
+	}
+	if cond.Condition.Operator != "==" {
+		t.Errorf("expected operator '==', got %q", cond.Condition.Operator)
+	}
+}
+
+func TestParseNestedConditional(t *testing.T) {
+	input := `val := if "a" == "a" { "first" } else if "b" == "b" { "second" } else { "third" }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	cond, ok := jf.Assignments[0].Value.(*Conditional)
+	if !ok {
+		t.Fatalf("expected Conditional, got %T", jf.Assignments[0].Value)
+	}
+	_, ok = cond.Otherwise.(*Conditional)
+	if !ok {
+		t.Fatalf("expected nested Conditional in else, got %T", cond.Otherwise)
+	}
+}
+
+func TestParseBacktick(t *testing.T) {
+	jf, err := Parse([]byte("val := `echo hello`"))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	bt, ok := jf.Assignments[0].Value.(*BacktickExpr)
+	if !ok {
+		t.Fatalf("expected BacktickExpr, got %T", jf.Assignments[0].Value)
+	}
+	if bt.Command != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", bt.Command)
+	}
+}
+
+// --- Recipe tests ---
+
+func TestParseRecipeWithParams(t *testing.T) {
+	jf, err := Parse([]byte("build target='all' mode=\"debug\":\n    echo done\n"))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 1 {
+		t.Fatalf("expected 1 recipe, got %d", len(jf.Recipes))
+	}
+	r := jf.Recipes[0]
+	if r.Name != "build" {
+		t.Errorf("expected recipe name 'build', got %q", r.Name)
+	}
+	if len(r.Parameters) != 2 {
+		t.Errorf("expected 2 parameters, got %d", len(r.Parameters))
+	}
+}
+
+func TestParseRecipeWithDeps(t *testing.T) {
+	jf, err := Parse([]byte("deploy: build test\n    echo deploying\n"))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	r := jf.Recipes[0]
+	if len(r.Dependencies) != 2 {
+		t.Errorf("expected 2 dependencies, got %d", len(r.Dependencies))
+	}
+}
+
+func TestParseRecipeWithDepArgs(t *testing.T) {
+	jf, err := Parse([]byte("deploy: (build \"release\")\n    echo deploying\n"))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	r := jf.Recipes[0]
+	if len(r.Dependencies) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(r.Dependencies))
+	}
+	if r.Dependencies[0].Name != "build" {
+		t.Errorf("expected dep name 'build', got %q", r.Dependencies[0].Name)
+	}
+	if len(r.Dependencies[0].Arguments) != 1 {
+		t.Errorf("expected 1 dep argument, got %d", len(r.Dependencies[0].Arguments))
+	}
+}
+
+func TestParseSubsequentDeps(t *testing.T) {
+	jf, err := Parse([]byte("all: build && test deploy\n    echo done\n"))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	r := jf.Recipes[0]
+	if len(r.Dependencies) != 3 {
+		t.Fatalf("expected 3 dependencies, got %d", len(r.Dependencies))
+	}
+	if r.Dependencies[0].Subsequent {
+		t.Error("first dep should not be subsequent")
+	}
+	if !r.Dependencies[1].Subsequent {
+		t.Error("second dep should be subsequent")
+	}
+	if !r.Dependencies[2].Subsequent {
+		t.Error("third dep should be subsequent")
+	}
+}
+
+func TestParseRecipeBody(t *testing.T) {
+	input := "build:\n    echo line1\n    echo line2\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	r := jf.Recipes[0]
+	if len(r.Body) != 2 {
+		t.Errorf("expected 2 body lines, got %d", len(r.Body))
+	}
+}
+
+func TestParseRecipeBodyInterpolation(t *testing.T) {
+	input := "build name:\n    echo \"hello {{name}}\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	r := jf.Recipes[0]
+	if len(r.Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(r.Body))
+	}
+	// Should have text, interpolation, text fragments
+	if len(r.Body[0].Fragments) < 2 {
+		t.Errorf("expected at least 2 fragments, got %d", len(r.Body[0].Fragments))
+	}
+	// Check that one fragment is an interpolation
+	foundInterp := false
+	for _, f := range r.Body[0].Fragments {
+		if _, ok := f.(*InterpolationFragment); ok {
+			foundInterp = true
+		}
+	}
+	if !foundInterp {
+		t.Error("expected to find an interpolation fragment")
+	}
+}
+
+func TestParseRecipeLinePrefixes(t *testing.T) {
+	input := "build:\n    @quiet\n    -error\n    @-both\n    -@also\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	r := jf.Recipes[0]
+	if len(r.Body) != 4 {
+		t.Fatalf("expected 4 body lines, got %d", len(r.Body))
+	}
+	if !r.Body[0].Quiet || r.Body[0].NoError {
+		t.Error("line 0: expected quiet only")
+	}
+	if r.Body[1].Quiet || !r.Body[1].NoError {
+		t.Error("line 1: expected error-suppressed only")
+	}
+	if !r.Body[2].Quiet || !r.Body[2].NoError {
+		t.Error("line 2: expected both quiet and error-suppressed")
+	}
+	if !r.Body[3].Quiet || !r.Body[3].NoError {
+		t.Error("line 3: expected both quiet and error-suppressed")
+	}
+}
+
+func TestParseMultipleRecipes(t *testing.T) {
+	input := "build:\n    echo build\n\ntest:\n    echo test\n\ndeploy:\n    echo deploy\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 3 {
+		t.Errorf("expected 3 recipes, got %d", len(jf.Recipes))
+	}
+}
+
+// --- Import/Module tests ---
+
+func TestParseImport(t *testing.T) {
+	jf, err := Parse([]byte(`import 'foo/bar.just'`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(jf.Imports))
+	}
+	if jf.Imports[0].Path != "foo/bar.just" {
+		t.Errorf("expected path 'foo/bar.just', got %q", jf.Imports[0].Path)
+	}
+	if jf.Imports[0].Justfile != nil {
+		t.Error("expected unresolved import from Parse()")
+	}
+}
+
+func TestParseOptionalImport(t *testing.T) {
+	jf, err := Parse([]byte(`import? 'optional.just'`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if !jf.Imports[0].Optional {
+		t.Error("expected optional import")
+	}
+}
+
+func TestParseModule(t *testing.T) {
+	jf, err := Parse([]byte(`mod bar`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Modules) != 1 {
+		t.Fatalf("expected 1 module, got %d", len(jf.Modules))
+	}
+	if jf.Modules[0].Name != "bar" {
+		t.Errorf("expected module name 'bar', got %q", jf.Modules[0].Name)
+	}
+}
+
+func TestParseModuleWithPath(t *testing.T) {
+	jf, err := Parse([]byte(`mod foo 'path/to/foo.just'`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Modules[0].Path != "path/to/foo.just" {
+		t.Errorf("expected path 'path/to/foo.just', got %q", jf.Modules[0].Path)
+	}
+}
+
+func TestParseOptionalModule(t *testing.T) {
+	jf, err := Parse([]byte(`mod? optional`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if !jf.Modules[0].Optional {
+		t.Error("expected optional module")
+	}
+}
+
+func TestParseFileWithImports(t *testing.T) {
+	jf, err := ParseFile(filepath.Join("testdata", "with_imports.just"))
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	if len(jf.Imports) != 1 {
+		t.Fatalf("expected 1 import, got %d", len(jf.Imports))
+	}
+	if jf.Imports[0].Justfile == nil {
+		t.Fatal("expected resolved import")
+	}
+	if len(jf.Imports[0].Justfile.Recipes) != 2 {
+		t.Errorf("expected 2 recipes in import, got %d", len(jf.Imports[0].Justfile.Recipes))
+	}
+
+	if len(jf.Modules) != 1 {
+		t.Fatalf("expected 1 module, got %d", len(jf.Modules))
+	}
+	if jf.Modules[0].Justfile == nil {
+		t.Fatal("expected resolved module")
+	}
+	if len(jf.Modules[0].Justfile.Recipes) != 2 {
+		t.Errorf("expected 2 recipes in module, got %d", len(jf.Modules[0].Justfile.Recipes))
+	}
+}
+
+// --- Setting tests ---
+
+func TestParseSetting(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"boolean implicit", "set dotenv-load\n"},
+		{"boolean explicit", "set dotenv-load := true\n"},
+		{"string", "set tempdir := '/tmp'\n"},
+		{"list", "set shell := ['bash', '-cu']\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jf, err := Parse([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			if len(jf.Settings) != 1 {
+				t.Errorf("expected 1 setting, got %d", len(jf.Settings))
+			}
+		})
+	}
+}
+
+// --- Attribute tests ---
+
+func TestParseAttribute(t *testing.T) {
+	input := "[private]\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Attributes) != 1 {
+		t.Fatalf("expected 1 attribute, got %d", len(jf.Recipes[0].Attributes))
+	}
+	if jf.Recipes[0].Attributes[0].Name != "private" {
+		t.Errorf("expected attribute 'private', got %q", jf.Recipes[0].Attributes[0].Name)
+	}
+}
+
+func TestParseAttributeWithValue(t *testing.T) {
+	input := "[group: 'ci']\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	attr := jf.Recipes[0].Attributes[0]
+	if attr.Name != "group" {
+		t.Errorf("expected attribute 'group', got %q", attr.Name)
+	}
+	if len(attr.Arguments) != 1 || attr.Arguments[0].Value != "ci" {
+		t.Errorf("expected argument 'ci', got %v", attr.Arguments)
+	}
+}
+
+func TestParseAttributeWithArgs(t *testing.T) {
+	input := "[confirm('are you sure?')]\ndeploy:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	attr := jf.Recipes[0].Attributes[0]
+	if attr.Name != "confirm" {
+		t.Errorf("expected attribute 'confirm', got %q", attr.Name)
+	}
+	if len(attr.Arguments) != 1 || attr.Arguments[0].Value != "are you sure?" {
+		t.Errorf("expected argument 'are you sure?', got %v", attr.Arguments)
+	}
+}
+
+func TestParseMultipleAttributes(t *testing.T) {
+	input := "[private, group: 'ci']\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Attributes) != 2 {
+		t.Fatalf("expected 2 attributes, got %d", len(jf.Recipes[0].Attributes))
+	}
+}
+
+// --- String type tests ---
+
+func TestParseStringTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"quoted", `val := "hello"`, "hello"},
+		{"raw", `val := 'hello'`, "hello"},
+		{"escaped newline", `val := "hello\nworld"`, "hello\nworld"},
+		{"raw no escape", `val := 'hello\nworld'`, `hello\nworld`},
+		{"backtick", "val := `echo hi`", "echo hi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jf, err := Parse([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			switch v := jf.Assignments[0].Value.(type) {
+			case *StringLiteral:
+				if v.Value != tt.expected {
+					t.Errorf("expected %q, got %q", tt.expected, v.Value)
+				}
+			case *BacktickExpr:
+				if v.Command != tt.expected {
+					t.Errorf("expected %q, got %q", tt.expected, v.Command)
+				}
+			default:
+				t.Fatalf("unexpected type %T", v)
+			}
+		})
+	}
+}
+
+// --- Validation tests ---
+
+func TestValidateDuplicateRecipe(t *testing.T) {
+	input := "build:\n    echo a\nbuild:\n    echo b\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	if len(diags) == 0 {
+		t.Error("expected diagnostics for duplicate recipe")
+	}
+	if !strings.Contains(diags[0].Message, "defined multiple times") {
+		t.Errorf("unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestValidateDuplicateVariable(t *testing.T) {
+	input := "x := \"a\"\nx := \"b\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	if len(diags) == 0 {
+		t.Error("expected diagnostics for duplicate variable")
+	}
+}
+
+func TestValidateUndefinedDependency(t *testing.T) {
+	input := "build: nonexistent\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityError && strings.Contains(d.Message, "undefined recipe") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for undefined dependency")
+	}
+}
+
+func TestValidateUndefinedAliasTarget(t *testing.T) {
+	input := "alias b := nonexistent\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityError && strings.Contains(d.Message, "undefined recipe") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for undefined alias target")
+	}
+}
+
+func TestValidateUnknownSetting(t *testing.T) {
+	input := "set bogus-setting := true\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityWarning && strings.Contains(d.Message, "unknown setting") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for unknown setting")
+	}
+}
+
+func TestValidateDuplicateParams(t *testing.T) {
+	input := "build x x:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "duplicate parameter") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for duplicate parameter")
+	}
+}
+
+func TestValidateParamsAfterVariadic(t *testing.T) {
+	input := "build *args extra:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "after variadic") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for params after variadic")
+	}
+}
+
+func TestValidateNoIssues(t *testing.T) {
+	input := "build:\n    echo build\ntest: build\n    echo test\nalias b := build\nset dotenv-load\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics, got %d: %v", len(diags), diags)
+	}
+}
+
+// --- Error tests ---
+
+func TestParseErrorPosition(t *testing.T) {
+	_, err := Parse([]byte("build\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.Pos.Line == 0 {
+		t.Error("expected non-zero line in parse error")
+	}
+}
+
+func TestParseErrorUnterminatedString(t *testing.T) {
+	_, err := Parse([]byte(`val := "unterminated`))
+	if err == nil {
+		t.Fatal("expected error for unterminated string")
+	}
+	if !strings.Contains(err.Error(), "unterminated") {
+		t.Errorf("expected 'unterminated' in error, got: %v", err)
+	}
+}
+
+func TestDiagnosticFormat(t *testing.T) {
+	d := Diagnostic{
+		Pos:      Position{Line: 10, Column: 5},
+		Severity: SeverityError,
+		Message:  "something broke",
+		File:     "justfile",
+	}
+	s := d.String()
+	if !strings.Contains(s, "justfile:10:5") {
+		t.Errorf("expected position in diagnostic string, got: %s", s)
+	}
+	if !strings.Contains(s, "error") {
+		t.Errorf("expected severity in diagnostic string, got: %s", s)
+	}
+}

--- a/pkg/validator/justfile/justdump.go
+++ b/pkg/validator/justfile/justdump.go
@@ -1,0 +1,548 @@
+//go:build justdump
+
+package gojust
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// toJustDump converts a parsed Justfile AST into the same JSON structure
+// produced by `just --dump --dump-format json` (pinned to v1.49.0).
+// Used internally for compatibility testing.
+func toJustDump(jf *Justfile, namePrefix string) map[string]interface{} {
+	recipes := collectRecipes(jf, namePrefix)
+	assignments := collectAssignments(jf)
+	aliases := collectAliases(jf)
+	unexports := collectUnexports(jf)
+
+	var first interface{} = nil
+	if len(jf.Recipes) > 0 {
+		first = jf.Recipes[0].Name
+	}
+	if first == nil {
+		for _, imp := range jf.Imports {
+			if imp.Justfile != nil && len(imp.Justfile.Recipes) > 0 {
+				first = imp.Justfile.Recipes[0].Name
+				break
+			}
+		}
+	}
+
+	modules := make(map[string]interface{})
+	for _, mod := range jf.Modules {
+		if mod.Justfile != nil {
+			modules[mod.Name] = toJustDump(mod.Justfile, namePrefix+mod.Name+"::")
+		}
+	}
+
+	return map[string]interface{}{
+		"aliases":     aliases,
+		"assignments": assignments,
+		"first":       first,
+		"doc":         nil,
+		"groups":      []interface{}{},
+		"modules":     modules,
+		"recipes":     recipes,
+		"settings":    buildSettings(jf),
+		"source":      jf.File,
+		"unexports":   unexports,
+		"warnings":    []interface{}{},
+	}
+}
+
+func collectRecipes(jf *Justfile, namePrefix string) map[string]interface{} {
+	recipes := make(map[string]interface{})
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			for k, v := range collectRecipes(imp.Justfile, namePrefix) {
+				recipes[k] = v
+			}
+		}
+	}
+	for _, r := range jf.Recipes {
+		recipes[r.Name] = dumpRecipe(r, namePrefix)
+	}
+	return recipes
+}
+
+func collectAssignments(jf *Justfile) map[string]interface{} {
+	assignments := make(map[string]interface{})
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			for k, v := range collectAssignments(imp.Justfile) {
+				assignments[k] = v
+			}
+		}
+	}
+	for _, a := range jf.Assignments {
+		// Function definitions (with parameters) are not included in just's dump
+		if len(a.Parameters) > 0 {
+			continue
+		}
+		assignments[a.Name] = dumpAssignment(a)
+	}
+	return assignments
+}
+
+func collectAliases(jf *Justfile) map[string]interface{} {
+	aliases := make(map[string]interface{})
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			for k, v := range collectAliases(imp.Justfile) {
+				aliases[k] = v
+			}
+		}
+	}
+	for _, a := range jf.Aliases {
+		aliases[a.Name] = dumpAlias(a)
+	}
+	return aliases
+}
+
+func collectUnexports(jf *Justfile) []interface{} {
+	var unexports []interface{}
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			unexports = append(unexports, collectUnexports(imp.Justfile)...)
+		}
+	}
+	for _, u := range jf.Unexports {
+		unexports = append(unexports, u.Name)
+	}
+	if unexports == nil {
+		return []interface{}{}
+	}
+	return unexports
+}
+
+func dumpRecipe(r *Recipe, namePrefix string) map[string]interface{} {
+	params := make([]interface{}, 0, len(r.Parameters))
+	for _, p := range r.Parameters {
+		params = append(params, dumpParameter(p))
+	}
+
+	deps := make([]interface{}, 0, len(r.Dependencies))
+	priors := 0
+	for _, d := range r.Dependencies {
+		dep := map[string]interface{}{
+			"arguments": dumpDepArgs(d.Arguments),
+			"recipe":    d.Name,
+		}
+		deps = append(deps, dep)
+		if !d.Subsequent {
+			priors++
+		}
+	}
+
+	body := make([]interface{}, 0, len(r.Body))
+	for _, line := range r.Body {
+		body = append(body, dumpRecipeLine(line))
+	}
+
+	attrs := dumpAttributes(r.Attributes)
+
+	var doc interface{} = nil
+	if r.Comment != "" {
+		doc = r.Comment
+	}
+	isPrivate := len(r.Name) > 0 && r.Name[0] == '_'
+	isShebang := r.Shebang != ""
+	for _, attr := range r.Attributes {
+		switch attr.Name {
+		case "doc":
+			if len(attr.Arguments) > 0 {
+				doc = attr.Arguments[0].Value
+			}
+		case "private":
+			isPrivate = true
+		case "script":
+			isShebang = true
+		}
+	}
+
+	return map[string]interface{}{
+		"attributes":   attrs,
+		"body":         body,
+		"dependencies": deps,
+		"doc":          doc,
+		"name":         r.Name,
+		"parameters":   params,
+		"priors":       priors,
+		"private":      isPrivate,
+		"quiet":        r.Quiet,
+		"namepath":     namePrefix + r.Name,
+		"shebang":      isShebang,
+	}
+}
+
+func dumpParameter(p *Parameter) map[string]interface{} {
+	kind := "singular"
+	switch p.Variadic {
+	case "*":
+		kind = "star"
+	case "+":
+		kind = "plus"
+	}
+
+	var def interface{} = nil
+	if p.Default != nil {
+		def = dumpExpression(p.Default)
+	}
+
+	return map[string]interface{}{
+		"default": def,
+		"export":  p.Export,
+		"help":    nil,
+		"kind":    kind,
+		"long":    nil,
+		"name":    p.Name,
+		"pattern": nil,
+		"short":   nil,
+		"value":   nil,
+	}
+}
+
+func dumpDepArgs(args []Expression) []interface{} {
+	result := make([]interface{}, 0, len(args))
+	for _, a := range args {
+		result = append(result, dumpExpression(a))
+	}
+	return result
+}
+
+func dumpRecipeLine(line *RecipeLine) []interface{} {
+	var parts []interface{}
+
+	for i, frag := range line.Fragments {
+		switch f := frag.(type) {
+		case *TextFragment:
+			text := reescapeBraces(f.Value)
+			if i == 0 {
+				text = applyLinePrefix(line, text)
+			}
+			parts = append(parts, text)
+		case *InterpolationFragment:
+			parts = append(parts, []interface{}{dumpExpression(f.Expression)})
+		}
+	}
+
+	if len(parts) == 0 {
+		prefix := applyLinePrefix(line, "")
+		if prefix != "" {
+			parts = append(parts, prefix)
+		}
+	}
+
+	return parts
+}
+
+// reescapeBraces converts {{ back to {{{{ in recipe body text,
+// matching just --dump's output which preserves the escape syntax.
+func reescapeBraces(s string) string {
+	return strings.ReplaceAll(s, "{{", "{{{{")
+}
+
+func applyLinePrefix(line *RecipeLine, text string) string {
+	prefix := ""
+	if line.Quiet && line.NoError {
+		prefix = line.PrefixOrder
+		if prefix == "" {
+			prefix = "@-" // fallback
+		}
+	} else if line.Quiet {
+		prefix = "@"
+	} else if line.NoError {
+		prefix = "-"
+	}
+	return prefix + text
+}
+
+func dumpExpression(expr Expression) interface{} {
+	switch e := expr.(type) {
+	case *StringLiteral:
+		return e.Value
+	case *Variable:
+		return []interface{}{"variable", e.Name}
+	case *Concatenation:
+		return []interface{}{"concatenate", dumpExpression(e.Left), dumpExpression(e.Right)}
+	case *PathJoin:
+		left := dumpExpression(e.Left)
+		// Leading / produces a PathJoin with empty string left — just encodes as null
+		if s, ok := left.(string); ok && s == "" {
+			left = nil
+		}
+		return []interface{}{"join", left, dumpExpression(e.Right)}
+	case *FunctionCall:
+		parts := []interface{}{"call", e.Name}
+		for _, arg := range e.Arguments {
+			parts = append(parts, dumpExpression(arg))
+		}
+		return parts
+	case *BacktickExpr:
+		return []interface{}{"evaluate", e.Command}
+	case *Conditional:
+		cond := []interface{}{
+			e.Condition.Operator,
+			dumpExpression(e.Condition.Left),
+			dumpExpression(e.Condition.Right),
+		}
+		return []interface{}{"if", cond, dumpExpression(e.Then), dumpExpression(e.Otherwise)}
+	case *ParenExpr:
+		return dumpExpression(e.Inner)
+	case *LogicalOp:
+		op := e.Operator
+		if op == "&&" {
+			op = "and"
+		} else if op == "||" {
+			op = "or"
+		}
+		return []interface{}{op, dumpExpression(e.Left), dumpExpression(e.Right)}
+	case *Comparison:
+		return []interface{}{e.Operator, dumpExpression(e.Left), dumpExpression(e.Right)}
+	default:
+		panic(fmt.Sprintf("gojust: unhandled expression type %T in dumpExpression", expr))
+	}
+}
+
+func dumpAlias(a *Alias) map[string]interface{} {
+	return map[string]interface{}{
+		"attributes": dumpAttributes(a.Attributes),
+		"name":       a.Name,
+		"target":     a.Target,
+	}
+}
+
+func dumpAssignment(a *Assignment) map[string]interface{} {
+	isPrivate := a.Private || (len(a.Name) > 0 && a.Name[0] == '_')
+	return map[string]interface{}{
+		"eager":   a.Eager,
+		"export":  a.Export,
+		"name":    a.Name,
+		"private": isPrivate,
+		"value":   dumpExpression(a.Value),
+	}
+}
+
+func dumpAttributes(attrs []*Attribute) []interface{} {
+	// just sorts attributes alphabetically by name
+	sorted := make([]*Attribute, len(attrs))
+	copy(sorted, attrs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	result := make([]interface{}, 0, len(sorted))
+	for _, attr := range sorted {
+		result = append(result, dumpAttribute(attr))
+	}
+	return result
+}
+
+// knownParameterizedAttributes lists attributes that just always encodes as
+// objects with a value (null if no argument was provided).
+var knownParameterizedAttributes = map[string]bool{
+	"confirm": true,
+	"group":   true,
+	"doc":     true,
+	"script":  true,
+}
+
+func dumpAttribute(attr *Attribute) interface{} {
+	if len(attr.Arguments) == 0 {
+		if knownParameterizedAttributes[attr.Name] {
+			return map[string]interface{}{attr.Name: nil}
+		}
+		return attr.Name
+	}
+	// [script('bash')] → {"script": {"command": "bash", "arguments": []}}
+	if attr.Name == "script" {
+		if len(attr.Arguments) >= 1 && attr.Arguments[0].Key == "" {
+			args := make([]interface{}, 0)
+			for _, a := range attr.Arguments[1:] {
+				args = append(args, a.Value)
+			}
+			return map[string]interface{}{"script": map[string]interface{}{
+				"command":   attr.Arguments[0].Value,
+				"arguments": args,
+			}}
+		}
+	}
+	if len(attr.Arguments) == 1 && attr.Arguments[0].Key == "" {
+		return map[string]interface{}{attr.Name: attr.Arguments[0].Value}
+	}
+	if len(attr.Arguments) == 1 && attr.Arguments[0].Key != "" {
+		return map[string]interface{}{attr.Name: map[string]interface{}{attr.Arguments[0].Key: attr.Arguments[0].Value}}
+	}
+	args := make([]interface{}, len(attr.Arguments))
+	for i, a := range attr.Arguments {
+		if a.Key != "" {
+			args[i] = map[string]interface{}{a.Key: a.Value}
+		} else {
+			args[i] = a.Value
+		}
+	}
+	return map[string]interface{}{attr.Name: args}
+}
+
+func buildSettings(jf *Justfile) map[string]interface{} {
+	s := make(map[string]interface{}, len(knownSettingsList))
+	for _, sd := range knownSettingsList {
+		key := strings.ReplaceAll(sd.Name, "-", "_")
+		s[key] = sd.Default
+	}
+
+	for _, setting := range collectSettings(jf) {
+		key := strings.ReplaceAll(setting.Name, "-", "_")
+		switch setting.Value.Kind() {
+		case "bool":
+			s[key] = *setting.Value.Bool
+		case "string":
+			s[key] = *setting.Value.String
+		case "list":
+			if key == "shell" || key == "windows_shell" {
+				if len(setting.Value.List) > 0 {
+					args := make([]interface{}, 0, len(setting.Value.List)-1)
+					for _, a := range setting.Value.List[1:] {
+						args = append(args, a)
+					}
+					s[key] = map[string]interface{}{
+						"command":   setting.Value.List[0],
+						"arguments": args,
+					}
+				}
+			} else {
+				list := make([]interface{}, len(setting.Value.List))
+				for i, v := range setting.Value.List {
+					list[i] = v
+				}
+				s[key] = list
+			}
+		}
+	}
+
+	return s
+}
+
+func collectSettings(jf *Justfile) []*Setting {
+	var settings []*Setting
+	for _, imp := range jf.Imports {
+		if imp.Justfile != nil {
+			settings = append(settings, collectSettings(imp.Justfile)...)
+		}
+	}
+	settings = append(settings, jf.Settings...)
+	return settings
+}
+
+func toJustDumpJSON(jf *Justfile) ([]byte, error) {
+	return json.MarshalIndent(toJustDump(jf, ""), "", "  ")
+}
+
+func compareWithJustDump(ours interface{}, theirs interface{}, path string) []string {
+	return deepCompare(ours, theirs, path)
+}
+
+func deepCompare(a, b interface{}, path string) []string {
+	if a == nil && b == nil {
+		return nil
+	}
+
+	if aNum, ok := toFloat64(a); ok {
+		if bNum, ok := toFloat64(b); ok {
+			if aNum == bNum {
+				return nil
+			}
+			return []string{path + ": value mismatch: " + jsonStr(a) + " vs " + jsonStr(b)}
+		}
+	}
+
+	aMap, aIsMap := a.(map[string]interface{})
+	bMap, bIsMap := b.(map[string]interface{})
+	if aIsMap && bIsMap {
+		return compareMaps(aMap, bMap, path)
+	}
+
+	aSlice, aIsSlice := a.([]interface{})
+	bSlice, bIsSlice := b.([]interface{})
+	if aIsSlice && bIsSlice {
+		return compareSlices(aSlice, bSlice, path)
+	}
+
+	aJSON := jsonStr(a)
+	bJSON := jsonStr(b)
+	if aJSON != bJSON {
+		return []string{path + ": " + aJSON + " != " + bJSON}
+	}
+	return nil
+}
+
+func compareMaps(a, b map[string]interface{}, path string) []string {
+	var diffs []string
+	keys := make(map[string]bool)
+	for k := range a {
+		keys[k] = true
+	}
+	for k := range b {
+		keys[k] = true
+	}
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	for _, k := range sorted {
+		aVal, aOk := a[k]
+		bVal, bOk := b[k]
+		p := path + "." + k
+		if !aOk {
+			diffs = append(diffs, p+": missing in ours (just has "+jsonStr(bVal)+")")
+		} else if !bOk {
+			diffs = append(diffs, p+": extra in ours ("+jsonStr(aVal)+")")
+		} else {
+			diffs = append(diffs, deepCompare(aVal, bVal, p)...)
+		}
+	}
+	return diffs
+}
+
+func compareSlices(a, b []interface{}, path string) []string {
+	var diffs []string
+	max := len(a)
+	if len(b) > max {
+		max = len(b)
+	}
+	if len(a) != len(b) {
+		diffs = append(diffs, path+": length mismatch: "+jsonStr(len(a))+" vs "+jsonStr(len(b)))
+	}
+	for i := 0; i < max; i++ {
+		p := path + "[" + jsonStr(i) + "]"
+		if i >= len(a) {
+			diffs = append(diffs, p+": missing in ours")
+		} else if i >= len(b) {
+			diffs = append(diffs, p+": extra in ours")
+		} else {
+			diffs = append(diffs, deepCompare(a[i], b[i], p)...)
+		}
+	}
+	return diffs
+}
+
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+func jsonStr(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/pkg/validator/justfile/justdump_test.go
+++ b/pkg/validator/justfile/justdump_test.go
@@ -1,0 +1,241 @@
+//go:build justdump
+
+package gojust
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// justPinnedVersion is the version of just that the dump tests are validated
+// against. Updating this is an intentional act — see the README.
+const justPinnedVersion = "1.49.0"
+
+// findJust locates the just binary. It checks JUST_PATH env var first,
+// then falls back to PATH lookup.
+func findJust() string {
+	if p := os.Getenv("JUST_PATH"); p != "" {
+		return p
+	}
+	if p, err := exec.LookPath("just"); err == nil {
+		return p
+	}
+	return ""
+}
+
+// justInfo holds the resolved just binary path and version for the test run.
+type justInfo struct {
+	path    string
+	version string // e.g. "1.49.0"
+	pinned  bool   // true if version matches justPinnedVersion
+}
+
+func getJustInfo(t *testing.T) justInfo {
+	t.Helper()
+	path := findJust()
+	if path == "" {
+		t.Skip("just not found (set JUST_PATH or add to PATH)")
+	}
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		t.Skipf("just --version failed: %v", err)
+	}
+	// "just 1.49.0" -> "1.49.0"
+	version := strings.TrimPrefix(strings.TrimSpace(string(out)), "just ")
+	return justInfo{
+		path:    path,
+		version: version,
+		pinned:  version == justPinnedVersion,
+	}
+}
+
+func TestJustVersionPinned(t *testing.T) {
+	info := getJustInfo(t)
+	if info.pinned {
+		t.Logf("just %s (pinned ✓)", info.version)
+		return
+	}
+	// In strict mode (CI), fail hard on version mismatch.
+	if os.Getenv("JUST_TEST_STRICT") == "1" {
+		t.Fatalf("just version mismatch: got %s, pinned to %s — update justPinnedVersion or install the pinned version", info.version, justPinnedVersion)
+	}
+	t.Logf("just %s (pinned to %s — diffs may be version differences, not bugs)", info.version, justPinnedVersion)
+}
+
+func TestDumpCompat(t *testing.T) {
+	info := getJustInfo(t)
+	strict := info.pinned || os.Getenv("JUST_TEST_STRICT") == "1"
+
+	entries, err := os.ReadDir("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !info.pinned {
+		t.Logf("running against just %s (pinned to %s) — failures may be version differences", info.version, justPinnedVersion)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".just") {
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			path := filepath.Join("testdata", e.Name())
+			absPath, _ := filepath.Abs(path)
+
+			justOut, err := exec.Command(info.path, "--dump", "--dump-format", "json", "--justfile", absPath).CombinedOutput()
+			if err != nil {
+				t.Skipf("just cannot dump %s: %s", e.Name(), string(justOut))
+			}
+
+			var expected interface{}
+			if err := json.Unmarshal(justOut, &expected); err != nil {
+				t.Fatalf("failed to parse just output: %v", err)
+			}
+
+			jf, err := ParseFile(absPath)
+			if err != nil {
+				t.Fatalf("ParseFile failed: %v", err)
+			}
+
+			diffs := compareDump(t, jf, expected)
+			reportDiffs(t, diffs, strict)
+		})
+	}
+}
+
+func TestDumpCompatWithImports(t *testing.T) {
+	info := getJustInfo(t)
+	strict := info.pinned || os.Getenv("JUST_TEST_STRICT") == "1"
+
+	path, _ := filepath.Abs(filepath.Join("testdata", "with_imports.just"))
+
+	justOut, err := exec.Command(info.path, "--dump", "--dump-format", "json", "--justfile", path).CombinedOutput()
+	if err != nil {
+		t.Skipf("just cannot dump: %s", string(justOut))
+	}
+
+	var expected interface{}
+	if err := json.Unmarshal(justOut, &expected); err != nil {
+		t.Fatalf("failed to parse just output: %v", err)
+	}
+
+	jf, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	diffs := compareDump(t, jf, expected)
+	reportDiffs(t, diffs, strict)
+}
+
+// TestDumpExpressionEncoding verifies specific expression encodings match just's format.
+func TestDumpExpressionEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		expr Expression
+		want string
+	}{
+		{"string", &StringLiteral{Value: "hello"}, `"hello"`},
+		{"variable", &Variable{Name: "foo"}, `["variable","foo"]`},
+		{"concatenation", &Concatenation{
+			Left:  &StringLiteral{Value: "a"},
+			Right: &Variable{Name: "b"},
+		}, `["concatenate","a",["variable","b"]]`},
+		{"path_join", &PathJoin{
+			Left:  &Variable{Name: "dir"},
+			Right: &StringLiteral{Value: "file"},
+		}, `["join",["variable","dir"],"file"]`},
+		{"function_call", &FunctionCall{
+			Name:      "env_var",
+			Arguments: []Expression{&StringLiteral{Value: "HOME"}},
+		}, `["call","env_var","HOME"]`},
+		{"function_no_args", &FunctionCall{
+			Name: "arch",
+		}, `["call","arch"]`},
+		{"backtick", &BacktickExpr{Command: "echo hi"}, `["evaluate","echo hi"]`},
+		{"conditional", &Conditional{
+			Condition: Comparison{
+				Left:     &StringLiteral{Value: "a"},
+				Right:    &StringLiteral{Value: "b"},
+				Operator: "==",
+			},
+			Then:      &StringLiteral{Value: "yes"},
+			Otherwise: &StringLiteral{Value: "no"},
+		}, `["if",["==","a","b"],"yes","no"]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := json.Marshal(dumpExpression(tt.expr))
+			if string(got) != tt.want {
+				t.Errorf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// compareDump converts our AST to the dump format and compares against just's output.
+func compareDump(t *testing.T, jf *Justfile, expected interface{}) []string {
+	t.Helper()
+	ours := toJustDump(jf, "")
+
+	oursJSON, _ := json.Marshal(ours)
+	var oursNorm interface{}
+	json.Unmarshal(oursJSON, &oursNorm)
+
+	skipFields := map[string]bool{"source": true}
+	cleanMap(oursNorm, skipFields)
+	cleanMap(expected, skipFields)
+
+	return compareWithJustDump(oursNorm, expected, "$")
+}
+
+// reportDiffs logs or fails depending on strict mode.
+// Strict mode (pinned version or JUST_TEST_STRICT=1): diffs are test failures.
+// Non-strict (different just version): diffs are warnings via t.Log.
+func reportDiffs(t *testing.T, diffs []string, strict bool) {
+	t.Helper()
+	if len(diffs) == 0 {
+		return
+	}
+
+	report := t.Errorf
+	if !strict {
+		report = func(format string, args ...interface{}) {
+			t.Logf("[WARN] "+format, args...)
+		}
+	}
+
+	report("found %d differences:", len(diffs))
+	max := 50
+	if len(diffs) < max {
+		max = len(diffs)
+	}
+	for _, d := range diffs[:max] {
+		report("  %s", d)
+	}
+	if len(diffs) > 50 {
+		report("  ... and %d more", len(diffs)-50)
+	}
+}
+
+func cleanMap(v interface{}, skip map[string]bool) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k := range skip {
+			delete(val, k)
+		}
+		for _, child := range val {
+			cleanMap(child, skip)
+		}
+	case []interface{}:
+		for _, child := range val {
+			cleanMap(child, skip)
+		}
+	}
+}

--- a/pkg/validator/justfile/lexer.go
+++ b/pkg/validator/justfile/lexer.go
@@ -1,0 +1,965 @@
+package gojust
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type lexer struct {
+	src    []byte
+	pos    int
+	line   int
+	col    int
+	tokens []token
+
+	// Indentation tracking for recipe bodies
+	inRecipeBody        bool
+	indentStack         []int
+	atLineStart         bool
+	recipeIndent        int
+	lastLineHadColon    bool // tracks whether previous line contained a colon (recipe header)
+	currentLineHasColon bool // tracks colon on the line being lexed
+}
+
+func newLexer(src []byte) *lexer {
+	return &lexer{
+		src:         src,
+		line:        1,
+		col:         1,
+		indentStack: []int{0},
+		atLineStart: true,
+	}
+}
+
+func (l *lexer) lex() ([]token, error) {
+	// Handle shebang line
+	if l.pos+1 < len(l.src) && l.src[0] == '#' && l.src[1] == '!' {
+		for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+			l.advance()
+		}
+		if l.pos < len(l.src) {
+			l.advance() // skip newline
+		}
+	}
+
+	for l.pos < len(l.src) {
+		if l.inRecipeBody {
+			if err := l.lexRecipeBody(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if l.atLineStart {
+			// Check if this line is indented (recipe body start)
+			if l.pos < len(l.src) && (l.src[l.pos] == ' ' || l.src[l.pos] == '\t') {
+				if l.lastLineHadColon {
+					indent := l.measureIndent()
+					l.indentStack = append(l.indentStack, 0) // base indent is 0 (non-recipe)
+					l.recipeIndent = indent
+					l.emit(tokenIndent, "")
+					l.inRecipeBody = true
+					// Don't skip spaces — lexRecipeBody will handle this line
+					continue
+				}
+			}
+			l.skipSpaces()
+			if l.pos < len(l.src) && l.peek() == '\n' {
+				l.emit(tokenNewline, "\n")
+				l.advance()
+				continue
+			}
+			if l.pos < len(l.src) && l.peek() == '#' {
+				l.lexComment()
+				continue
+			}
+		}
+		l.atLineStart = false
+
+		if l.pos >= len(l.src) {
+			break
+		}
+
+		ch := l.peek()
+
+		switch {
+		case ch == '\n':
+			l.emit(tokenNewline, "\n")
+			l.advance()
+			l.atLineStart = true
+			l.lastLineHadColon = l.currentLineHasColon
+			l.currentLineHasColon = false
+
+		case ch == '\\' && l.pos+1 < len(l.src) && (l.src[l.pos+1] == '\n' || (l.src[l.pos+1] == '\r' && l.pos+2 < len(l.src) && l.src[l.pos+2] == '\n')):
+			l.lexLineContinuation()
+
+		case ch == '#':
+			l.lexComment()
+
+		case ch == ' ' || ch == '\t' || ch == '\r':
+			l.advance()
+
+		case ch == ':' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '=':
+			// := is assignment, not a recipe header colon — do NOT set currentLineHasColon
+			l.emit(tokenAssign, ":=")
+			l.advance()
+			l.advance()
+
+		case ch == ':':
+			// Bare : indicates a recipe header
+			l.emit(tokenColon, ":")
+			l.advance()
+			l.currentLineHasColon = true
+
+		case ch == '=' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '=':
+			l.emit(tokenEquals, "==")
+			l.advance()
+			l.advance()
+
+		case ch == '=' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '~':
+			l.emit(tokenRegexMatch, "=~")
+			l.advance()
+			l.advance()
+
+		case ch == '=':
+			l.emit(tokenParamAssign, "=")
+			l.advance()
+
+		case ch == '!' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '=':
+			l.emit(tokenNotEquals, "!=")
+			l.advance()
+			l.advance()
+
+		case ch == '!' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '~':
+			l.emit(tokenRegexMismatch, "!~")
+			l.advance()
+			l.advance()
+
+		case ch == '!':
+			l.emit(tokenBang, "!")
+			l.advance()
+
+		case ch == '&' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '&':
+			l.emit(tokenAnd, "&&")
+			l.advance()
+			l.advance()
+
+		case ch == '|' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '|':
+			l.emit(tokenOr, "||")
+			l.advance()
+			l.advance()
+
+		case ch == '{' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '{':
+			l.emit(tokenInterpolStart, "{{")
+			l.advance()
+			l.advance()
+
+		case ch == '}' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '}':
+			l.emit(tokenInterpolEnd, "}}")
+			l.advance()
+			l.advance()
+
+		case ch == '{':
+			l.emit(tokenLBrace, "{")
+			l.advance()
+
+		case ch == '}':
+			l.emit(tokenRBrace, "}")
+			l.advance()
+
+		case ch == '(':
+			l.emit(tokenLParen, "(")
+			l.advance()
+
+		case ch == ')':
+			l.emit(tokenRParen, ")")
+			l.advance()
+
+		case ch == '[':
+			l.emit(tokenLBracket, "[")
+			l.advance()
+
+		case ch == ']':
+			l.emit(tokenRBracket, "]")
+			l.advance()
+
+		case ch == '+':
+			l.emit(tokenPlus, "+")
+			l.advance()
+
+		case ch == '/':
+			l.emit(tokenSlash, "/")
+			l.advance()
+
+		case ch == '@' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '-':
+			l.emit(tokenAtDash, "@-")
+			l.advance()
+			l.advance()
+
+		case ch == '@':
+			l.emit(tokenAt, "@")
+			l.advance()
+
+		case ch == '-' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '@':
+			l.emit(tokenDashAt, "-@")
+			l.advance()
+			l.advance()
+
+		case ch == '-':
+			l.emit(tokenDash, "-")
+			l.advance()
+
+		case ch == '*':
+			l.emit(tokenStar, "*")
+			l.advance()
+
+		case ch == ',':
+			l.emit(tokenComma, ",")
+			l.advance()
+
+		case ch == '$':
+			l.emit(tokenDollar, "$")
+			l.advance()
+
+		case ch == '?':
+			l.emit(tokenQuestion, "?")
+			l.advance()
+
+		case ch == '"':
+			if err := l.lexQuotedString(); err != nil {
+				return nil, err
+			}
+
+		case ch == '\'':
+			if err := l.lexRawString(); err != nil {
+				return nil, err
+			}
+
+		case ch == '`':
+			if err := l.lexBacktick(); err != nil {
+				return nil, err
+			}
+
+		case isIdentStart(ch):
+			// Check for string prefix before lexing as identifier.
+			if handled, err := l.lexStringPrefix(); handled {
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				l.lexIdentifier()
+			}
+
+		default:
+			return nil, l.errorf("unexpected character %q", ch)
+		}
+	}
+
+	// Close any remaining indentation
+	for len(l.indentStack) > 1 {
+		l.emit(tokenDedent, "")
+		l.indentStack = l.indentStack[:len(l.indentStack)-1]
+	}
+
+	l.emit(tokenEOF, "")
+	return l.tokens, nil
+}
+
+func (l *lexer) peek() byte {
+	return l.src[l.pos]
+}
+
+func (l *lexer) advance() {
+	if l.pos < len(l.src) {
+		if l.src[l.pos] == '\n' {
+			l.line++
+			l.col = 1
+		} else {
+			l.col++
+		}
+		l.pos++
+	}
+}
+
+func (l *lexer) emit(typ tokenType, value string) {
+	// Position is the start of the token, so capture before advancing.
+	// For multi-char tokens, the caller should emit before advancing.
+	l.tokens = append(l.tokens, token{
+		Type:  typ,
+		Value: value,
+		Pos:   Position{Line: l.line, Column: l.col, Offset: l.pos},
+	})
+}
+
+func (l *lexer) errorf(format string, args ...any) *ParseError {
+	return &ParseError{
+		Pos:     Position{Line: l.line, Column: l.col, Offset: l.pos},
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func (l *lexer) skipSpaces() {
+	for l.pos < len(l.src) && (l.src[l.pos] == ' ' || l.src[l.pos] == '\t') {
+		l.advance()
+	}
+}
+
+func (l *lexer) measureIndent() int {
+	indent := 0
+	pos := l.pos
+	for pos < len(l.src) && (l.src[pos] == ' ' || l.src[pos] == '\t') {
+		if l.src[pos] == '\t' {
+			indent += 4
+		} else {
+			indent++
+		}
+		pos++
+	}
+	return indent
+}
+
+func (l *lexer) lexComment() {
+	start := l.pos
+	for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+		l.advance()
+	}
+	l.emit(tokenComment, string(l.src[start:l.pos]))
+}
+
+func (l *lexer) lexLineContinuation() {
+	l.advance() // skip backslash
+	if l.pos < len(l.src) && l.src[l.pos] == '\r' {
+		l.advance()
+	}
+	l.advance() // skip newline
+	l.skipSpaces()
+}
+
+func (l *lexer) lexIdentifier() {
+	start := l.pos
+	for l.pos < len(l.src) && isIdentContinue(l.src[l.pos]) {
+		l.advance()
+	}
+	word := string(l.src[start:l.pos])
+
+	typ := tokenIdentifier
+	switch word {
+	case "alias":
+		typ = tokenAlias
+	case "export":
+		typ = tokenExport
+	case "unexport":
+		typ = tokenUnexport
+	case "import":
+		typ = tokenImport
+	case "mod":
+		typ = tokenMod
+	case "set":
+		typ = tokenSet
+	case "if":
+		typ = tokenIf
+	case "else":
+		typ = tokenElse
+	case "true":
+		typ = tokenTrue
+	case "false":
+		typ = tokenFalse
+	case "eager":
+		typ = tokenEager
+	default:
+		// not a keyword, stays as tokenIdentifier
+	}
+
+	l.tokens = append(l.tokens, token{
+		Type:  typ,
+		Value: word,
+		Pos:   Position{Line: l.line, Column: l.col - len(word), Offset: start},
+	})
+}
+
+func (l *lexer) lexQuotedString() error {
+	return l.lexQuotedStringAs(tokenString)
+}
+
+func (l *lexer) lexQuotedStringAs(typ tokenType) error {
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	// Check for indented string """
+	if l.pos+2 < len(l.src) && l.src[l.pos+1] == '"' && l.src[l.pos+2] == '"' {
+		return l.lexIndentedQuotedString(typ)
+	}
+
+	l.advance() // skip opening "
+	var buf strings.Builder
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+		if ch == '\\' {
+			esc, err := l.lexEscapeSequence()
+			if err != nil {
+				return err
+			}
+			buf.WriteString(esc)
+			continue
+		}
+		if ch == '"' {
+			l.advance() // skip closing "
+			l.tokens = append(l.tokens, token{Type: typ, Value: buf.String(), Pos: startPos})
+			return nil
+		}
+		_ = buf.WriteByte(ch)
+		l.advance()
+	}
+	return &ParseError{Pos: startPos, Message: "unterminated string"}
+}
+
+func (l *lexer) lexIndentedQuotedString(typ tokenType) error {
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	if typ == tokenString {
+		typ = tokenIndentedString
+	}
+
+	l.advance() // "
+	l.advance() // "
+	l.advance() // "
+
+	var buf strings.Builder
+	for l.pos < len(l.src) {
+		if l.src[l.pos] == '\\' {
+			esc, err := l.lexEscapeSequence()
+			if err != nil {
+				return err
+			}
+			buf.WriteString(esc)
+			continue
+		}
+		if l.src[l.pos] == '"' && l.pos+2 < len(l.src) && l.src[l.pos+1] == '"' && l.src[l.pos+2] == '"' {
+			l.advance() // "
+			l.advance() // "
+			l.advance() // "
+			l.tokens = append(l.tokens, token{Type: typ, Value: dedentString(buf.String()), Pos: startPos})
+			return nil
+		}
+		_ = buf.WriteByte(l.src[l.pos])
+		l.advance()
+	}
+	return &ParseError{Pos: startPos, Message: "unterminated indented string"}
+}
+
+func (l *lexer) lexRawString() error {
+	return l.lexRawStringAs(tokenRawString)
+}
+
+func (l *lexer) lexRawStringAs(typ tokenType) error {
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	// Check for indented raw string '''
+	if l.pos+2 < len(l.src) && l.src[l.pos+1] == '\'' && l.src[l.pos+2] == '\'' {
+		return l.lexIndentedRawString(typ)
+	}
+
+	l.advance() // skip opening '
+	var buf strings.Builder
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+		if ch == '\'' {
+			l.advance() // skip closing '
+			l.tokens = append(l.tokens, token{Type: typ, Value: buf.String(), Pos: startPos})
+			return nil
+		}
+		_ = buf.WriteByte(ch)
+		l.advance()
+	}
+	return &ParseError{Pos: startPos, Message: "unterminated raw string"}
+}
+
+func (l *lexer) lexIndentedRawString(typ tokenType) error {
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	if typ == tokenRawString {
+		typ = tokenIndentedRawString
+	}
+
+	l.advance() // '
+	l.advance() // '
+	l.advance() // '
+
+	var buf strings.Builder
+	for l.pos < len(l.src) {
+		if l.src[l.pos] == '\'' && l.pos+2 < len(l.src) && l.src[l.pos+1] == '\'' && l.src[l.pos+2] == '\'' {
+			l.advance() // '
+			l.advance() // '
+			l.advance() // '
+			l.tokens = append(l.tokens, token{Type: typ, Value: dedentString(buf.String()), Pos: startPos})
+			return nil
+		}
+		_ = buf.WriteByte(l.src[l.pos])
+		l.advance()
+	}
+	return &ParseError{Pos: startPos, Message: "unterminated indented raw string"}
+}
+
+func (l *lexer) lexBacktick() error {
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	// Check for indented backtick ```
+	if l.pos+2 < len(l.src) && l.src[l.pos+1] == '`' && l.src[l.pos+2] == '`' {
+		return l.lexIndentedBacktick()
+	}
+
+	l.advance() // skip opening `
+	var buf strings.Builder
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+		if ch == '`' {
+			l.advance()
+			l.tokens = append(l.tokens, token{Type: tokenBacktick, Value: buf.String(), Pos: startPos})
+			return nil
+		}
+		_ = buf.WriteByte(ch)
+		l.advance()
+	}
+	return &ParseError{Pos: startPos, Message: "unterminated backtick"}
+}
+
+func (l *lexer) lexIndentedBacktick() error {
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	l.advance() // `
+	l.advance() // `
+	l.advance() // `
+
+	var buf strings.Builder
+	for l.pos < len(l.src) {
+		if l.src[l.pos] == '`' && l.pos+2 < len(l.src) && l.src[l.pos+1] == '`' && l.src[l.pos+2] == '`' {
+			l.advance() // `
+			l.advance() // `
+			l.advance() // `
+			l.tokens = append(l.tokens, token{Type: tokenIndentedBacktick, Value: dedentString(buf.String()), Pos: startPos})
+			return nil
+		}
+		_ = buf.WriteByte(l.src[l.pos])
+		l.advance()
+	}
+	return &ParseError{Pos: startPos, Message: "unterminated indented backtick"}
+}
+
+func (l *lexer) lexEscapeSequence() (string, error) {
+	l.advance() // skip backslash
+	if l.pos >= len(l.src) {
+		return "", l.errorf("unterminated escape sequence")
+	}
+	ch := l.src[l.pos]
+	l.advance()
+	switch ch {
+	case 'n':
+		return "\n", nil
+	case 'r':
+		return "\r", nil
+	case 't':
+		return "\t", nil
+	case '"':
+		return "\"", nil
+	case '\\':
+		return "\\", nil
+	case '\n':
+		return "", nil // line continuation
+	case '\r':
+		if l.pos < len(l.src) && l.src[l.pos] == '\n' {
+			l.advance()
+		}
+		return "", nil
+	case 'u':
+		return l.lexUnicodeEscape()
+	default:
+		return "", l.errorf("unknown escape sequence '\\%c'", ch)
+	}
+}
+
+func (l *lexer) lexUnicodeEscape() (string, error) {
+	if l.pos >= len(l.src) || l.src[l.pos] != '{' {
+		return "", l.errorf("expected '{' after '\\u'")
+	}
+	l.advance() // skip {
+
+	start := l.pos
+	for l.pos < len(l.src) && l.src[l.pos] != '}' {
+		ch := l.src[l.pos]
+		if !isHexDigit(ch) {
+			return "", l.errorf("invalid character %q in unicode escape", ch)
+		}
+		l.advance()
+	}
+	if l.pos >= len(l.src) {
+		return "", l.errorf("unterminated unicode escape")
+	}
+
+	hex := string(l.src[start:l.pos])
+	l.advance() // skip }
+
+	var codepoint int
+	for _, ch := range hex {
+		codepoint = codepoint*16 + hexValRune(ch)
+	}
+	if !utf8.ValidRune(rune(codepoint)) {
+		return "", l.errorf("invalid unicode codepoint U+%s", strings.ToUpper(hex))
+	}
+	return string(rune(codepoint)), nil
+}
+
+// lexRecipeBody lexes lines inside a recipe body, handling indentation
+// and interpolation.
+func (l *lexer) lexRecipeBody() error {
+	// Measure indent without consuming
+	indent := l.measureIndent()
+
+	// Empty line — consume whitespace and newline, stay in recipe body
+	savePos, saveLine, saveCol := l.pos, l.line, l.col
+	l.skipSpaces()
+	if l.pos >= len(l.src) || l.src[l.pos] == '\n' {
+		if l.pos < len(l.src) {
+			l.emit(tokenNewline, "\n")
+			l.advance()
+		}
+		return nil
+	}
+
+	// Dedent — line is not indented enough, exit recipe body
+	if indent < l.recipeIndent {
+		// Restore position to start of line so main loop can re-lex
+		l.pos, l.line, l.col = savePos, saveLine, saveCol
+		l.inRecipeBody = false
+		l.emit(tokenDedent, "")
+		l.indentStack = l.indentStack[:len(l.indentStack)-1]
+		l.atLineStart = true
+		return nil
+	}
+
+	// Restore to start of line, then skip exactly the recipe's base indentation.
+	// Any indentation beyond that is preserved as part of the line text.
+	l.pos, l.line, l.col = savePos, saveLine, saveCol
+	l.skipIndent(l.recipeIndent)
+
+	// Check for recipe line prefix
+	if l.pos < len(l.src) {
+		ch := l.src[l.pos]
+		if ch == '@' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '-' {
+			l.emit(tokenAtDash, "@-")
+			l.advance()
+			l.advance()
+		} else if ch == '-' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '@' {
+			l.emit(tokenDashAt, "-@")
+			l.advance()
+			l.advance()
+		} else if ch == '@' {
+			l.emit(tokenAt, "@")
+			l.advance()
+		} else if ch == '-' {
+			l.emit(tokenDash, "-")
+			l.advance()
+		}
+	}
+
+	// Lex the rest of the line as text with interpolations
+	return l.lexRecipeLine()
+}
+
+// skipIndent skips exactly n units of indentation (spaces=1, tabs=4).
+func (l *lexer) skipIndent(n int) {
+	skipped := 0
+	for l.pos < len(l.src) && skipped < n {
+		switch ch := l.src[l.pos]; ch {
+		case '\t':
+			skipped += 4
+		case ' ':
+			skipped++
+		default:
+			return
+		}
+		l.advance()
+	}
+}
+
+func (l *lexer) lexRecipeLine() error {
+	var buf strings.Builder
+	startPos := Position{Line: l.line, Column: l.col, Offset: l.pos}
+
+	flushText := func() {
+		if buf.Len() > 0 {
+			l.tokens = append(l.tokens, token{Type: tokenText, Value: buf.String(), Pos: startPos})
+			buf.Reset()
+			startPos = Position{Line: l.line, Column: l.col, Offset: l.pos}
+		}
+	}
+
+	for l.pos < len(l.src) {
+		ch := l.src[l.pos]
+
+		// Line continuation: backslash followed by newline joins with next line
+		if ch == '\\' && l.pos+1 < len(l.src) {
+			next := l.src[l.pos+1]
+			if next == '\n' || (next == '\r' && l.pos+2 < len(l.src) && l.src[l.pos+2] == '\n') {
+				_ = buf.WriteByte('\\')
+				l.advance() // skip backslash
+				if l.src[l.pos] == '\r' {
+					l.advance()
+				}
+				l.advance() // skip newline
+				// Flush current text, emit newline, then start new line
+				flushText()
+				l.emit(tokenNewline, "\n")
+				// The continuation line is a new recipe line; return so
+				// lexRecipeBody handles its indentation properly
+				return nil
+			}
+		}
+
+		if ch == '\n' {
+			break
+		}
+
+		if ch == '{' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '{' {
+			// {{{{ is an escape for literal {{ in text
+			if l.pos+3 < len(l.src) && l.src[l.pos+2] == '{' && l.src[l.pos+3] == '{' {
+				buf.WriteString("{{")
+				l.advance()
+				l.advance()
+				l.advance()
+				l.advance()
+				continue
+			}
+			flushText()
+			l.emit(tokenInterpolStart, "{{")
+			l.advance()
+			l.advance()
+
+			// Lex the expression inside the interpolation
+			depth := 1
+			for l.pos < len(l.src) && depth > 0 {
+				if l.src[l.pos] == '{' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '{' {
+					depth++
+					l.emit(tokenInterpolStart, "{{")
+					l.advance()
+					l.advance()
+					continue
+				}
+				if l.src[l.pos] == '}' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '}' {
+					depth--
+					if depth == 0 {
+						l.emit(tokenInterpolEnd, "}}")
+						l.advance()
+						l.advance()
+						break
+					}
+					l.emit(tokenInterpolEnd, "}}")
+					l.advance()
+					l.advance()
+					continue
+				}
+
+				if err := l.lexExpressionToken(); err != nil {
+					return err
+				}
+			}
+			startPos = Position{Line: l.line, Column: l.col, Offset: l.pos}
+			continue
+		}
+		_ = buf.WriteByte(l.src[l.pos])
+		l.advance()
+	}
+
+	flushText()
+
+	if l.pos < len(l.src) {
+		l.emit(tokenNewline, "\n")
+		l.advance()
+	}
+	return nil
+}
+
+// stringPrefixes maps single-character prefixes to their token types for
+// quoted and raw string variants. To add a new string prefix (e.g. g"..."),
+// add an entry here — no other lexer changes needed.
+var stringPrefixes = map[byte]struct {
+	quoted tokenType
+	raw    tokenType
+}{
+	'f': {tokenFormatString, tokenFormatString},
+	'x': {tokenShellExpandedString, tokenShellExpandedRawString},
+}
+
+// lexStringPrefix checks if the current character is a string prefix (f, x, etc.)
+// followed by a quote. Returns (true, err) if it handled the token, (false, nil)
+// if the character is not a string prefix and should be lexed as an identifier.
+func (l *lexer) lexStringPrefix() (bool, error) {
+	ch := l.src[l.pos]
+	prefix, ok := stringPrefixes[ch]
+	if !ok || l.pos+1 >= len(l.src) {
+		return false, nil
+	}
+	next := l.src[l.pos+1]
+	switch next {
+	case '"':
+		l.advance() // skip prefix char
+		return true, l.lexQuotedStringAs(prefix.quoted)
+	case '\'':
+		l.advance() // skip prefix char
+		return true, l.lexRawStringAs(prefix.raw)
+	}
+	return false, nil
+}
+
+// lexExpressionToken lexes a single token that can appear inside an expression.
+// Used by both the main lexer and the interpolation lexer inside recipe bodies.
+func (l *lexer) lexExpressionToken() error {
+	ch := l.src[l.pos]
+	switch {
+	case ch == ' ' || ch == '\t':
+		l.advance()
+	case ch == '"':
+		return l.lexQuotedString()
+	case ch == '\'':
+		return l.lexRawString()
+	case ch == '`':
+		return l.lexBacktick()
+	case ch == '+':
+		l.emit(tokenPlus, "+")
+		l.advance()
+	case ch == '/':
+		l.emit(tokenSlash, "/")
+		l.advance()
+	case ch == '(':
+		l.emit(tokenLParen, "(")
+		l.advance()
+	case ch == ')':
+		l.emit(tokenRParen, ")")
+		l.advance()
+	case ch == ',':
+		l.emit(tokenComma, ",")
+		l.advance()
+	case ch == '=' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '=':
+		l.emit(tokenEquals, "==")
+		l.advance()
+		l.advance()
+	case ch == '=' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '~':
+		l.emit(tokenRegexMatch, "=~")
+		l.advance()
+		l.advance()
+	case ch == '!' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '=':
+		l.emit(tokenNotEquals, "!=")
+		l.advance()
+		l.advance()
+	case ch == '!' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '~':
+		l.emit(tokenRegexMismatch, "!~")
+		l.advance()
+		l.advance()
+	case ch == '&' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '&':
+		l.emit(tokenAnd, "&&")
+		l.advance()
+		l.advance()
+	case ch == '|' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '|':
+		l.emit(tokenOr, "||")
+		l.advance()
+		l.advance()
+	case ch == '{':
+		l.emit(tokenLBrace, "{")
+		l.advance()
+	case ch == '}':
+		l.emit(tokenRBrace, "}")
+		l.advance()
+	case isIdentStart(ch):
+		l.lexIdentifier()
+	default:
+		return l.errorf("unexpected character %q in interpolation", ch)
+	}
+	return nil
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isIdentContinue(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9') || ch == '-'
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+}
+
+func hexVal(ch byte) int {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0')
+	case ch >= 'a' && ch <= 'f':
+		return int(ch-'a') + 10
+	case ch >= 'A' && ch <= 'F':
+		return int(ch-'A') + 10
+	}
+	return 0
+}
+
+func hexValRune(ch rune) int {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0')
+	case ch >= 'a' && ch <= 'f':
+		return int(ch-'a') + 10
+	case ch >= 'A' && ch <= 'F':
+		return int(ch-'A') + 10
+	}
+	return 0
+}
+
+// dedentString implements just's indented string dedent algorithm:
+// 1. Strip the leading newline (if present)
+// 2. Find the common leading whitespace prefix (by character count) of all non-empty lines
+// 3. Strip that prefix from every line; whitespace-only lines become empty
+func dedentString(s string) string {
+	if len(s) > 0 && s[0] == '\n' {
+		s = s[1:]
+	} else if len(s) > 1 && s[0] == '\r' && s[1] == '\n' {
+		s = s[2:]
+	}
+
+	lines := strings.Split(s, "\n")
+
+	// Find minimum indentation (character count) of non-empty lines.
+	// Tabs count as one character, matching just's dedent behavior.
+	minIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := 0
+		for _, ch := range line {
+			if ch != ' ' && ch != '\t' {
+				break
+			}
+			indent++
+		}
+		if minIndent < 0 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+	if minIndent < 0 {
+		minIndent = 0
+	}
+
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			_ = b.WriteByte('\n')
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if len(line) >= minIndent {
+			b.WriteString(line[minIndent:])
+		} else {
+			b.WriteString(line)
+		}
+	}
+	return b.String()
+}

--- a/pkg/validator/justfile/lexer_test.go
+++ b/pkg/validator/justfile/lexer_test.go
@@ -1,0 +1,581 @@
+package gojust
+
+import (
+	"testing"
+)
+
+func TestLexIndentedString(t *testing.T) {
+	input := "val := \"\"\"\n  hello\n  world\n\"\"\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Kind != StringKindIndentedQuoted {
+		t.Errorf("expected indented string, got %s", sl.Kind)
+	}
+}
+
+func TestLexIndentedRawString(t *testing.T) {
+	input := "val := '''\n  hello\\n\n  world\n'''\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Kind != StringKindIndentedRaw {
+		t.Errorf("expected indented raw string, got %s", sl.Kind)
+	}
+}
+
+func TestLexIndentedBacktick(t *testing.T) {
+	input := "val := ```\n  echo hello\n  echo world\n```\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	bt, ok := jf.Assignments[0].Value.(*BacktickExpr)
+	if !ok {
+		t.Fatalf("expected BacktickExpr, got %T", jf.Assignments[0].Value)
+	}
+	if !bt.Indented {
+		t.Error("expected indented backtick")
+	}
+}
+
+func TestLexUnicodeEscape(t *testing.T) {
+	input := `val := "\u{1F600}"`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Value != "\U0001F600" {
+		t.Errorf("expected grinning face emoji, got %q", sl.Value)
+	}
+}
+
+func TestLexEscapeSequences(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"newline", `val := "a\nb"`, "a\nb"},
+		{"tab", `val := "a\tb"`, "a\tb"},
+		{"carriage return", `val := "a\rb"`, "a\rb"},
+		{"escaped quote", `val := "a\"b"`, "a\"b"},
+		{"escaped backslash", `val := "a\\b"`, "a\\b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			jf, err := Parse([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+			if !ok {
+				t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+			}
+			if sl.Value != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, sl.Value)
+			}
+		})
+	}
+}
+
+func TestLexLineContinuation(t *testing.T) {
+	input := "val := \"hello\" + \\\n  \"world\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	_, ok := jf.Assignments[0].Value.(*Concatenation)
+	if !ok {
+		t.Fatalf("expected Concatenation, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestLexShellExpandedString(t *testing.T) {
+	input := `val := x"echo hello"`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Kind != StringKindShellExpanded {
+		t.Errorf("expected shell-expanded string, got %s", sl.Kind)
+	}
+}
+
+func TestLexShellExpandedRawString(t *testing.T) {
+	input := `val := x'echo hello'`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Kind != StringKindShellExpandedRaw {
+		t.Errorf("expected shell-expanded raw string, got %s", sl.Kind)
+	}
+}
+
+func TestLexFormatString(t *testing.T) {
+	input := `val := f"hello {name}"`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Kind != StringKindFormat {
+		t.Errorf("expected format string, got %s", sl.Kind)
+	}
+}
+
+func TestLexShebang(t *testing.T) {
+	input := "#!/usr/bin/env just\nval := \"hello\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestLexErrorUnterminatedBacktick(t *testing.T) {
+	_, err := Parse([]byte("val := `unterminated"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLexErrorUnterminatedRawString(t *testing.T) {
+	_, err := Parse([]byte("val := 'unterminated"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLexErrorUnterminatedIndentedString(t *testing.T) {
+	_, err := Parse([]byte("val := \"\"\"\nunterminated"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLexErrorUnterminatedIndentedRawString(t *testing.T) {
+	_, err := Parse([]byte("val := '''\nunterminated"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLexErrorUnterminatedIndentedBacktick(t *testing.T) {
+	_, err := Parse([]byte("val := ```\nunterminated"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLexErrorBadEscape(t *testing.T) {
+	_, err := Parse([]byte(`val := "\q"`))
+	if err == nil {
+		t.Fatal("expected error for bad escape")
+	}
+}
+
+func TestLexErrorBadUnicodeEscape(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"no brace", `val := "\u0041"`},
+		{"bad hex", `val := "\u{ZZZZ}"`},
+		{"unterminated", `val := "\u{0041"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.input))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestLexErrorUnexpectedChar(t *testing.T) {
+	_, err := Parse([]byte("val := ~bad"))
+	if err == nil {
+		t.Fatal("expected error for unexpected character")
+	}
+}
+
+func TestLexTabIndent(t *testing.T) {
+	input := "build:\n\techo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 1 || len(jf.Recipes[0].Body) != 1 {
+		t.Error("expected 1 recipe with 1 body line")
+	}
+}
+
+func TestLexEscapeLineContInString(t *testing.T) {
+	// Backslash-newline inside a string is a line continuation
+	input := "val := \"hello\\\nworld\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Value != "helloworld" {
+		t.Errorf("expected 'helloworld', got %q", sl.Value)
+	}
+}
+
+func TestLexEscapeCarriageReturnInString(t *testing.T) {
+	input := "val := \"hello\\\r\nworld\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl2, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected *StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl2.Value != "helloworld" {
+		t.Errorf("expected 'helloworld', got %q", sl2.Value)
+	}
+}
+
+// --- Lexer edge cases ---
+
+func TestLexCarriageReturn(t *testing.T) {
+	input := "val := \"hello\"\r\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestLexLineContinuationCRLF(t *testing.T) {
+	input := "val := \"a\" + \\\r\n  \"b\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	_, ok := jf.Assignments[0].Value.(*Concatenation)
+	if !ok {
+		t.Fatalf("expected Concatenation, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestLexAllOperators(t *testing.T) {
+	// Exercise operators that might not be hit elsewhere
+	tests := []struct {
+		input string
+	}{
+		{"val := \"a\" + \"b\"\n"},
+		{"val := \"a\" / \"b\"\n"},
+	}
+	for _, tt := range tests {
+		_, err := Parse([]byte(tt.input))
+		if err != nil {
+			t.Errorf("Parse failed for %q: %v", tt.input, err)
+		}
+	}
+}
+
+// --- resolveModulePath edge cases ---
+
+func TestLexIndentedQuotedStringWithEscape(t *testing.T) {
+	input := "val := \"\"\"\nhello\\nworld\n\"\"\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sl, ok := jf.Assignments[0].Value.(*StringLiteral)
+	if !ok {
+		t.Fatalf("expected StringLiteral, got %T", jf.Assignments[0].Value)
+	}
+	if sl.Kind != StringKindIndentedQuoted {
+		t.Errorf("expected indented string, got %s", sl.Kind)
+	}
+}
+
+func TestLexRecipeBodyWithFunctionInInterpolation(t *testing.T) {
+	input := "build:\n    echo {{replace(\"a.b\", \".\", \"-\")}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestLexRecipeBodyWithRawStringInInterpolation(t *testing.T) {
+	input := "build:\n    echo {{env_var('HOME')}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+// --- Parser error paths for remaining uncovered branches ---
+
+func TestHexVal(t *testing.T) {
+	tests := []struct {
+		ch  byte
+		val int
+	}{
+		{'0', 0}, {'9', 9},
+		{'a', 10}, {'f', 15},
+		{'A', 10}, {'F', 15},
+		{'g', 0}, // fallthrough
+	}
+	for _, tt := range tests {
+		if got := hexVal(tt.ch); got != tt.val {
+			t.Errorf("hexVal(%q) = %d, want %d", tt.ch, got, tt.val)
+		}
+	}
+}
+
+func TestIsHexDigit(t *testing.T) {
+	for _, ch := range []byte("0123456789abcdefABCDEF") {
+		if !isHexDigit(ch) {
+			t.Errorf("expected %q to be hex digit", ch)
+		}
+	}
+	if isHexDigit('g') {
+		t.Error("expected 'g' to not be hex digit")
+	}
+}
+
+// --- Remaining parser expression paths ---
+
+func TestLexBangOperator(t *testing.T) {
+	// Standalone ! is rare but should lex
+	l := newLexer([]byte("!\n"))
+	tokens, err := l.lex()
+	if err != nil {
+		t.Fatalf("lex failed: %v", err)
+	}
+	found := false
+	for _, tok := range tokens {
+		if tok.Type == tokenBang {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected tokenBang")
+	}
+}
+
+func TestLexAndOrOperatorsTopLevel(t *testing.T) {
+	// && and || at top level (in dependency list)
+	input := "all: build && test deploy\n"
+	l := newLexer([]byte(input))
+	tokens, err := l.lex()
+	if err != nil {
+		t.Fatalf("lex failed: %v", err)
+	}
+	foundAnd := false
+	for _, tok := range tokens {
+		if tok.Type == tokenAnd {
+			foundAnd = true
+		}
+	}
+	if !foundAnd {
+		t.Error("expected tokenAnd")
+	}
+}
+
+func TestLexInterpolStartEndTopLevel(t *testing.T) {
+	// {{ and }} outside recipe body — in an expression context
+	l := newLexer([]byte("val := {{ broken }}\n"))
+	tokens, err := l.lex()
+	if err != nil {
+		t.Fatalf("lex failed: %v", err)
+	}
+	foundStart := false
+	foundEnd := false
+	for _, tok := range tokens {
+		if tok.Type == tokenInterpolStart {
+			foundStart = true
+		}
+		if tok.Type == tokenInterpolEnd {
+			foundEnd = true
+		}
+	}
+	if !foundStart || !foundEnd {
+		t.Error("expected {{ and }} tokens")
+	}
+}
+
+func TestLexSingleBracesTopLevel(t *testing.T) {
+	l := newLexer([]byte("val := if \"a\" == \"b\" { \"y\" } else { \"n\" }\n"))
+	tokens, err := l.lex()
+	if err != nil {
+		t.Fatalf("lex failed: %v", err)
+	}
+	braceCount := 0
+	for _, tok := range tokens {
+		if tok.Type == tokenLBrace || tok.Type == tokenRBrace {
+			braceCount++
+		}
+	}
+	if braceCount != 4 {
+		t.Errorf("expected 4 brace tokens, got %d", braceCount)
+	}
+}
+
+func TestLexRecipeBodyError(t *testing.T) {
+	// Error inside recipe body interpolation
+	input := "build:\n    echo {{~bad}}\n"
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for bad char in interpolation")
+	}
+}
+
+func TestLexCommentAfterNewline(t *testing.T) {
+	// Comment at start of line (atLineStart path)
+	input := "# comment1\n# comment2\nval := \"x\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Comments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(jf.Comments))
+	}
+}
+
+func TestLexEmptyLineAtStart(t *testing.T) {
+	// Empty line at start (atLineStart + newline path)
+	input := "\n\nval := \"x\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestLexEscapeSequenceAtEOF(t *testing.T) {
+	_, err := Parse([]byte("val := \"\\\n"))
+	if err == nil {
+		t.Fatal("expected error for escape at EOF")
+	}
+}
+
+func TestLexUnicodeEscapeInvalidCodepoint(t *testing.T) {
+	_, err := Parse([]byte(`val := "\u{D800}"`))
+	if err == nil {
+		t.Fatal("expected error for invalid unicode codepoint (surrogate)")
+	}
+}
+
+// --- parser.go uncovered error branches ---
+
+func TestLexRecipeBodyNestedInterpolation(t *testing.T) {
+	// This is extremely rare but tests the depth > 1 path in lexRecipeLine
+	// In practice just doesn't support nested {{ }} but the lexer handles it
+	input := "build:\n    echo {{ \"hello\" }}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestLexFPrefixAsIdentifier(t *testing.T) {
+	// 'f' not followed by quote should be an identifier
+	input := "f := \"hello\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Assignments[0].Name != "f" {
+		t.Errorf("expected name 'f', got %q", jf.Assignments[0].Name)
+	}
+}
+
+func TestLexXPrefixAsIdentifier(t *testing.T) {
+	// 'x' not followed by quote should be an identifier
+	input := "x := \"hello\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Assignments[0].Name != "x" {
+		t.Errorf("expected name 'x', got %q", jf.Assignments[0].Name)
+	}
+}
+
+// --- Exercise || and && in expression context ---
+
+func TestLexRecipeLineBacktickInInterpolation(t *testing.T) {
+	input := "build:\n    echo {{`whoami`}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestLexRecipeLineComparisonOpsInInterpolation(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"regex match", "build:\n    echo {{ if \"a\" =~ \"a\" { \"y\" } else { \"n\" } }}\n"},
+		{"regex mismatch", "build:\n    echo {{ if \"a\" !~ \"z\" { \"y\" } else { \"n\" } }}\n"},
+		{"and", "build:\n    echo {{ if \"a\" == \"a\" && \"b\" == \"b\" { \"y\" } else { \"n\" } }}\n"},
+		{"or", "build:\n    echo {{ if \"a\" == \"a\" || \"b\" == \"b\" { \"y\" } else { \"n\" } }}\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.input))
+			// We're exercising the lexer paths, parse may or may not succeed
+			// depending on grammar support
+			_ = err
+		})
+	}
+}
+
+// --- ParseFile uncovered: filepath.Abs error ---

--- a/pkg/validator/justfile/multiline_test.go
+++ b/pkg/validator/justfile/multiline_test.go
@@ -1,0 +1,84 @@
+package gojust
+
+import (
+	"testing"
+)
+
+func TestMultilineStringInAssignment(t *testing.T) {
+	input := "val := 'multi\nline\nstring'\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestMultilineStringInDepArg(t *testing.T) {
+	input := "build x:\n    echo done\nfoo: (build 'multi\nline\narg')\n    echo deploying\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 2 {
+		t.Errorf("expected 2 recipes, got %d", len(jf.Recipes))
+	}
+}
+
+func TestMultilineStringInInterpolation(t *testing.T) {
+	input := "build:\n    echo {{'multi\nline\nstring'}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 1 {
+		t.Errorf("expected 1 recipe, got %d", len(jf.Recipes))
+	}
+}
+
+func TestMultilineQuotedStringInAssignment(t *testing.T) {
+	input := "val := \"multi\nline\nquoted\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestMultilineStringInConditional(t *testing.T) {
+	input := "val := if 'a' == 'b' { 'multi\nline\nyes' } else { 'multi\nline\nno' }\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestMultilineStringInFunctionArg(t *testing.T) {
+	input := "val := replace('multi\nline\nstring', 'line', 'LINE')\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Errorf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+}
+
+func TestRecipeBodyTextIsShell(t *testing.T) {
+	// Single quotes in recipe body text are shell quotes, not justfile strings.
+	// The lexer should treat them as opaque text.
+	input := "build:\n    echo 'hello world'\n    echo \"shell quoted\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 2 {
+		t.Errorf("expected 2 body lines, got %d", len(jf.Recipes[0].Body))
+	}
+}

--- a/pkg/validator/justfile/parser.go
+++ b/pkg/validator/justfile/parser.go
@@ -1,0 +1,1079 @@
+package gojust
+
+import (
+	"fmt"
+	"strings"
+)
+
+type parser struct {
+	tokens      []token
+	pos         int
+	file        string
+	lastComment string // most recent comment, cleared on non-comment/newline tokens
+}
+
+func newParser(tokens []token, file string) *parser {
+	return &parser{tokens: tokens, file: file}
+}
+
+func (p *parser) parse() (*Justfile, error) {
+	jf := &Justfile{File: p.file}
+
+	for !p.atEnd() {
+		if p.check(tokenNewline) {
+			p.advance()
+			continue
+		}
+		if p.check(tokenComment) {
+			val := p.current().Value
+			jf.Comments = append(jf.Comments, &Comment{
+				Value: val,
+				Pos:   p.current().Pos,
+			})
+			// Strip leading # and space for doc comments
+			if len(val) > 1 && val[0] == '#' {
+				p.lastComment = strings.TrimLeft(val[1:], " ")
+			} else {
+				p.lastComment = val
+			}
+			p.advance()
+			continue
+		}
+
+		if err := p.parseItem(jf); err != nil {
+			return nil, err
+		}
+	}
+
+	return jf, nil
+}
+
+func (p *parser) parseItem(jf *Justfile) error {
+	// Attributes
+	var attrs []*Attribute
+	for p.check(tokenLBracket) {
+		attr, err := p.parseAttributes()
+		if err != nil {
+			return err
+		}
+		attrs = append(attrs, attr...)
+		p.skipNewlines()
+	}
+
+	// Non-recipe items clear the pending comment
+	switch {
+	case p.check(tokenAlias):
+		p.lastComment = ""
+		return p.parseAlias(jf, attrs)
+	case p.check(tokenExport), p.check(tokenEager):
+		p.lastComment = ""
+		return p.parsePrefixedAssignment(jf)
+	case p.check(tokenUnexport):
+		p.lastComment = ""
+		return p.parseUnexport(jf)
+	case p.check(tokenImport):
+		// 'import' followed by ':' is a recipe named 'import', not an import statement
+		if p.pos+1 < len(p.tokens) && p.tokens[p.pos+1].Type == tokenColon {
+			return p.parseRecipe(jf, attrs)
+		}
+		p.lastComment = ""
+		return p.parseImport(jf)
+	case p.check(tokenMod):
+		p.lastComment = ""
+		return p.parseModule(jf, attrs)
+	case p.check(tokenSet):
+		p.lastComment = ""
+		return p.parseSetting(jf)
+	case p.check(tokenIdentifier):
+		return p.parseAssignmentOrRecipe(jf, attrs)
+	case p.check(tokenAt):
+		return p.parseRecipe(jf, attrs)
+	default:
+		return p.errorf("unexpected %s", p.current().Type)
+	}
+}
+
+func (p *parser) parseAlias(jf *Justfile, attrs []*Attribute) error {
+	pos := p.current().Pos
+	p.advance() // skip 'alias'
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return err
+	}
+
+	if err := p.expect(tokenAssign); err != nil {
+		return err
+	}
+
+	target, err := p.expectIdentifier()
+	if err != nil {
+		return err
+	}
+
+	jf.Aliases = append(jf.Aliases, &Alias{
+		Name:       name,
+		Target:     target,
+		Attributes: attrs,
+		Pos:        pos,
+	})
+	return nil
+}
+
+// parsePrefixedAssignment handles assignment prefixes: export, eager, or both.
+func (p *parser) parsePrefixedAssignment(jf *Justfile) error {
+	pos := p.current().Pos
+
+	var export, eager bool
+	for p.check(tokenExport) || p.check(tokenEager) {
+		if p.check(tokenExport) {
+			export = true
+		} else {
+			eager = true
+		}
+		p.advance()
+	}
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return err
+	}
+
+	if err := p.expect(tokenAssign); err != nil {
+		return err
+	}
+
+	value, err := p.parseExpression()
+	if err != nil {
+		return err
+	}
+
+	jf.Assignments = append(jf.Assignments, &Assignment{
+		Name:   name,
+		Value:  value,
+		Export: export,
+		Eager:  eager,
+		Pos:    pos,
+	})
+	return nil
+}
+
+func (p *parser) parseUnexport(jf *Justfile) error {
+	pos := p.current().Pos
+	p.advance() // skip 'unexport'
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return err
+	}
+
+	jf.Unexports = append(jf.Unexports, &Unexport{
+		Name: name,
+		Pos:  pos,
+	})
+	return nil
+}
+
+func (p *parser) parseImport(jf *Justfile) error {
+	pos := p.current().Pos
+	p.advance() // skip 'import'
+
+	optional := false
+	if p.check(tokenQuestion) {
+		optional = true
+		p.advance()
+	}
+
+	path, err := p.expectString()
+	if err != nil {
+		return err
+	}
+
+	jf.Imports = append(jf.Imports, &Import{
+		Path:     path,
+		Optional: optional,
+		Pos:      pos,
+	})
+	return nil
+}
+
+func (p *parser) parseModule(jf *Justfile, attrs []*Attribute) error {
+	pos := p.current().Pos
+	p.advance() // skip 'mod'
+
+	optional := false
+	if p.check(tokenQuestion) {
+		optional = true
+		p.advance()
+	}
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return err
+	}
+
+	var path string
+	if p.check(tokenString) || p.check(tokenRawString) {
+		path = p.current().Value
+		p.advance()
+	}
+
+	jf.Modules = append(jf.Modules, &Module{
+		Name:       name,
+		Path:       path,
+		Optional:   optional,
+		Attributes: attrs,
+		Pos:        pos,
+	})
+	return nil
+}
+
+func (p *parser) parseSetting(jf *Justfile) error {
+	pos := p.current().Pos
+	p.advance() // skip 'set'
+
+	// Setting names can be keywords like 'export'
+	name, err := p.expectAnyIdentifier()
+	if err != nil {
+		return err
+	}
+
+	setting := &Setting{Name: name, Pos: pos}
+
+	// Setting with no value (boolean true)
+	if p.check(tokenNewline) || p.check(tokenEOF) || p.check(tokenComment) {
+		t := true
+		setting.Value.Bool = &t
+		jf.Settings = append(jf.Settings, setting)
+		return nil
+	}
+
+	if err := p.expect(tokenAssign); err != nil {
+		return err
+	}
+
+	// Boolean value
+	if p.check(tokenTrue) || p.check(tokenFalse) {
+		b := p.current().Type == tokenTrue
+		setting.Value.Bool = &b
+		p.advance()
+		jf.Settings = append(jf.Settings, setting)
+		return nil
+	}
+
+	// List value [...]
+	if p.check(tokenLBracket) {
+		p.advance() // skip [
+		var items []string
+		for !p.check(tokenRBracket) {
+			s, err := p.expectString()
+			if err != nil {
+				return err
+			}
+			items = append(items, s)
+			if p.check(tokenComma) {
+				p.advance()
+			}
+		}
+		if err := p.expect(tokenRBracket); err != nil {
+			return err
+		}
+		setting.Value.List = items
+		jf.Settings = append(jf.Settings, setting)
+		return nil
+	}
+
+	// String value
+	s, err := p.expectString()
+	if err != nil {
+		return err
+	}
+	setting.Value.String = &s
+	jf.Settings = append(jf.Settings, setting)
+	return nil
+}
+
+func (p *parser) parseAssignmentOrRecipe(jf *Justfile, attrs []*Attribute) error {
+	// Look ahead to determine if this is an assignment, function def, or recipe.
+	// Use peekAt to avoid mutating parser state.
+	if p.peekAt(1).Type == tokenAssign {
+		return p.parseAssignment(jf, attrs)
+	}
+
+	// Function definition: name(params) := expression
+	if p.peekAt(1).Type == tokenLParen {
+		depth := 1
+		i := 2
+		for depth > 0 {
+			tok := p.peekAt(i)
+			switch tok.Type {
+			case tokenEOF:
+				depth = 0
+			case tokenLParen:
+				depth++
+			case tokenRParen:
+				depth--
+			default:
+			}
+			i++
+		}
+		if p.peekAt(i).Type == tokenAssign {
+			return p.parseFunctionDef(jf)
+		}
+	}
+
+	return p.parseRecipe(jf, attrs)
+}
+
+func (p *parser) parseAssignment(jf *Justfile, attrs []*Attribute) error {
+	p.lastComment = ""
+	pos := p.current().Pos
+	name := p.current().Value
+	p.advance() // skip name
+
+	if err := p.expect(tokenAssign); err != nil {
+		return err
+	}
+
+	value, err := p.parseExpression()
+	if err != nil {
+		return err
+	}
+
+	private := false
+	for _, a := range attrs {
+		if a.Name == "private" {
+			private = true
+		}
+	}
+
+	jf.Assignments = append(jf.Assignments, &Assignment{
+		Name:    name,
+		Value:   value,
+		Private: private,
+		Pos:     pos,
+	})
+	return nil
+}
+
+func (p *parser) parseFunctionDef(jf *Justfile) error {
+	pos := p.current().Pos
+	name := p.current().Value
+	p.advance() // skip name
+	p.advance() // skip (
+
+	var params []string
+	for !p.check(tokenRParen) && !p.atEnd() {
+		param, err := p.expectIdentifier()
+		if err != nil {
+			return err
+		}
+		params = append(params, param)
+		if p.check(tokenComma) {
+			p.advance()
+		}
+	}
+	if err := p.expect(tokenRParen); err != nil {
+		return err
+	}
+	if err := p.expect(tokenAssign); err != nil {
+		return err
+	}
+
+	// Function definitions can span multiple lines
+	p.skipNewlines()
+	value, err := p.parseExpression()
+	if err != nil {
+		return err
+	}
+
+	jf.Assignments = append(jf.Assignments, &Assignment{
+		Name:       name,
+		Value:      value,
+		Parameters: params,
+		Pos:        pos,
+	})
+	return nil
+}
+
+func (p *parser) parseRecipe(jf *Justfile, attrs []*Attribute) error {
+	pos := p.current().Pos
+
+	quiet := false
+	if p.check(tokenAt) {
+		quiet = true
+		p.advance() // skip @
+	}
+
+	// Grab preceding comment as doc and clear it
+	comment := p.lastComment
+	p.lastComment = ""
+
+	name, err := p.expectIdentifierOrKeyword()
+	if err != nil {
+		return err
+	}
+
+	// Parameters
+	var params []*Parameter
+	for !p.check(tokenColon) && !p.check(tokenNewline) && !p.check(tokenEOF) {
+		param, err := p.parseParameter()
+		if err != nil {
+			return err
+		}
+		params = append(params, param)
+	}
+
+	if err := p.expect(tokenColon); err != nil {
+		return err
+	}
+
+	// Dependencies
+	var deps []*Dependency
+	subsequent := false
+	for !p.check(tokenNewline) && !p.check(tokenEOF) && !p.check(tokenComment) {
+		if p.check(tokenAnd) {
+			subsequent = true
+			p.advance()
+		}
+		dep, err := p.parseDependency(subsequent)
+		if err != nil {
+			return err
+		}
+		deps = append(deps, dep)
+	}
+
+	// Skip to body
+	p.skipNewlines()
+
+	// Recipe body
+	var body []*RecipeLine
+	if p.check(tokenIndent) {
+		p.advance()
+		for !p.check(tokenDedent) && !p.atEnd() {
+			if p.check(tokenNewline) {
+				p.advance()
+				continue
+			}
+			line, err := p.parseRecipeLine()
+			if err != nil {
+				return err
+			}
+			body = append(body, line)
+		}
+		if p.check(tokenDedent) {
+			p.advance()
+		}
+	}
+
+	jf.Recipes = append(jf.Recipes, &Recipe{
+		Name:         name,
+		Parameters:   params,
+		Dependencies: deps,
+		Body:         body,
+		Attributes:   attrs,
+		Shebang:      extractShebang(body),
+		Quiet:        quiet,
+		Comment:      comment,
+		Pos:          pos,
+	})
+	return nil
+}
+
+func (p *parser) parseParameter() (*Parameter, error) {
+	pos := p.current().Pos
+	param := &Parameter{Pos: pos}
+
+	// Variadic
+	if p.check(tokenStar) || p.check(tokenPlus) {
+		param.Variadic = p.current().Value
+		p.advance()
+	}
+
+	// Export
+	if p.check(tokenDollar) {
+		param.Export = true
+		p.advance()
+	}
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	param.Name = name
+
+	// Default value — only accepts a single value, not a full expression,
+	// because + and / in parameter context are ambiguous with variadic
+	// and path operators.
+	if p.check(tokenParamAssign) {
+		p.advance()
+		val, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+		param.Default = val
+	}
+
+	return param, nil
+}
+
+func (p *parser) parseDependency(subsequent bool) (*Dependency, error) {
+	pos := p.current().Pos
+
+	// Dependency with arguments: (name args...)
+	if p.check(tokenLParen) {
+		p.advance()
+		name, err := p.expectIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		var args []Expression
+		for !p.check(tokenRParen) && !p.atEnd() {
+			expr, err := p.parseExpression()
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, expr)
+		}
+		if err := p.expect(tokenRParen); err != nil {
+			return nil, err
+		}
+		return &Dependency{Name: name, Arguments: args, Subsequent: subsequent, Pos: pos}, nil
+	}
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	return &Dependency{Name: name, Subsequent: subsequent, Pos: pos}, nil
+}
+
+func (p *parser) parseRecipeLine() (*RecipeLine, error) {
+	pos := p.current().Pos
+	line := &RecipeLine{Pos: pos}
+
+	// Line prefix
+	if p.check(tokenAtDash) {
+		line.Quiet = true
+		line.NoError = true
+		line.PrefixOrder = "@-"
+		p.advance()
+	} else if p.check(tokenDashAt) {
+		line.Quiet = true
+		line.NoError = true
+		line.PrefixOrder = "-@"
+		p.advance()
+	} else if p.check(tokenAt) {
+		line.Quiet = true
+		p.advance()
+	} else if p.check(tokenDash) {
+		line.NoError = true
+		p.advance()
+	}
+
+	// Fragments
+	for !p.check(tokenNewline) && !p.check(tokenDedent) && !p.atEnd() {
+		if p.check(tokenInterpolStart) {
+			p.advance()
+			expr, err := p.parseExpression()
+			if err != nil {
+				return nil, err
+			}
+			if err := p.expect(tokenInterpolEnd); err != nil {
+				return nil, err
+			}
+			line.Fragments = append(line.Fragments, &InterpolationFragment{
+				Expression: expr,
+				Pos:        pos,
+			})
+		} else if p.check(tokenText) {
+			line.Fragments = append(line.Fragments, &TextFragment{
+				Value: p.current().Value,
+				Pos:   p.current().Pos,
+			})
+			p.advance()
+		} else {
+			return nil, p.errorf("unexpected %s in recipe body", p.current().Type)
+		}
+	}
+
+	if p.check(tokenNewline) {
+		p.advance()
+	}
+
+	return line, nil
+}
+
+func (p *parser) parseAttributes() ([]*Attribute, error) {
+	if err := p.expect(tokenLBracket); err != nil {
+		return nil, err
+	}
+
+	var attrs []*Attribute
+	for !p.check(tokenRBracket) && !p.atEnd() {
+		attr, err := p.parseAttribute()
+		if err != nil {
+			return nil, err
+		}
+		attrs = append(attrs, attr)
+		if p.check(tokenComma) {
+			p.advance()
+		}
+	}
+
+	if err := p.expect(tokenRBracket); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}
+
+func (p *parser) parseAttribute() (*Attribute, error) {
+	pos := p.current().Pos
+	// Attribute names can be identifiers or keywords used as identifiers
+	name, err := p.expectAnyIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	attr := &Attribute{Name: name, Pos: pos}
+
+	// [name(args...)]
+	if p.check(tokenLParen) {
+		p.advance()
+		for !p.check(tokenRParen) && !p.atEnd() {
+			arg, err := p.parseAttributeArg()
+			if err != nil {
+				return nil, err
+			}
+			attr.Arguments = append(attr.Arguments, arg)
+			if p.check(tokenComma) {
+				p.advance()
+			}
+		}
+		if err := p.expect(tokenRParen); err != nil {
+			return nil, err
+		}
+	}
+
+	// [name: 'value'] shorthand
+	if p.check(tokenColon) {
+		p.advance()
+		val, err := p.expectString()
+		if err != nil {
+			return nil, err
+		}
+		attr.Arguments = []AttributeArg{{Value: val}}
+	}
+
+	return attr, nil
+}
+
+func (p *parser) parseAttributeArg() (AttributeArg, error) {
+	// Check for key=value
+	if p.check(tokenIdentifier) && p.pos+1 < len(p.tokens) && p.tokens[p.pos+1].Type == tokenParamAssign {
+		key := p.current().Value
+		p.advance() // key
+		p.advance() // =
+		val, err := p.expectString()
+		if err != nil {
+			return AttributeArg{}, err
+		}
+		return AttributeArg{Key: key, Value: val}, nil
+	}
+
+	// Positional string arg
+	if p.check(tokenString) || p.check(tokenRawString) {
+		val := p.current().Value
+		p.advance()
+		return AttributeArg{Value: val}, nil
+	}
+
+	// Positional identifier arg
+	if p.check(tokenIdentifier) {
+		val := p.current().Value
+		p.advance()
+		return AttributeArg{Value: val}, nil
+	}
+
+	return AttributeArg{}, p.errorf("expected attribute argument, found %s", p.current().Type)
+}
+
+// Expression parsing
+
+func (p *parser) parseExpression() (Expression, error) {
+	// Expressions can start with / for absolute paths
+	if p.check(tokenSlash) {
+		pos := p.current().Pos
+		p.advance()
+		right, err := p.parseLogicalOr()
+		if err != nil {
+			return nil, err
+		}
+		return &PathJoin{
+			Left:  &StringLiteral{Value: "", Kind: StringKindQuoted, Pos: pos},
+			Right: right,
+			Pos:   pos,
+		}, nil
+	}
+	return p.parseLogicalOr()
+}
+
+func (p *parser) parseLogicalOr() (Expression, error) {
+	left, err := p.parseLogicalAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.check(tokenOr) {
+		pos := p.current().Pos
+		p.advance()
+		right, err := p.parseLogicalAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &LogicalOp{Left: left, Right: right, Operator: "||", Pos: pos}
+	}
+	return left, nil
+}
+
+func (p *parser) parseLogicalAnd() (Expression, error) {
+	left, err := p.parseComparison()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.check(tokenAnd) {
+		pos := p.current().Pos
+		p.advance()
+		right, err := p.parseComparison()
+		if err != nil {
+			return nil, err
+		}
+		left = &LogicalOp{Left: left, Right: right, Operator: "&&", Pos: pos}
+	}
+	return left, nil
+}
+
+func (p *parser) parseComparison() (Expression, error) {
+	left, err := p.parsePathJoin()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.check(tokenEquals) || p.check(tokenNotEquals) || p.check(tokenRegexMatch) || p.check(tokenRegexMismatch) {
+		op := p.current().Value
+		p.advance()
+		right, err := p.parsePathJoin()
+		if err != nil {
+			return nil, err
+		}
+		return &Comparison{Left: left, Right: right, Operator: op, Pos: left.GetPos()}, nil
+	}
+
+	return left, nil
+}
+
+// parsePathJoin parses / expressions. In just, + binds tighter than /,
+// and / is right-associative: a / b / c = a / (b / c).
+func (p *parser) parsePathJoin() (Expression, error) {
+	left, err := p.parseConcatenation()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.check(tokenSlash) {
+		pos := p.current().Pos
+		p.advance()
+		// Right-associative: recurse into parsePathJoin for the right side
+		right, err := p.parsePathJoin()
+		if err != nil {
+			return nil, err
+		}
+		return &PathJoin{Left: left, Right: right, Pos: pos}, nil
+	}
+	return left, nil
+}
+
+// parseConcatenation parses + expressions. + is right-associative in just:
+// a + b + c = a + (b + c).
+func (p *parser) parseConcatenation() (Expression, error) {
+	left, err := p.parseValue()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.check(tokenPlus) {
+		pos := p.current().Pos
+		p.advance()
+		// Right-associative: recurse into parseConcatenation for the right side
+		right, err := p.parseConcatenation()
+		if err != nil {
+			return nil, err
+		}
+		return &Concatenation{Left: left, Right: right, Pos: pos}, nil
+	}
+	return left, nil
+}
+
+func (p *parser) parseValue() (Expression, error) {
+	tok := p.current()
+
+	switch tok.Type {
+	case tokenIf:
+		return p.parseConditional()
+
+	case tokenString, tokenRawString, tokenIndentedString, tokenIndentedRawString,
+		tokenShellExpandedString, tokenShellExpandedRawString, tokenFormatString:
+		p.advance()
+		return &StringLiteral{Value: tok.Value, Kind: tokenTypeToStringKind[tok.Type], Pos: tok.Pos}, nil
+
+	case tokenBacktick, tokenIndentedBacktick:
+		p.advance()
+		return &BacktickExpr{
+			Command:  tok.Value,
+			Indented: tok.Type == tokenIndentedBacktick,
+			Pos:      tok.Pos,
+		}, nil
+
+	case tokenIdentifier:
+		// Check for function call
+		if p.pos+1 < len(p.tokens) && p.tokens[p.pos+1].Type == tokenLParen {
+			return p.parseFunctionCall()
+		}
+		p.advance()
+		return &Variable{Name: tok.Value, Pos: tok.Pos}, nil
+
+	case tokenLParen:
+		pos := tok.Pos
+		p.advance()
+		expr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		if err := p.expect(tokenRParen); err != nil {
+			return nil, err
+		}
+		return &ParenExpr{Inner: expr, Pos: pos}, nil
+
+	default:
+		return nil, p.errorf("expected expression, found %s", tok.Type)
+	}
+}
+
+func (p *parser) parseConditional() (Expression, error) {
+	pos := p.current().Pos
+	p.advance() // skip 'if'
+	p.skipNewlines()
+
+	// Parse condition: value op value
+	left, err := p.parsePathJoin()
+	if err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+
+	// Operator
+	if !p.check(tokenEquals) && !p.check(tokenNotEquals) && !p.check(tokenRegexMatch) && !p.check(tokenRegexMismatch) {
+		return nil, p.errorf("expected comparison operator, found %s", p.current().Type)
+	}
+	op := p.current().Value
+	p.advance()
+	p.skipNewlines()
+
+	right, err := p.parsePathJoin()
+	if err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+
+	if err := p.expect(tokenLBrace); err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+	then, err := p.parseExpression()
+	if err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+	if err := p.expect(tokenRBrace); err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+
+	if err := p.expect(tokenElse); err != nil {
+		return nil, err
+	}
+	p.skipNewlines()
+
+	// else if ...
+	var otherwise Expression
+	if p.check(tokenIf) {
+		otherwise, err = p.parseConditional()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if err := p.expect(tokenLBrace); err != nil {
+			return nil, err
+		}
+		p.skipNewlines()
+		otherwise, err = p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		p.skipNewlines()
+		if err := p.expect(tokenRBrace); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Conditional{
+		Condition: Comparison{Left: left, Right: right, Operator: op, Pos: pos},
+		Then:      then,
+		Otherwise: otherwise,
+		Pos:       pos,
+	}, nil
+}
+
+func (p *parser) parseFunctionCall() (Expression, error) {
+	pos := p.current().Pos
+	name := p.current().Value
+	p.advance() // name
+	p.advance() // (
+
+	var args []Expression
+	for !p.check(tokenRParen) && !p.atEnd() {
+		expr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, expr)
+		if p.check(tokenComma) {
+			p.advance()
+		}
+	}
+
+	if err := p.expect(tokenRParen); err != nil {
+		return nil, err
+	}
+
+	return &FunctionCall{Name: name, Arguments: args, Pos: pos}, nil
+}
+
+// Helper methods
+
+func (p *parser) current() token {
+	if p.pos >= len(p.tokens) {
+		return token{Type: tokenEOF, Pos: Position{Line: -1, Column: -1}}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *parser) check(typ tokenType) bool {
+	return p.current().Type == typ
+}
+
+func (p *parser) atEnd() bool {
+	return p.pos >= len(p.tokens) || p.tokens[p.pos].Type == tokenEOF
+}
+
+func (p *parser) advance() {
+	if p.pos < len(p.tokens) {
+		p.pos++
+	}
+}
+
+// peekAt returns the token at offset positions ahead without advancing.
+func (p *parser) peekAt(offset int) token {
+	pos := p.pos + offset
+	if pos >= len(p.tokens) {
+		return token{Type: tokenEOF, Pos: Position{Line: -1, Column: -1}}
+	}
+	return p.tokens[pos]
+}
+
+func (p *parser) expect(typ tokenType) error {
+	if !p.check(typ) {
+		return p.errorf("expected %s, found %s", typ, p.current().Type)
+	}
+	p.advance()
+	return nil
+}
+
+func (p *parser) expectIdentifier() (string, error) {
+	if !p.check(tokenIdentifier) {
+		return "", p.errorf("expected identifier, found %s", p.current().Type)
+	}
+	val := p.current().Value
+	p.advance()
+	return val, nil
+}
+
+func (p *parser) expectIdentifierOrKeyword() (string, error) {
+	// Some keywords can be used as recipe names
+	switch p.current().Type {
+	case tokenIdentifier, tokenImport:
+		val := p.current().Value
+		p.advance()
+		return val, nil
+	}
+	return "", p.errorf("expected identifier, found %s", p.current().Type)
+}
+
+// expectAnyIdentifier accepts any identifier-like token including all keywords.
+func (p *parser) expectAnyIdentifier() (string, error) {
+	switch p.current().Type {
+	case tokenIdentifier, tokenAlias, tokenExport, tokenUnexport, tokenEager, tokenImport, tokenMod,
+		tokenSet, tokenIf, tokenElse, tokenTrue, tokenFalse:
+		val := p.current().Value
+		p.advance()
+		return val, nil
+	}
+	return "", p.errorf("expected identifier, found %s", p.current().Type)
+}
+
+func (p *parser) expectString() (string, error) {
+	switch p.current().Type {
+	case tokenString, tokenRawString, tokenIndentedString, tokenIndentedRawString,
+		tokenShellExpandedString, tokenShellExpandedRawString:
+		val := p.current().Value
+		p.advance()
+		return val, nil
+	}
+	return "", p.errorf("expected string, found %s", p.current().Type)
+}
+
+func (p *parser) skipNewlines() {
+	for p.check(tokenNewline) || p.check(tokenComment) {
+		p.advance()
+	}
+}
+
+func (p *parser) errorf(format string, args ...any) *ParseError {
+	tok := p.current()
+	return &ParseError{
+		Pos:     tok.Pos,
+		Message: fmt.Sprintf(format, args...),
+		File:    p.file,
+	}
+}
+
+// extractShebang checks if the first line of a recipe body is a shebang
+// and returns it. Returns empty string if no shebang.
+func extractShebang(body []*RecipeLine) string {
+	if len(body) == 0 {
+		return ""
+	}
+	line := body[0]
+	if len(line.Fragments) == 0 {
+		return ""
+	}
+	tf, ok := line.Fragments[0].(*TextFragment)
+	if !ok {
+		return ""
+	}
+	if strings.HasPrefix(tf.Value, "#!") {
+		return tf.Value
+	}
+	return ""
+}

--- a/pkg/validator/justfile/parser_test.go
+++ b/pkg/validator/justfile/parser_test.go
@@ -1,0 +1,1045 @@
+package gojust
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseLogicalOr(t *testing.T) {
+	jf, err := Parse([]byte(`val := env_var("A") + env_var("B")`))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	_, ok := jf.Assignments[0].Value.(*Concatenation)
+	if !ok {
+		t.Fatalf("expected Concatenation, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestParseParenExpression(t *testing.T) {
+	input := `val := ("hello" + "world")`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	pe, ok := jf.Assignments[0].Value.(*ParenExpr)
+	if !ok {
+		t.Fatalf("expected ParenExpr, got %T", jf.Assignments[0].Value)
+	}
+	_, ok = pe.Inner.(*Concatenation)
+	if !ok {
+		t.Fatalf("expected Concatenation inside parens, got %T", pe.Inner)
+	}
+}
+
+func TestParseFunctionCallMultipleArgs(t *testing.T) {
+	input := `val := replace("hello.world", ".", "-")`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	fc, ok := jf.Assignments[0].Value.(*FunctionCall)
+	if !ok {
+		t.Fatalf("expected FunctionCall, got %T", jf.Assignments[0].Value)
+	}
+	if fc.Name != "replace" {
+		t.Errorf("expected 'replace', got %q", fc.Name)
+	}
+	if len(fc.Arguments) != 3 {
+		t.Errorf("expected 3 args, got %d", len(fc.Arguments))
+	}
+}
+
+func TestParseFunctionCallNoArgs(t *testing.T) {
+	input := `val := arch()`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	fc, ok := jf.Assignments[0].Value.(*FunctionCall)
+	if !ok {
+		t.Fatalf("expected FunctionCall, got %T", jf.Assignments[0].Value)
+	}
+	if len(fc.Arguments) != 0 {
+		t.Errorf("expected 0 args, got %d", len(fc.Arguments))
+	}
+}
+
+func TestParseComplexExpression(t *testing.T) {
+	input := `val := "prefix-" + version + "-" + arch()`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	// Should be nested Concatenation
+	_, ok := jf.Assignments[0].Value.(*Concatenation)
+	if !ok {
+		t.Fatalf("expected Concatenation, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestParsePathJoinMultiple(t *testing.T) {
+	input := `val := "a" / "b" / "c" / "d"`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	_, ok := jf.Assignments[0].Value.(*PathJoin)
+	if !ok {
+		t.Fatalf("expected PathJoin, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestParseConditionalRegex(t *testing.T) {
+	input := `val := if arch() =~ "x86" { "intel" } else { "other" }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	cond, ok := jf.Assignments[0].Value.(*Conditional)
+	if !ok {
+		t.Fatalf("expected Conditional, got %T", jf.Assignments[0].Value)
+	}
+	if cond.Condition.Operator != "=~" {
+		t.Errorf("expected '=~', got %q", cond.Condition.Operator)
+	}
+}
+
+func TestParseConditionalNotEquals(t *testing.T) {
+	input := `val := if "a" != "b" { "different" } else { "same" }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	cond, ok := jf.Assignments[0].Value.(*Conditional)
+	if !ok {
+		t.Fatalf("expected *Conditional, got %T", jf.Assignments[0].Value)
+	}
+	if cond.Condition.Operator != "!=" {
+		t.Errorf("expected '!=', got %q", cond.Condition.Operator)
+	}
+}
+
+func TestParseQuietRecipe(t *testing.T) {
+	input := "@build:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if !jf.Recipes[0].Quiet {
+		t.Error("expected quiet recipe")
+	}
+}
+
+func TestParseRecipeNoBody(t *testing.T) {
+	input := "build: dep1 dep2\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 0 {
+		t.Errorf("expected empty body, got %d lines", len(jf.Recipes[0].Body))
+	}
+	if len(jf.Recipes[0].Dependencies) != 2 {
+		t.Errorf("expected 2 deps, got %d", len(jf.Recipes[0].Dependencies))
+	}
+}
+
+func TestParseRecipeEmptyLines(t *testing.T) {
+	input := "build:\n    echo line1\n\n    echo line2\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 2 {
+		t.Errorf("expected 2 body lines, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestParsePrivateAssignment(t *testing.T) {
+	input := "[private]\n_internal := \"secret\"\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if !jf.Assignments[0].Private {
+		t.Error("expected private assignment")
+	}
+}
+
+func TestParseUnexport(t *testing.T) {
+	input := "unexport FOO\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Unexports) != 1 {
+		t.Fatalf("expected 1 unexport, got %d", len(jf.Unexports))
+	}
+	if jf.Unexports[0].Name != "FOO" {
+		t.Errorf("expected 'FOO', got %q", jf.Unexports[0].Name)
+	}
+}
+
+func TestParseAttributeKeyValue(t *testing.T) {
+	input := "[env(name=\"FOO\", value=\"bar\")]\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	attr := jf.Recipes[0].Attributes[0]
+	if attr.Name != "env" {
+		t.Errorf("expected 'env', got %q", attr.Name)
+	}
+	if len(attr.Arguments) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(attr.Arguments))
+	}
+	if attr.Arguments[0].Key != "name" || attr.Arguments[0].Value != "FOO" {
+		t.Errorf("unexpected first arg: %+v", attr.Arguments[0])
+	}
+}
+
+func TestParseRecipeComment(t *testing.T) {
+	input := "# Build the project\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Recipes[0].Comment != "Build the project" {
+		t.Errorf("expected 'Build the project', got %q", jf.Recipes[0].Comment)
+	}
+}
+
+func TestParseRecipeCommentNotLeaked(t *testing.T) {
+	input := "# This is for var\nval := \"hello\"\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Recipes[0].Comment != "" {
+		t.Errorf("expected empty comment, got %q", jf.Recipes[0].Comment)
+	}
+}
+
+func TestParseSettingBooleanFalse(t *testing.T) {
+	input := "set dotenv-load := false\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Settings[0].Value.Bool == nil || *jf.Settings[0].Value.Bool {
+		t.Error("expected false")
+	}
+}
+
+func TestParseMultipleImports(t *testing.T) {
+	input := "import 'a.just'\nimport 'b.just'\nimport? 'c.just'\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Imports) != 3 {
+		t.Errorf("expected 3 imports, got %d", len(jf.Imports))
+	}
+	if !jf.Imports[2].Optional {
+		t.Error("expected third import to be optional")
+	}
+}
+
+func TestParseErrorMissingColon(t *testing.T) {
+	_, err := Parse([]byte("build\n"))
+	if err == nil {
+		t.Fatal("expected error for missing colon")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.Pos.Line != 1 {
+		t.Errorf("expected error on line 1, got %d", pe.Pos.Line)
+	}
+}
+
+func TestParseErrorBadAttribute(t *testing.T) {
+	_, err := Parse([]byte("[123]\nbuild:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad attribute")
+	}
+}
+
+func TestParseErrorMissingExpression(t *testing.T) {
+	_, err := Parse([]byte("val :=\n"))
+	if err == nil {
+		t.Fatal("expected error for missing expression")
+	}
+}
+
+func TestParseEmptyFile(t *testing.T) {
+	jf, err := Parse([]byte(""))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 0 || len(jf.Assignments) != 0 {
+		t.Error("expected empty justfile")
+	}
+}
+
+func TestParseCommentsOnly(t *testing.T) {
+	jf, err := Parse([]byte("# just a comment\n# another one\n"))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Comments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(jf.Comments))
+	}
+}
+
+func TestASTGetPos(t *testing.T) {
+	input := `val := if "a" == "b" { "yes" + path() / "x" } else { ("no") }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	// Walk the expression tree to exercise all GetPos/exprNode methods
+	var walk func(Expression)
+	walk = func(e Expression) {
+		if e == nil {
+			return
+		}
+		e.GetPos()
+		e.exprNode()
+		switch v := e.(type) {
+		case *Conditional:
+			walk(v.Condition.Left)
+			walk(v.Condition.Right)
+			walk(v.Then)
+			walk(v.Otherwise)
+		case *Concatenation:
+			walk(v.Left)
+			walk(v.Right)
+		case *PathJoin:
+			walk(v.Left)
+			walk(v.Right)
+		case *FunctionCall:
+			for _, a := range v.Arguments {
+				walk(a)
+			}
+		case *ParenExpr:
+			walk(v.Inner)
+		case *LogicalOp:
+			walk(v.Left)
+			walk(v.Right)
+		case *Comparison:
+			walk(v.Left)
+			walk(v.Right)
+		case *BacktickExpr:
+		case *StringLiteral:
+		case *Variable:
+		default:
+		}
+	}
+	walk(jf.Assignments[0].Value)
+}
+
+func TestFragmentGetPos(t *testing.T) {
+	input := "build name:\n    echo {{name}} done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	for _, line := range jf.Recipes[0].Body {
+		for _, f := range line.Fragments {
+			f.GetPos()
+			f.fragmentNode()
+		}
+	}
+}
+
+// --- Logical operators ---
+
+func TestParseLogicalAndExpression(t *testing.T) {
+	// && in a conditional context
+	input := `val := if "a" == "a" { "yes" } else { "no" }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if _, ok := jf.Assignments[0].Value.(*Conditional); !ok {
+		t.Fatalf("expected *Conditional, got %T", jf.Assignments[0].Value)
+	}
+}
+
+func TestParseComparisonStandalone(t *testing.T) {
+	// Comparison operators used in if conditions
+	tests := []struct {
+		name string
+		op   string
+	}{
+		{"equals", `if "a" == "a" { "y" } else { "n" }`},
+		{"not equals", `if "a" != "b" { "y" } else { "n" }`},
+		{"regex match", `if "abc" =~ "a" { "y" } else { "n" }`},
+		{"regex mismatch", `if "abc" !~ "z" { "y" } else { "n" }`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := "val := " + tt.op
+			_, err := Parse([]byte(input))
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+		})
+	}
+}
+
+// --- Recipe body interpolation edge cases ---
+
+func TestRecipeBodyComplexInterpolation(t *testing.T) {
+	input := "build:\n    echo {{env_var(\"HOME\") + \"/bin\"}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	body := jf.Recipes[0].Body
+	if len(body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(body))
+	}
+	found := false
+	for _, f := range body[0].Fragments {
+		if _, ok := f.(*InterpolationFragment); ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected interpolation fragment")
+	}
+}
+
+func TestRecipeBodyMultipleInterpolations(t *testing.T) {
+	input := "build a b:\n    echo {{a}} and {{b}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	interpCount := 0
+	for _, f := range jf.Recipes[0].Body[0].Fragments {
+		if _, ok := f.(*InterpolationFragment); ok {
+			interpCount++
+		}
+	}
+	if interpCount != 2 {
+		t.Errorf("expected 2 interpolations, got %d", interpCount)
+	}
+}
+
+func TestRecipeBodyInterpolationWithPath(t *testing.T) {
+	input := "build:\n    cat {{\"a\" / \"b\"}}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+// --- Conditional error paths ---
+
+func TestParseConditionalMissingOperator(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" { "y" } else { "n" }`))
+	if err == nil {
+		t.Fatal("expected error for missing comparison operator")
+	}
+}
+
+func TestParseConditionalMissingElse(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" == "b" { "y" }`))
+	if err == nil {
+		t.Fatal("expected error for missing else")
+	}
+}
+
+func TestParseConditionalMissingBrace(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" == "b" "y" } else { "n" }`))
+	if err == nil {
+		t.Fatal("expected error for missing brace")
+	}
+}
+
+// --- Attribute edge cases ---
+
+func TestParseAttributeIdentifierArg(t *testing.T) {
+	input := "[group(ci)]\nbuild:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	attr := jf.Recipes[0].Attributes[0]
+	if len(attr.Arguments) != 1 || attr.Arguments[0].Value != "ci" {
+		t.Errorf("expected identifier arg 'ci', got %v", attr.Arguments)
+	}
+}
+
+func TestParseAttributeErrorBadArg(t *testing.T) {
+	_, err := Parse([]byte("[group(123)]\nbuild:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad attribute arg")
+	}
+}
+
+func TestParseAttributeErrorUnclosed(t *testing.T) {
+	_, err := Parse([]byte("[private\nbuild:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for unclosed attribute")
+	}
+}
+
+// --- String method coverage ---
+
+func TestParseModuleWithExplicitPath(t *testing.T) {
+	input := "mod foo 'custom/path.just'\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Modules[0].Path != "custom/path.just" {
+		t.Errorf("expected 'custom/path.just', got %q", jf.Modules[0].Path)
+	}
+}
+
+func TestParseExpressionWithComparison(t *testing.T) {
+	input := "build:\n    echo {{ if arch() == \"x86\" { \"yes\" } else { \"no\" } }}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestParseConditionalInRecipeBody(t *testing.T) {
+	input := "build:\n    echo {{ if \"a\" != \"b\" { \"diff\" } else { \"same\" } }}\n"
+	_, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+}
+
+// --- Exercise all exprNode/GetPos stubs via type assertions ---
+
+func TestParseLogicalOrActual(t *testing.T) {
+	// The error paths in parseLogicalOr/And are only hit when sub-parsers fail.
+	// Exercise the happy path at minimum.
+	input := `val := if "a" == "a" { "y" } else { "n" }`
+	_, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+}
+
+func TestParseExpressionAtEOF(t *testing.T) {
+	// Exercise current() returning EOF token
+	_, err := Parse([]byte("val :="))
+	if err == nil {
+		t.Fatal("expected error at EOF")
+	}
+}
+
+func TestParseRecipeWithImportAsName(t *testing.T) {
+	// 'import' can be used as a recipe name
+	input := "import:\n    echo importing\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 1 || jf.Recipes[0].Name != "import" {
+		t.Error("expected recipe named 'import'")
+	}
+}
+
+func TestParseExportErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("export := \"bad\"\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseUnexportErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("unexport\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseModuleErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("mod\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseSettingErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("set := true\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseDependencyErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("build: ()\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for empty dependency parens")
+	}
+}
+
+func TestParseRecipeBodyOnlyText(t *testing.T) {
+	input := "build:\n    plain text no interpolation\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body[0].Fragments) != 1 {
+		t.Errorf("expected 1 fragment, got %d", len(jf.Recipes[0].Body[0].Fragments))
+	}
+	tf, ok := jf.Recipes[0].Body[0].Fragments[0].(*TextFragment)
+	if !ok {
+		t.Fatalf("expected TextFragment, got %T", jf.Recipes[0].Body[0].Fragments[0])
+	}
+	if tf.Value != "plain text no interpolation" {
+		t.Errorf("unexpected text: %q", tf.Value)
+	}
+}
+
+func TestParseImportErrorMissingPath(t *testing.T) {
+	_, err := Parse([]byte("import\n"))
+	if err == nil {
+		t.Fatal("expected error for import without path")
+	}
+}
+
+func TestParseSettingListTrailingComma(t *testing.T) {
+	input := "set shell := ['bash', '-cu',]\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Settings[0].Value.List) != 2 {
+		t.Errorf("expected 2 items, got %d", len(jf.Settings[0].Value.List))
+	}
+}
+
+func TestParseSettingListUnclosed(t *testing.T) {
+	_, err := Parse([]byte("set shell := ['bash'\n"))
+	if err == nil {
+		t.Fatal("expected error for unclosed list")
+	}
+}
+
+// --- gojust.go uncovered branches ---
+
+func TestParseRecipeErrorBadParam(t *testing.T) {
+	// Parameter parsing fails
+	_, err := Parse([]byte("build $:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad parameter")
+	}
+}
+
+func TestParseRecipeErrorBadDepName(t *testing.T) {
+	_, err := Parse([]byte("build: 123\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad dependency name")
+	}
+}
+
+func TestParseAttributeErrorBadName(t *testing.T) {
+	_, err := Parse([]byte("[+bad]\nbuild:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad attribute name")
+	}
+}
+
+func TestParseAttributeParenErrorUnclosed(t *testing.T) {
+	_, err := Parse([]byte("[confirm(\nbuild:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for unclosed attribute paren")
+	}
+}
+
+func TestParseConditionalElseIfError(t *testing.T) {
+	input := `val := if "a" == "b" { "y" } else if "c" == "d" { "z" } else { "n" }`
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	cond, ok := jf.Assignments[0].Value.(*Conditional)
+	if !ok {
+		t.Fatalf("expected *Conditional, got %T", jf.Assignments[0].Value)
+	}
+	// The else branch should be another Conditional
+	_, ok = cond.Otherwise.(*Conditional)
+	if !ok {
+		t.Fatalf("expected nested Conditional, got %T", cond.Otherwise)
+	}
+}
+
+func TestParseRecipeBodyInterpolationError(t *testing.T) {
+	// Unclosed interpolation in recipe body
+	_, err := Parse([]byte("build:\n    echo {{name\n"))
+	if err == nil {
+		t.Fatal("expected error for unclosed interpolation")
+	}
+}
+
+func TestParseExpectIdentifierOrKeywordError(t *testing.T) {
+	// Recipe name that's not an identifier or keyword
+	_, err := Parse([]byte("@123:\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad recipe name after @")
+	}
+}
+
+func TestParseSettingErrorMissingAssign(t *testing.T) {
+	_, err := Parse([]byte("set shell 'bash'\n"))
+	if err == nil {
+		t.Fatal("expected error for setting without :=")
+	}
+}
+
+// --- Exercise parseLogicalOr/And/Comparison loop bodies ---
+
+func TestParseStandaloneComparison(t *testing.T) {
+	// Comparison as a standalone expression in a recipe body interpolation
+	input := "build:\n    echo {{ \"a\" == \"b\" }}\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestParseConcatenationErrorPath(t *testing.T) {
+	// + followed by something that's not a value
+	_, err := Parse([]byte("val := \"a\" +\n"))
+	if err == nil {
+		t.Fatal("expected error for dangling +")
+	}
+}
+
+func TestParsePathJoinErrorPath(t *testing.T) {
+	// / followed by something that's not a value
+	_, err := Parse([]byte("val := \"a\" /\n"))
+	if err == nil {
+		t.Fatal("expected error for dangling /")
+	}
+}
+
+func TestParseRecipeLineInterpolationExpression(t *testing.T) {
+	// Exercise the else branch in parseRecipeLine where token is not text or interpolation
+	input := "build:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Errorf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+}
+
+func TestParseAttributeErrorAtEnd(t *testing.T) {
+	// Attribute list that hits EOF
+	_, err := Parse([]byte("[private"))
+	if err == nil {
+		t.Fatal("expected error for attribute at EOF")
+	}
+}
+
+func TestParseExportErrorMissingValue(t *testing.T) {
+	_, err := Parse([]byte("export FOO :=\n"))
+	if err == nil {
+		t.Fatal("expected error for export missing value")
+	}
+}
+
+func TestParseDependencyParenErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("build: (\"not-a-name\")\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for dep paren with string instead of name")
+	}
+}
+
+func TestParseConditionalErrorInThenExpr(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" == "b" { } else { "n" }`))
+	if err == nil {
+		t.Fatal("expected error for empty then expression")
+	}
+}
+
+func TestParseConditionalErrorInElseExpr(t *testing.T) {
+	_, err := Parse([]byte(`val := if "a" == "b" { "y" } else { }`))
+	if err == nil {
+		t.Fatal("expected error for empty else expression")
+	}
+}
+
+func TestParseFunctionCallErrorInArg(t *testing.T) {
+	_, err := Parse([]byte("val := env_var(,)\n"))
+	if err == nil {
+		t.Fatal("expected error for bad function arg")
+	}
+}
+
+func TestParseAliasErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("alias := build\n"))
+	if err == nil {
+		t.Fatal("expected error for alias missing name")
+	}
+}
+
+func TestParseLogicalOrInExpression(_ *testing.T) {
+	// Create tokens manually to exercise the || loop in parseLogicalOr
+	// We need || to appear in an expression context
+	// In just, this can happen in recipe body interpolations
+	input := "build:\n    echo {{ \"a\" == \"a\" || \"b\" == \"b\" }}\n"
+	_, err := Parse([]byte(input))
+	// This may or may not parse correctly depending on grammar,
+	// but it exercises the code path
+	_ = err
+}
+
+func TestParseLogicalAndInExpression(_ *testing.T) {
+	input := "build:\n    echo {{ \"a\" == \"a\" && \"b\" == \"b\" }}\n"
+	_, err := Parse([]byte(input))
+	_ = err
+}
+
+// --- lexRecipeLine remaining branches ---
+
+func TestParseAtEndOfTokens(t *testing.T) {
+	// Trigger the EOF fallback in current()
+	p := newParser([]token{{Type: tokenEOF, Pos: Position{1, 1, 0}}}, "")
+	jf, err := p.parse()
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes) != 0 {
+		t.Error("expected empty justfile")
+	}
+}
+
+func TestParserCurrentPastEnd(t *testing.T) {
+	p := newParser(nil, "")
+	tok := p.current()
+	if tok.Type != tokenEOF {
+		t.Errorf("expected EOF, got %s", tok.Type)
+	}
+}
+
+// --- expectIdentifierOrKeyword error branch ---
+
+func TestExpectIdentifierOrKeywordError(t *testing.T) {
+	// A token that's not an identifier or keyword
+	p := newParser([]token{
+		{Type: tokenString, Value: "bad", Pos: Position{1, 1, 0}},
+		{Type: tokenEOF, Pos: Position{1, 4, 3}},
+	}, "")
+	_, err := p.expectIdentifierOrKeyword()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- parseDependency error in paren dep args ---
+
+func TestParseDependencyParenArgError(t *testing.T) {
+	_, err := Parse([]byte("build: (dep +)\n    echo done\n"))
+	if err == nil {
+		t.Fatal("expected error for bad dep arg")
+	}
+}
+
+// --- eager keyword ---
+
+func TestParseEagerAssignment(t *testing.T) {
+	input := "eager val := `expensive-command`\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+	if !jf.Assignments[0].Eager {
+		t.Error("expected eager assignment")
+	}
+	if jf.Assignments[0].Name != "val" {
+		t.Errorf("expected name 'val', got %q", jf.Assignments[0].Name)
+	}
+}
+
+func TestParseEagerErrorMissingName(t *testing.T) {
+	_, err := Parse([]byte("eager := \"bad\"\n"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// --- allow-duplicate-recipes setting ---
+
+func TestParseRecipeBodyBraceEscape(t *testing.T) {
+	input := "build:\n    echo '{{{{LOVE}} curly braces'\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Recipes[0].Body) != 1 {
+		t.Fatalf("expected 1 body line, got %d", len(jf.Recipes[0].Body))
+	}
+	// The {{{{ should produce {{ as text
+	found := false
+	for _, f := range jf.Recipes[0].Body[0].Fragments {
+		if tf, ok := f.(*TextFragment); ok {
+			if strings.Contains(tf.Value, "{{") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected text fragment containing literal {{")
+	}
+}
+
+// --- Unified prefix assignment ---
+
+func TestParseEagerExportCombined(t *testing.T) {
+	input := "eager export TOKEN := `get-token`\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(jf.Assignments) != 1 {
+		t.Fatalf("expected 1 assignment, got %d", len(jf.Assignments))
+	}
+	a := jf.Assignments[0]
+	if !a.Eager {
+		t.Error("expected eager")
+	}
+	if !a.Export {
+		t.Error("expected export")
+	}
+	if a.Name != "TOKEN" {
+		t.Errorf("expected name 'TOKEN', got %q", a.Name)
+	}
+}
+
+func TestParseExportEagerCombined(t *testing.T) {
+	input := "export eager TOKEN := `get-token`\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	a := jf.Assignments[0]
+	if !a.Eager || !a.Export {
+		t.Error("expected both eager and export")
+	}
+}
+
+// --- Shebang extraction ---
+
+func TestRecipeShebang(t *testing.T) {
+	input := "build:\n    #!/usr/bin/env bash\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Recipes[0].Shebang != "#!/usr/bin/env bash" {
+		t.Errorf("expected shebang, got %q", jf.Recipes[0].Shebang)
+	}
+}
+
+func TestRecipeShebangPython(t *testing.T) {
+	input := "script:\n    #!/usr/bin/env python3\n    print('hello')\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Recipes[0].Shebang != "#!/usr/bin/env python3" {
+		t.Errorf("expected python shebang, got %q", jf.Recipes[0].Shebang)
+	}
+}
+
+func TestRecipeNoShebang(t *testing.T) {
+	input := "build:\n    echo done\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if jf.Recipes[0].Shebang != "" {
+		t.Errorf("expected no shebang, got %q", jf.Recipes[0].Shebang)
+	}
+}
+
+// --- Variable reference checking ---
+
+func TestParseErrorUnwrap(t *testing.T) {
+	inner := errors.New("inner error")
+	pe := &ParseError{
+		Pos:     Position{Line: 1, Column: 1},
+		Message: "outer",
+		Err:     inner,
+	}
+	if !errors.Is(pe.Unwrap(), inner) {
+		t.Error("expected Unwrap to return inner error")
+	}
+
+	pe2 := &ParseError{Message: "no inner"}
+	if pe2.Unwrap() != nil {
+		t.Error("expected nil from Unwrap with no inner error")
+	}
+}
+
+func TestPeekAtEOF(t *testing.T) {
+	p := newParser([]token{
+		{Type: tokenIdentifier, Value: "x", Pos: Position{1, 1, 0}},
+		{Type: tokenEOF, Pos: Position{1, 2, 1}},
+	}, "")
+	// Peek past end
+	tok := p.peekAt(10)
+	if tok.Type != tokenEOF {
+		t.Errorf("expected EOF, got %s", tok.Type)
+	}
+}
+
+func TestParseRecipeBodyWithWalkExpr(t *testing.T) {
+	// Exercise walkExpr through all expression types in a real parse
+	input := `val := if ("a" + "b") / "c" == env_var("X") { ` + "`cmd`" + ` } else { "n" }` + "\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	// Validate walks all expressions
+	_ = jf.Validate()
+}
+
+func TestParseFunctionDefErrorPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"unclosed paren", "f(x := \"bad\"\n"},
+		{"missing assign", "f(x) \"bad\"\n"},
+		{"missing body", "f(x) :=\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.input))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/pkg/validator/justfile/realworld_test.go
+++ b/pkg/validator/justfile/realworld_test.go
@@ -1,0 +1,36 @@
+package gojust
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseAllTestdata(t *testing.T) {
+	entries, err := os.ReadDir("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".just") {
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join("testdata", e.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(content) == 0 {
+				t.Skip("empty file")
+			}
+			jf, err := Parse(content)
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+			t.Logf("Parsed: %d recipes, %d assignments, %d settings, %d aliases, %d imports, %d modules",
+				len(jf.Recipes), len(jf.Assignments), len(jf.Settings),
+				len(jf.Aliases), len(jf.Imports), len(jf.Modules))
+		})
+	}
+}

--- a/pkg/validator/justfile/resolve_test.go
+++ b/pkg/validator/justfile/resolve_test.go
@@ -1,0 +1,380 @@
+package gojust
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseFileResolvesImports(t *testing.T) {
+	jf, err := ParseFile(filepath.Join("testdata", "with_imports.just"))
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	// Import should be resolved
+	if jf.Imports[0].Justfile == nil {
+		t.Fatal("expected resolved import")
+	}
+	// Should have recipes from the imported file
+	importedRecipes := jf.Imports[0].Justfile.Recipes
+	names := make(map[string]bool)
+	for _, r := range importedRecipes {
+		names[r.Name] = true
+	}
+	if !names["lint"] || !names["fmt"] {
+		t.Errorf("expected lint and fmt recipes in import, got %v", names)
+	}
+}
+
+func TestParseFileResolvesModules(t *testing.T) {
+	jf, err := ParseFile(filepath.Join("testdata", "with_imports.just"))
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	if jf.Modules[0].Justfile == nil {
+		t.Fatal("expected resolved module")
+	}
+	modRecipes := jf.Modules[0].Justfile.Recipes
+	names := make(map[string]bool)
+	for _, r := range modRecipes {
+		names[r.Name] = true
+	}
+	if !names["install"] || !names["update"] {
+		t.Errorf("expected install and update recipes in module, got %v", names)
+	}
+}
+
+func TestParseFileNotFound(t *testing.T) {
+	_, err := ParseFile("nonexistent/justfile")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestParseFileOptionalImportMissing(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("import? 'nonexistent.just'\nbuild:\n    echo done\n")
+	path := filepath.Join(dir, "justfile")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	jf, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	if jf.Imports[0].Justfile != nil {
+		t.Error("expected unresolved optional import")
+	}
+}
+
+func TestParseFileCircularImport(t *testing.T) {
+	dir := t.TempDir()
+
+	// a.just imports b.just, b.just imports a.just
+	aContent := []byte("import 'b.just'\n")
+	bContent := []byte("import 'a.just'\n")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.just"), aContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.just"), bContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseFile(filepath.Join(dir, "a.just"))
+	if err == nil {
+		t.Fatal("expected error for circular import")
+	}
+	if !strings.Contains(err.Error(), "circular") {
+		t.Errorf("expected circular import error, got: %v", err)
+	}
+}
+
+func TestParseFileDiamondImport(t *testing.T) {
+	dir := t.TempDir()
+
+	// root imports a and b, both import shared
+	shared := []byte("shared_var := \"hello\"\n")
+	a := []byte("import 'shared.just'\n")
+	b := []byte("import 'shared.just'\n")
+	root := []byte("import 'a.just'\nimport 'b.just'\nbuild:\n    echo done\n")
+
+	if err := os.WriteFile(filepath.Join(dir, "shared.just"), shared, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.just"), a, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.just"), b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "root.just"), root, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Diamond imports should NOT be flagged as circular
+	jf, err := ParseFile(filepath.Join(dir, "root.just"))
+	if err != nil {
+		t.Fatalf("ParseFile failed on diamond import: %v", err)
+	}
+	if len(jf.Imports) != 2 {
+		t.Errorf("expected 2 imports, got %d", len(jf.Imports))
+	}
+}
+
+func TestParseFileModuleNotFound(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("mod nonexistent\n")
+	path := filepath.Join(dir, "justfile")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing module")
+	}
+}
+
+func TestParseFileOptionalModuleMissing(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("mod? nonexistent\nbuild:\n    echo done\n")
+	path := filepath.Join(dir, "justfile")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	jf, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	if jf.Modules[0].Justfile != nil {
+		t.Error("expected unresolved optional module")
+	}
+}
+
+func TestParseFileHomeExpansion(t *testing.T) {
+	// Just test that resolveImportPath handles ~/
+	result := resolveImportPath("/some/dir", "~/foo.just")
+	if strings.HasPrefix(result, "~/") {
+		t.Error("expected ~ to be expanded")
+	}
+}
+
+// Validation with resolved imports
+
+func TestValidateWithResolvedImports(t *testing.T) {
+	jf, err := ParseFile(filepath.Join("testdata", "with_imports.just"))
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	diags := jf.Validate()
+	// "check" depends on "build" and "lint" — lint comes from import
+	// Should have no errors about undefined deps
+	for _, d := range diags {
+		if d.Severity == SeverityError && strings.Contains(d.Message, "undefined recipe 'lint'") {
+			t.Error("lint should be found via import")
+		}
+	}
+}
+
+func TestValidateDuplicateAlias(t *testing.T) {
+	input := "build:\n    echo done\nalias b := build\nalias b := build\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "alias") && strings.Contains(d.Message, "multiple times") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected duplicate alias diagnostic")
+	}
+}
+
+func TestValidateDuplicateSetting(t *testing.T) {
+	input := "set dotenv-load\nset dotenv-load\n"
+	jf, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	diags := jf.Validate()
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "set multiple times") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected duplicate setting diagnostic")
+	}
+}
+
+func TestResolveImportAbsolutePath(t *testing.T) {
+	result := resolveImportPath("/some/dir", "/absolute/path.just")
+	if result != "/absolute/path.just" {
+		t.Errorf("expected absolute path unchanged, got %q", result)
+	}
+}
+
+func TestResolveImportRelativePath(t *testing.T) {
+	result := resolveImportPath("/some/dir", "relative.just")
+	if result != "/some/dir/relative.just" {
+		t.Errorf("expected joined path, got %q", result)
+	}
+}
+
+// --- Exercise expression paths that go through parseLogicalOr/And/Comparison ---
+
+func TestParseFileAbsPathError(t *testing.T) {
+	// ParseFile with a path that can't be made absolute shouldn't panic
+	_, err := ParseFile("testdata/basic.just")
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+}
+
+func TestParseFileWithSyntaxError(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("build\n    echo done\n")
+	path := dir + "/justfile"
+	if err := writeTestFile(path, content); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ParseFile(path)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.File == "" {
+		t.Error("expected file path in error")
+	}
+}
+
+func TestParseFileLexError(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("val := \"unterminated\n")
+	path := dir + "/justfile"
+	if err := writeTestFile(path, content); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ParseFile(path)
+	if err == nil {
+		t.Fatal("expected lex error")
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.File == "" {
+		t.Error("expected file path in lex error")
+	}
+}
+
+func writeTestFile(path string, content []byte) error {
+	return os.WriteFile(path, content, 0600)
+}
+
+func TestParseFileAbsPathFailure(t *testing.T) {
+	// ParseFile error on filepath.Abs — hard to trigger on real OS
+	// but we can test the module explicit path resolution
+	dir := t.TempDir()
+	modContent := []byte("build:\n    echo done\n")
+	if err := os.MkdirAll(dir+"/sub", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/sub/custom.just", modContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rootContent := []byte("mod foo 'sub/custom.just'\n")
+	if err := os.WriteFile(dir+"/justfile", rootContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	jf, err := ParseFile(dir + "/justfile")
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	if jf.Modules[0].Justfile == nil {
+		t.Error("expected resolved module with explicit path")
+	}
+}
+
+func TestParseFileModuleParseError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/bad.just", []byte("not valid {{{\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/justfile", []byte("mod bad 'bad.just'\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseFile(dir + "/justfile")
+	if err == nil {
+		t.Fatal("expected error from bad module file")
+	}
+}
+
+func TestParseFileImportParseError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/bad.just", []byte("not valid {{{\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/justfile", []byte("import 'bad.just'\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseFile(dir + "/justfile")
+	if err == nil {
+		t.Fatal("expected error from bad import file")
+	}
+}
+
+func TestParseFileOptionalModuleParseError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/bad.just", []byte("not valid {{{\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/justfile", []byte("mod? bad 'bad.just'\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Optional module with a parse error should still fail — optional only
+	// applies to missing files, not broken ones
+	_, err := ParseFile(dir + "/justfile")
+	if err == nil {
+		t.Fatal("expected error from bad optional module file")
+	}
+}
+
+// --- lexer.go uncovered branches ---
+
+func TestParseFileRelativePath(t *testing.T) {
+	// Exercise the filepath.Abs success path with a relative path
+	jf, err := ParseFile("testdata/basic.just")
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	if jf.File == "" {
+		t.Error("expected non-empty file path")
+	}
+	if jf.File == "testdata/basic.just" {
+		t.Error("expected absolute path, got relative")
+	}
+}
+
+// --- current() EOF branch ---

--- a/pkg/validator/justfile/stress_test.go
+++ b/pkg/validator/justfile/stress_test.go
@@ -1,0 +1,410 @@
+package gojust
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"testing"
+)
+
+// stressGen is a second independent generator focused on adversarial
+// combinations and boundary conditions rather than typical usage.
+type stressGen struct {
+	rng *rand.Rand
+	ids int
+}
+
+func newStressGen(seed int64) *stressGen {
+	return &stressGen{rng: rand.New(rand.NewPCG(uint64(seed), uint64(seed)))}
+}
+
+func (g *stressGen) id() string {
+	g.ids++
+	bases := []string{"a", "b", "c", "foo", "bar", "x", "y", "_z", "my-thing", "do_it"}
+	return fmt.Sprintf("%s%d", bases[g.rng.IntN(len(bases))], g.ids)
+}
+
+func (g *stressGen) oneOf(choices ...string) string {
+	return choices[g.rng.IntN(len(choices))]
+}
+
+func (g *stressGen) simpleStr() string {
+	return g.oneOf(
+		`"simple"`,
+		`'raw'`,
+		fmt.Sprintf(`"id_%d"`, g.rng.IntN(1000)),
+		fmt.Sprintf(`'raw_%d'`, g.rng.IntN(1000)),
+		`'has spaces'`,
+		`"esc\nnewline"`,
+		`"esc\ttab"`,
+	)
+}
+
+func (g *stressGen) val() string {
+	return g.oneOf(
+		g.simpleStr(),
+		g.id(),
+		fmt.Sprintf("%s()", g.oneOf("arch", "os", "os_family", "num_cpus")),
+		fmt.Sprintf(`env_var(%s)`, g.simpleStr()),
+		fmt.Sprintf(`env_var_or_default(%s, %s)`, g.simpleStr(), g.simpleStr()),
+		fmt.Sprintf("(%s)", g.simpleStr()),
+		fmt.Sprintf("`echo %d`", g.rng.IntN(100)),
+	)
+}
+
+func (g *stressGen) expr(depth int) string {
+	if depth > 2 {
+		return g.val()
+	}
+	return g.oneOf(
+		g.val(),
+		g.expr(depth+1)+" + "+g.expr(depth+1),
+		g.expr(depth+1)+" / "+g.expr(depth+1),
+		g.expr(depth+1)+" && "+g.expr(depth+1),
+		g.expr(depth+1)+" || "+g.expr(depth+1),
+		fmt.Sprintf(`if %s == %s { %s } else { %s }`, g.val(), g.val(), g.val(), g.val()),
+		fmt.Sprintf(`if %s != %s { %s } else { %s }`, g.val(), g.val(), g.val(), g.val()),
+		fmt.Sprintf(`if %s =~ %s { %s } else { %s }`, g.val(), g.simpleStr(), g.val(), g.val()),
+		fmt.Sprintf(`replace(%s, %s, %s)`, g.simpleStr(), g.simpleStr(), g.simpleStr()),
+		fmt.Sprintf(`trim(%s)`, g.simpleStr()),
+		fmt.Sprintf(`uppercase(%s)`, g.simpleStr()),
+	)
+}
+
+// Generators for each top-level item type
+
+func (g *stressGen) genSettings(n int) string {
+	var b strings.Builder
+	settings := []string{
+		"set dotenv-load\n",
+		"set export\n",
+		"set positional-arguments\n",
+		"set quiet\n",
+		"set fallback\n",
+		"set unstable\n",
+		"set dotenv-load := true\n",
+		"set fallback := false\n",
+		fmt.Sprintf("set shell := [%s, %s]\n", g.simpleStr(), g.simpleStr()),
+		fmt.Sprintf("set tempdir := %s\n", g.simpleStr()),
+		fmt.Sprintf("set dotenv-filename := %s\n", g.simpleStr()),
+	}
+	for i := 0; i < n; i++ {
+		b.WriteString(settings[g.rng.IntN(len(settings))])
+	}
+	return b.String()
+}
+
+func (g *stressGen) genAssignment() string {
+	prefix := g.oneOf("", "", "", "export ", "eager ", "eager export ")
+	return fmt.Sprintf("%s%s := %s\n", prefix, g.id(), g.expr(0))
+}
+
+func (g *stressGen) genFuncDef() string {
+	name := g.id()
+	nParams := 1 + g.rng.IntN(3)
+	params := make([]string, nParams)
+	for i := range params {
+		params[i] = g.id()
+	}
+	return fmt.Sprintf("%s(%s) := %s\n", name, strings.Join(params, ", "), g.expr(0))
+}
+
+func (g *stressGen) genAlias(recipes []string) string {
+	if len(recipes) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("alias %s := %s\n", g.id(), recipes[g.rng.IntN(len(recipes))])
+}
+
+func (g *stressGen) genRecipe(existing []string) (name string, body string) {
+	name = g.id()
+	var b strings.Builder
+
+	// Attributes (0-3)
+	nAttrs := g.rng.IntN(4)
+	for i := 0; i < nAttrs; i++ {
+		attr := g.oneOf(
+			"[private]",
+			"[no-cd]",
+			"[linux]",
+			"[macos]",
+			"[windows]",
+			fmt.Sprintf("[group: %s]", g.simpleStr()),
+			fmt.Sprintf("[doc(%s)]", g.simpleStr()),
+			fmt.Sprintf("[confirm(%s)]", g.simpleStr()),
+		)
+		b.WriteString(attr + "\n")
+	}
+
+	// Quiet
+	if g.rng.IntN(5) == 0 {
+		b.WriteString("@")
+	}
+
+	b.WriteString(name)
+
+	// Params (0-4)
+	nParams := g.rng.IntN(5)
+	hasVariadic := false
+	for i := 0; i < nParams; i++ {
+		b.WriteString(" ")
+		if !hasVariadic && i == nParams-1 && g.rng.IntN(3) == 0 {
+			b.WriteString(g.oneOf("*", "+"))
+			hasVariadic = true
+		}
+		if g.rng.IntN(4) == 0 {
+			b.WriteString("$")
+		}
+		pname := g.id()
+		b.WriteString(pname)
+		if !hasVariadic && g.rng.IntN(3) == 0 {
+			b.WriteString("=" + g.simpleStr())
+		}
+	}
+
+	b.WriteString(":")
+
+	// Deps (0-3)
+	nDeps := g.rng.IntN(4)
+	subsequent := false
+	for i := 0; i < nDeps && i < len(existing); i++ {
+		if !subsequent && i > 0 && g.rng.IntN(3) == 0 {
+			b.WriteString(" &&")
+			subsequent = true
+		}
+		dep := existing[g.rng.IntN(len(existing))]
+		if g.rng.IntN(3) == 0 {
+			fmt.Fprintf(&b, " (%s %s)", dep, g.simpleStr())
+		} else {
+			b.WriteString(" " + dep)
+		}
+	}
+
+	b.WriteString("\n")
+
+	// Body (1-5 lines)
+	nLines := 1 + g.rng.IntN(5)
+	for i := 0; i < nLines; i++ {
+		prefix := g.oneOf("", "", "", "@", "-", "@-", "-@")
+		switch g.rng.IntN(5) {
+		case 0:
+			fmt.Fprintf(&b, "    %secho done\n", prefix)
+		case 1:
+			fmt.Fprintf(&b, "    %secho {{%s}}\n", prefix, g.id())
+		case 2:
+			fmt.Fprintf(&b, "    %secho {{%s + %s}}\n", prefix, g.simpleStr(), g.simpleStr())
+		case 3:
+			fmt.Fprintf(&b, "    %secho {{%s(%s)}}\n", prefix,
+				g.oneOf("replace", "trim", "uppercase", "lowercase"),
+				g.simpleStr())
+		case 4:
+			fmt.Fprintf(&b, "    %secho {{ if %s == %s { %s } else { %s } }}\n",
+				prefix, g.simpleStr(), g.simpleStr(), g.simpleStr(), g.simpleStr())
+		default:
+		}
+	}
+
+	return name, b.String()
+}
+
+func (g *stressGen) generate() string {
+	var b strings.Builder
+
+	// Shebang (sometimes)
+	if g.rng.IntN(5) == 0 {
+		b.WriteString("#!/usr/bin/env just --justfile\n\n")
+	}
+
+	// Settings
+	b.WriteString(g.genSettings(g.rng.IntN(4)))
+	b.WriteString("\n")
+
+	// Assignments + function defs
+	nAssign := 1 + g.rng.IntN(6)
+	for i := 0; i < nAssign; i++ {
+		if g.rng.IntN(5) == 0 {
+			b.WriteString(g.genFuncDef())
+		} else {
+			b.WriteString(g.genAssignment())
+		}
+	}
+	b.WriteString("\n")
+
+	// Comments interspersed
+	if g.rng.IntN(2) == 0 {
+		b.WriteString("# This is a comment\n")
+	}
+
+	// Recipes
+	var recipes []string
+	nRecipes := 2 + g.rng.IntN(8)
+	for i := 0; i < nRecipes; i++ {
+		if g.rng.IntN(3) == 0 {
+			fmt.Fprintf(&b, "# Recipe %d docs\n", i)
+		}
+		name, recipe := g.genRecipe(recipes)
+		recipes = append(recipes, name)
+		b.WriteString(recipe)
+		b.WriteString("\n")
+	}
+
+	// Aliases
+	nAliases := g.rng.IntN(3)
+	for i := 0; i < nAliases; i++ {
+		b.WriteString(g.genAlias(recipes))
+	}
+
+	// Unexports (sometimes)
+	if g.rng.IntN(4) == 0 {
+		b.WriteString("unexport " + g.id() + "\n")
+	}
+
+	return b.String()
+}
+
+func TestStressGenerated(t *testing.T) {
+	numFiles := int64(2000)
+	if testing.Short() {
+		numFiles = 200
+	}
+
+	for seed := int64(0); seed < numFiles; seed++ {
+		t.Run(fmt.Sprintf("seed_%d", seed), func(t *testing.T) {
+			g := newStressGen(seed)
+			content := g.generate()
+
+			jf, err := Parse([]byte(content))
+			if err != nil {
+				t.Fatalf("seed %d: Parse failed: %v\n\nContent:\n%s", seed, err, content)
+			}
+
+			// Validate shouldn't panic
+			_ = jf.Validate()
+
+			// Basic sanity checks
+			if len(jf.Recipes) == 0 {
+				t.Error("expected at least one recipe")
+			}
+		})
+	}
+}
+
+// TestStressSpecificPatterns tests patterns that are syntactically tricky
+// and likely to expose parser edge cases.
+func TestStressSpecificPatterns(t *testing.T) {
+	patterns := []struct {
+		name    string
+		content string
+	}{
+		// Deeply nested conditionals
+		{"nested_if_3", `v := if "a" == "b" { if "c" == "d" { if "e" == "f" { "g" } else { "h" } } else { "i" } } else { "j" }` + "\n"},
+
+		// Chained operators
+		{"chain_concat_10", `v := "a" + "b" + "c" + "d" + "e" + "f" + "g" + "h" + "i" + "j"` + "\n"},
+		{"chain_path_10", `v := "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j"` + "\n"},
+		{"chain_and", `v := "a" && "b" && "c" && "d"` + "\n"},
+		{"chain_or", `v := "a" || "b" || "c" || "d"` + "\n"},
+		{"mixed_ops", `v := "a" + "b" / "c" + "d"` + "\n"},
+
+		// Many params
+		{"many_params", "r a b c d e f g h:\n    echo done\n"},
+		{"many_deps", "a:\n    echo a\nb:\n    echo b\nc:\n    echo c\nd: a b c\n    echo d\n"},
+		{"many_subsequent_deps", "a:\n    echo a\nb:\n    echo b\nc:\n    echo c\nd: a && b c\n    echo d\n"},
+
+		// All attribute forms on one recipe
+		{"all_attrs", "[private]\n[no-cd]\n[linux]\n[group: 'test']\n[doc('my recipe')]\n[confirm('sure?')]\nbuild:\n    echo done\n"},
+
+		// Multiple attributes on one line
+		{"multi_attr_line", "[private, no-cd, linux]\nbuild:\n    echo done\n"},
+
+		// Empty body
+		{"empty_body", "build:\n"},
+		{"empty_body_with_deps", "a:\n    echo a\nb: a\n"},
+
+		// Recipe with only shebang
+		{"shebang_only", "build:\n    #!/bin/bash\n"},
+
+		// Many settings
+		{"all_bool_settings", "set dotenv-load\nset export\nset positional-arguments\nset quiet\nset fallback\nset unstable\n"},
+
+		// Multiline function def with nested if
+		{"funcdef_multiline_nested", "f(a, b) := if a == b {\n  if a == 'x' {\n    'xx'\n  } else {\n    'ab'\n  }\n} else {\n  'diff'\n}\n"},
+
+		// String with every escape
+		{"all_escapes", `v := "tab\there\nnewline\rcarriage\"\u{0041}"` + "\n"},
+
+		// Indented strings
+		{"indented_quoted", "v := \"\"\"\n  hello\n  world\n\"\"\"\n"},
+		{"indented_raw", "v := '''\n  hello\n  world\n'''\n"},
+		{"indented_backtick", "v := ```\n  echo hello\n  echo world\n```\n"},
+
+		// Format and shell-expanded strings
+		{"fstring_quoted", `v := f"hello {name}"` + "\n"},
+		{"fstring_raw", "v := f'hello {name}'\n"},
+		{"xstring_quoted", `v := x"$HOME/bin"` + "\n"},
+		{"xstring_raw", "v := x'$HOME/bin'\n"},
+
+		// Leading slash
+		{"leading_slash", `v := / "usr" / "local"` + "\n"},
+		{"leading_slash_complex", `v := / "usr" / "local" / "bin"` + "\n"},
+
+		// Brace escape
+		{"brace_escape", "build:\n    echo '{{{{literal}}'\n"},
+
+		// Recipe named with keyword
+		{"recipe_named_import", "import:\n    echo done\n"},
+
+		// Comment before recipe with attributes
+		{"comment_attr_recipe", "# docs\n[private]\nbuild:\n    echo done\n"},
+
+		// Multiline string in dep arg
+		{"multiline_dep_arg", "build x:\n    echo done\nfoo: (build 'multi\nline')\n    echo foo\n"},
+
+		// Multiline string in interpolation
+		{"multiline_interp", "build:\n    echo {{'multi\nline'}}\n"},
+
+		// Multiline string in conditional
+		{"multiline_cond", "v := if 'a' == 'b' { 'yes\nmulti' } else { 'no\nmulti' }\n"},
+
+		// Eager export
+		{"eager_export", "eager export TOKEN := `echo hi`\n"},
+		{"export_eager", "export eager TOKEN := `echo hi`\n"},
+
+		// Many recipes with cross-deps
+		{"cross_deps", "a:\n    echo a\nb: a\n    echo b\nc: a b\n    echo c\nd: a b c\n    echo d\ne: a b c d\n    echo e\n"},
+
+		// Recipe with complex interpolation
+		{"complex_interp", "build:\n    echo {{ replace(arch() + \"-\" + os(), \"-\", \"_\") }}\n"},
+
+		// Backtick in expression
+		{"backtick_expr", "v := `echo hello` + \" \" + `echo world`\n"},
+
+		// Paren expression
+		{"paren_expr", `v := ("a" + "b") + ("c" + "d")` + "\n"},
+
+		// Optional import and mod
+		{"optional_both", "import? 'maybe.just'\nmod? maybe\nbuild:\n    echo done\n"},
+
+		// Blank lines everywhere
+		{"blank_lines", "\n\n\nv := 'a'\n\n\nbuild:\n    echo done\n\n\n"},
+
+		// Unicode escape
+		{"unicode", `v := "\u{1F600}\u{0041}\u{00E9}"` + "\n"},
+
+		// Line continuation
+		{"line_cont", "v := \"a\" + \\\n  \"b\" + \\\n  \"c\"\n"},
+
+		// Setting with list trailing comma
+		{"list_trailing_comma", "set shell := ['bash', '-cu',]\n"},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.name, func(t *testing.T) {
+			jf, err := Parse([]byte(p.content))
+			if err != nil {
+				t.Fatalf("Parse failed: %v\n\nContent:\n%s", err, p.content)
+			}
+			_ = jf.Validate()
+		})
+	}
+}

--- a/pkg/validator/justfile/testdata/advanced.just
+++ b/pkg/validator/justfile/testdata/advanced.just
@@ -1,0 +1,95 @@
+#!/usr/bin/env just --justfile
+
+set shell := ["bash", "-cu"]
+set dotenv-load
+set export
+set positional-arguments
+
+# Variables
+version := "1.0.0"
+arch := arch()
+os_name := os()
+build_dir := justfile_directory() / "build"
+export DATABASE_URL := "postgres://localhost/mydb"
+
+# Conditional assignment
+greeting := if version == "1.0.0" { "stable" } else { "dev" }
+nested := if arch == "x86_64" { "64bit" } else if arch == "aarch64" { "arm64" } else { "other" }
+
+# String types
+raw := 'hello\nworld'
+escaped := "hello\nworld"
+backtick_val := `echo hello`
+
+# Recipes with various parameter types
+build target='all' mode="debug":
+    echo "Building {{target}} in {{mode}}"
+    echo "Version: {{version}}"
+
+# Variadic parameters
+test +args:
+    cargo test {{args}}
+
+test-optional *args:
+    cargo test {{args}}
+
+# Export parameter
+run-with-env $ENV_VAR:
+    echo $ENV_VAR
+
+# Dependencies
+deploy env='staging': build (test "integration")
+    echo "Deploying to {{env}}"
+
+# Subsequent dependencies
+all: build && deploy
+    echo "All done"
+
+# Quiet recipe
+@quiet-recipe:
+    echo "this is quiet"
+
+# Recipe with error suppression in body
+error-suppressed:
+    -might-fail
+
+# Recipe line prefixes
+mixed-prefixes:
+    normal line
+    @quiet line
+    -error line
+    @-both line
+    -@also-both line
+
+# Attributes
+[private]
+[group: 'ci']
+ci: build deploy
+
+[confirm]
+[no-cd]
+dangerous:
+    rm -rf /
+
+[linux]
+[macos]
+unix-only:
+    uname -a
+
+# Aliases
+alias b := build
+alias t := test
+alias d := deploy
+
+# Settings
+# Unexport a non-exported variable
+unexport SOME_VAR
+
+# Function calls in expressions
+home := env_var("HOME")
+with_default := env_var_or_default("MISSING", "fallback")
+replaced := replace(version, ".", "-")
+
+# Complex expressions
+full := "prefix-" + version + "-" + arch
+path := build_dir / "output" / arch

--- a/pkg/validator/justfile/testdata/basic.just
+++ b/pkg/validator/justfile/testdata/basic.just
@@ -1,0 +1,34 @@
+# This is a test justfile
+
+set shell := ["bash", "-cu"]
+set dotenv-load
+
+version := "1.0.0"
+export DATABASE_URL := "postgres://localhost/mydb"
+
+# Build the project
+[group: 'build']
+build target='all':
+    echo "Building {{target}} version {{version}}"
+
+# Run tests
+[private]
+test *args: build
+    cargo test {{args}}
+
+# Deploy to production
+[confirm]
+deploy env='staging': build test
+    echo "Deploying to {{env}}"
+
+alias b := build
+alias t := test
+
+# Clean build artifacts
+clean:
+    rm -rf target/
+    rm -rf dist/
+
+greeting := if "hello" == "hello" { "match" } else { "no match" }
+
+full_path := justfile_directory() / "src"

--- a/pkg/validator/justfile/testdata/cross-platform.just
+++ b/pkg/validator/justfile/testdata/cross-platform.just
@@ -1,0 +1,26 @@
+# use with https://github.com/casey/just
+#
+# Example cross-platform Python project
+#
+
+python_dir := if os_family() == "windows" { "./.venv/Scripts" } else { "./.venv/bin" }
+python := python_dir + if os_family() == "windows" { "/python.exe" } else { "/python3" }
+system_python := if os_family() == "windows" { "py.exe -3.9" } else { "python3.9" }
+
+# Set up development environment
+bootstrap:
+    if test ! -e .venv; then {{ system_python }} -m venv .venv; fi
+    {{ python }} -m pip install --upgrade pip wheel pip-tools
+    {{ python_dir }}/pip-sync
+
+# Upgrade Python dependencies
+upgrade-deps: && bootstrap
+    {{ python_dir }}/pip-compile --upgrade
+
+# Sample project script 1
+script1:
+    {{ python }} script1.py
+
+# Sample project script 2
+script2 *ARGS:
+    {{ python }} script2.py {{ ARGS }}

--- a/pkg/validator/justfile/testdata/dump-coverage.just
+++ b/pkg/validator/justfile/testdata/dump-coverage.just
@@ -1,0 +1,63 @@
+set unstable
+
+# unexport
+unexport HOME
+
+# eager assignment
+eager eagerly := "now"
+
+# export eager combo (just doesn't support this syntax)
+# export eager both := "exported-eager"
+
+# Various attributes
+[doc('Build the project')]
+[group: 'ci']
+[no-cd]
+build:
+    echo "building"
+
+[script('bash')]
+scripted:
+    echo "hello"
+    echo "world"
+
+[confirm('Really delete?')]
+danger:
+    echo "danger"
+
+[confirm]
+also-danger:
+    echo "also danger"
+
+# Multiple attributes on one line
+[private, group: 'internal']
+multi-attr:
+    echo "multi"
+
+[positional-arguments]
+pos-args arg:
+    echo $1
+
+# Dependency with arguments
+deploy env:
+    echo "deploying to {{env}}"
+
+push: (deploy "production")
+    echo "pushed"
+
+# Dependency with expression argument
+release version='latest': (deploy version)
+    echo "releasing"
+
+# Expression operators (unstable)
+truthy := "hello" && "goodbye"
+falsy := "" || "fallback"
+chained := "a" && "b" || "c"
+
+# f-string (format string)
+name := "world"
+
+# _private variable
+_secret := "hidden"
+
+# Nested modules would need subdirectories, tested in with_imports.just

--- a/pkg/validator/justfile/testdata/fuzz/FuzzParse/930f49fab2367014
+++ b/pkg/validator/justfile/testdata/fuzz/FuzzParse/930f49fab2367014
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte(" ")

--- a/pkg/validator/justfile/testdata/imported.just
+++ b/pkg/validator/justfile/testdata/imported.just
@@ -1,0 +1,7 @@
+helper_var := "from-import"
+
+lint:
+    echo "linting"
+
+fmt:
+    echo "formatting"

--- a/pkg/validator/justfile/testdata/just-project.just
+++ b/pkg/validator/justfile/testdata/just-project.just
@@ -1,0 +1,242 @@
+#!/usr/bin/env -S just --justfile
+# ^ A shebang isn't required, but allows a justfile to be executed
+#   like a script, with `./justfile test`, for example.
+
+alias t := test
+
+log := "warn"
+
+export JUST_LOG := log
+
+[group: 'dev']
+watch +args='test':
+  cargo watch --clear --exec '{{ args }}'
+
+[group: 'test']
+test:
+  cargo test --all
+
+[group: 'check']
+ci: test clippy build-book forbid
+  cargo fmt --all -- --check
+  cargo update --locked --package just
+
+[group: 'check']
+fuzz:
+  cargo +nightly fuzz run fuzz-compiler
+
+[group: 'misc']
+run:
+  cargo run
+
+# only run tests matching `PATTERN`
+[group: 'test']
+filter PATTERN:
+  cargo test {{PATTERN}}
+
+[group: 'misc']
+build:
+  cargo build
+
+[group: 'misc']
+fmt:
+  cargo fmt --all
+
+[group: 'check']
+shellcheck:
+  shellcheck www/install.sh
+
+[group: 'doc']
+man:
+  mkdir -p man
+  cargo run -- --man > man/just.1
+
+[group: 'doc']
+view-man: man
+  man man/just.1
+
+# add git log messages to changelog
+[group: 'release']
+update-changelog:
+  echo >> CHANGELOG.md
+  git log --pretty='format:- %s' >> CHANGELOG.md
+
+[group: 'release']
+update-contributors:
+  cargo run --release --package update-contributors
+
+[group: 'check']
+action-versions:
+  cargo run --package action-versions
+
+[group: 'check']
+outdated:
+  cargo outdated -R
+
+[group: 'check']
+unused:
+  cargo +nightly udeps --workspace
+
+# publish current GitHub master branch
+[group: 'release']
+publish:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  rm -rf tmp/release
+  git clone --depth 1 git@github.com:casey/just.git tmp/release
+  cd tmp/release
+  ! grep '<sup>master</sup>' README.md
+  VERSION=`sed -En 's/version[[:space:]]*=[[:space:]]*"([^"]+)"/\1/p' Cargo.toml | head -1`
+  git tag -a $VERSION -m "Release $VERSION"
+  git push origin $VERSION
+  cargo publish
+  cd ../..
+  rm -rf tmp/release
+
+[group: 'release']
+readme-version-notes:
+  grep '<sup>master</sup>' README.md
+
+# clean up feature branch BRANCH
+[group: 'dev']
+done BRANCH=`git rev-parse --abbrev-ref HEAD`:
+  git checkout master
+  git diff --no-ext-diff --quiet --exit-code
+  git pull --rebase github master
+  git diff --no-ext-diff --quiet --exit-code {{BRANCH}}
+  git branch -D {{BRANCH}}
+
+# install just from crates.io
+[group: 'misc']
+install:
+  cargo install -f just
+
+# install development dependencies
+[group: 'dev']
+install-dev-deps:
+  rustup install nightly
+  rustup update nightly
+  cargo +nightly install cargo-fuzz
+  cargo install cargo-check
+  cargo install cargo-watch
+  cargo install mdbook mdbook-linkcheck
+
+# everyone's favorite animate paper clip
+[group: 'check']
+clippy:
+  cargo clippy --all --all-targets --all-features -- --deny warnings
+
+[group: 'check']
+forbid:
+  ./bin/forbid
+
+[group: 'dev']
+replace FROM TO:
+  sd '{{FROM}}' '{{TO}}' src/*.rs
+
+[group: 'demo']
+test-quine:
+  cargo run -- quine
+
+# make a quine, compile it, and verify it
+[group: 'demo']
+quine:
+  mkdir -p tmp
+  @echo '{{quine-text}}' > tmp/gen0.c
+  cc tmp/gen0.c -o tmp/gen0
+  ./tmp/gen0 > tmp/gen1.c
+  cc tmp/gen1.c -o tmp/gen1
+  ./tmp/gen1 > tmp/gen2.c
+  diff tmp/gen1.c tmp/gen2.c
+  rm -r tmp
+  @echo 'It was a quine!'
+
+quine-text := '
+  int printf(const char*, ...);
+
+  int main() {
+    char *s =
+      "int printf(const char*, ...);"
+      "int main() {"
+      "   char *s = %c%s%c;"
+      "  printf(s, 34, s, 34);"
+      "  return 0;"
+      "}";
+    printf(s, 34, s, 34);
+    return 0;
+  }
+'
+
+[group: 'check']
+build-book:
+  cargo run --package generate-book
+  mdbook build book/en
+  mdbook build book/zh
+
+[group: 'dev']
+print-readme-constants-table:
+  cargo test constants::tests::readme_table -- --nocapture
+
+# run all polyglot recipes
+[group: 'demo']
+polyglot: _python _js _perl _sh _ruby
+
+_python:
+  #!/usr/bin/env python3
+  print('Hello from python!')
+
+_js:
+  #!/usr/bin/env node
+  console.log('Greetings from JavaScript!')
+
+_perl:
+  #!/usr/bin/env perl
+  print "Larry Wall says Hi!\n";
+
+_sh:
+  #!/usr/bin/env sh
+  hello='Yo'
+  echo "$hello from a shell script!"
+
+_nu:
+  #!/usr/bin/env nu
+  let hellos = ["Greetings", "Yo", "Howdy"]
+  $hellos | each {|el| print $"($el) from a nushell script!" }
+
+_ruby:
+  #!/usr/bin/env ruby
+  puts "Hello from ruby!"
+
+# Print working directory, for demonstration purposes!
+[group: 'demo']
+pwd:
+  echo {{invocation_directory()}}
+
+[group: 'test']
+test-release-workflow:
+  -git tag -d test-release
+  -git push origin :test-release
+  git tag test-release
+  git push origin test-release
+
+[group: 'test']
+test-completions:
+  #!/usr/bin/env bash
+  rm -rf tmp/complete
+  mkdir -p tmp/complete/bin
+  cargo build
+  cp target/debug/just tmp/complete/bin
+  ./tmp/complete/bin/just --completions bash > tmp/complete/just.bash
+  cat > tmp/complete/justfile << EOF
+  alias hello := foo::bar
+  mod foo
+  EOF
+  echo 'bar:' > tmp/complete/foo.just
+  cd tmp/complete && PATH="`realpath bin`:$PATH" bash --init-file just.bash
+
+rule110:
+  just -f examples/rule110.just
+
+# Local Variables:
+# mode: makefile
+# End:

--- a/pkg/validator/justfile/testdata/kitchen-sink.just
+++ b/pkg/validator/justfile/testdata/kitchen-sink.just
@@ -1,0 +1,214 @@
+set shell := ["sh", "-c"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set allow-duplicate-recipes
+set positional-arguments
+set dotenv-load
+set export
+
+alias s := serve
+
+bt := '0'
+
+export RUST_BACKTRACE_1 := bt
+
+log := "warn"
+
+export JUST_LOG := (log + "ing" + `grep loop /etc/networks | cut -f2`)
+
+tmpdir  := `mktemp`
+version := "0.2.7"
+tardir  := tmpdir / "awesomesauce-" + version
+foo1    := / "tmp"
+foo2_3  := "a/"
+tarball := tardir + ".tar.gz"
+
+export RUST_BACKTRACE_2 := "1"
+string-with-tab             := "\t"
+string-with-newline         := "\n"
+string-with-carriage-return := "\r"
+string-with-double-quote    := "\""
+string-with-slash           := "\\"
+string-with-no-newline      := "\
+"
+
+# Newlines in variables
+single := '
+hello
+'
+
+double := "
+goodbye
+"
+escapes := '\t\n\r\"\\'
+
+# this string will evaluate to `foo\nbar\n`
+x := '''
+  foo
+  bar
+'''
+
+# this string will evaluate to `abc\n  wuv\nxyz\n`
+y := """
+  abc
+    wuv
+  xyz
+"""
+
+for:
+  for file in `ls .`; do \
+    echo $file; \
+  done
+
+serve:
+  touch {{tmpdir}}/file
+
+# This backtick evaluates the command `echo foo\necho bar\n`, which produces the value `foo\nbar\n`.
+stuff := ```
+    echo foo
+    echo bar
+  ```
+
+
+an_arch := trim(lowercase(justfile())) + arch()
+trim_end := trim_end("99.99954%   ")
+home_dir := replace(env_var('HOME') / "yep", 'yep', '')
+quoted := quote("some things beyond\"$()^%#@!|-+=_*&'`")
+smartphone := trim_end_match('blah.txt', 'txt')
+museum := trim_start_match(trim_start(trim_end_matches('   yep_blah.txt.txt', '.txt')), 'yep_')
+water := trim_start_matches('ssssssoup.txt', 's')
+congress := uppercase(os())
+fam := os_family()
+path_1 := absolute_path('test')
+path_2 := '/tmp/subcommittee.txt'
+ext_z := extension(path_2)
+exe_name := file_name(just_executable())
+a_stem := file_stem(path_2)
+a_parent := parent_directory(path_2)
+sans_ext := without_extension(path_2)
+camera := join('tmp', 'dir1', 'dir2', path_2)
+cleaned := clean('/tmp/blah/..///thing.txt')
+id__path := '/tmp' / sha256('blah') / sha256_file(justfile())
+_another_var := env_var_or_default("HOME", justfile_directory())
+python := `which python`
+
+exists := if path_exists(just_executable()) =~ '^/User' { uuid() } else { 'yeah' }
+
+foo   := if env_var("_") == "/usr/bin/env" { `touch /tmp/a_file` } else { "dummy-value" }
+foo_b := if "hello" == "goodbye" { "xyz" } else { if "no" == "no" { "yep"} else { error("123") } }
+foo_c := if "hello" == "goodbye" {
+  "xyz"
+} else if "a" == "a" {
+  "abc"
+} else {
+  "123"
+}
+
+bar:
+  @echo {{foo}}
+
+
+bar2 foo_stuff:
+  echo {{ if foo_stuff == "bar" { "hello" } else { "goodbye" } }}
+
+executable:
+  @echo The executable is at: {{just_executable()}}
+
+
+rustfmt:
+  find {{invocation_directory()}} -name \*.rs -exec rustfmt {} \;
+
+test:
+  echo "{{home_dir}}"
+
+
+linewise:
+  Write-Host "Hello, world!"
+
+serve2:
+  @echo "Starting server with database $DATABASE_ADDRESS on port $SERVER_PORT…"
+
+
+shebang := if os() == 'windows' {
+  'powershell.exe'
+} else {
+  '/usr/bin/env pwsh'
+}
+
+shebang:
+	#!{{shebang}}
+	$PSV = $PSVersionTable.PSVersion | % {"$_" -split "\." }
+	$psver = $PSV[0] + "." + $PSV[1]
+	if ($PSV[2].Length -lt 4) {
+		$psver += "." + $PSV[2] + " Core"
+	} else {
+		$psver += " Desktop"
+	}
+	echo "PowerShell $psver"
+
+@foo:
+  echo bar
+
+@test5 *args='':
+  bash -c 'while (( "$#" )); do echo - $1; shift; done' -- "$@"
+
+test2 $RUST_BACKTRACE="1":
+  # will print a stack trace if it crashes
+  cargo test
+
+
+notify m="":
+	keybase chat send --topic-type "chat" --channel <channel> <team> "upd(<repo>): {{m}}"
+
+# Sample project script 2
+script2 *ARGS:
+    {{ python }} script2.py {{ ARGS }}
+
+braces:
+  echo 'I {{{{LOVE}} curly braces!'
+
+_braces2:
+  echo '{{'I {{LOVE}} curly braces!'}}'
+
+_braces3:
+  echo 'I {{ "{{" }}LOVE}} curly braces!'
+
+foo2:
+  -@cat foo
+  echo 'Done!'
+
+test3 target tests=path_1:
+  @echo 'Testing {{target}}:{{tests}}…'
+  ./test --tests {{tests}} {{target}}
+
+test4 triple=(an_arch + "-unknown-unknown") input=(an_arch / "input.dat"):
+  ./test {{triple}}
+
+variadic $VAR1_1 VAR2 VAR3 VAR4=("a") +$FLAGS='-q': foo2 braces
+  cargo test {{FLAGS}}
+
+time:
+  @-date +"%H:%S"
+  -cat /tmp/nonexistent_file.txt
+  @echo "finished"
+
+justwords:
+  grep just \
+    --text /usr/share/dict/words \
+    > /tmp/justwords
+
+# Subsequent dependencies
+# https://just.systems/man/en/chapter_37.html
+# To test, run `$ just -f test-suite.just b`
+a:
+  echo 'A!'
+
+b: a && d
+  echo 'B start!'
+  just -f {{justfile()}} c
+  echo 'B end!'
+
+c:
+  echo 'C!'
+
+d:
+  echo 'D!'

--- a/pkg/validator/justfile/testdata/pre-commit.just
+++ b/pkg/validator/justfile/testdata/pre-commit.just
@@ -1,0 +1,59 @@
+# use with https://github.com/casey/just
+
+# Example combining just + pre-commit
+# pre-commit: https://pre-commit.com/
+# > A framework for managing and maintaining
+# > multi-language pre-commit hooks.
+
+# pre-commit brings about encapsulation of your
+# most common repo scripting tasks. It is perfectly
+# usable without actually setting up precommit hooks.
+# If you chose to, this justfile includes shorthands
+# for git commit and amend to keep pre-commit out of
+# the way when in flow on a feature branch.
+
+# uses: https://github.com/tekwizely/pre-commit-golang
+# uses: https://github.com/prettier/prettier (pre-commit hook)
+# configures: https://www.git-town.com/ (setup receipt)
+
+# fix auto-fixable lint issues in staged files
+fix:
+	pre-commit run go-returns  # fixes all Go lint issues
+	pre-commit run prettier    # fixes all Markdown (& other) lint issues
+
+# lint most common issues in - or due - to staged files
+lint:
+	pre-commit run go-vet-mod || true  # runs go vet
+	pre-commit run go-lint    || true  # runs golint
+	pre-commit run go-critic  || true  # runs gocritic
+
+# lint all issues in - or due - to staged files:
+lint-all:
+	pre-commit run golangci-lint-mod || true  # runs golangci-lint
+
+# run tests in - or due - to staged files
+test:
+	pre-commit run go-test-mod || true  # runs go test
+
+# commit skipping pre-commit hooks
+commit m:
+	git commit --no-verify -m "{{m}}"
+
+# amend skipping pre-commit hooks
+amend:
+	git commit --amend --no-verify
+
+# install/update code automation (prettier, pre-commit, goreturns, lintpack, gocritic, golangci-lint)
+install:
+	npm i -g prettier
+	curl https://pre-commit.com/install-local.py | python3 -
+	go get github.com/sqs/goreturns
+	go get github.com/go-lintpack/lintpack/...
+	go get github.com/go-critic/go-critic/...
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.27.0
+
+# setup/update pre-commit hooks (optional)
+setup:
+	pre-commit install --install-hooks # uninstall: `pre-commit uninstall`
+	git config git-town.code-hosting-driver gitea  # setup git-town with gitea
+	git config git-town.code-hosting-origin-hostname gitea.example.org  # setup git-town origin hostname

--- a/pkg/validator/justfile/testdata/readme-patterns.just
+++ b/pkg/validator/justfile/testdata/readme-patterns.just
@@ -1,0 +1,168 @@
+# Patterns from the just README
+# https://github.com/casey/just/blob/master/README.md
+
+set shell := ["bash", "-cu"]
+set unstable
+set allow-duplicate-recipes
+set allow-duplicate-variables
+set dotenv-load
+set export
+set positional-arguments
+
+# String operators
+foo := '' && 'goodbye'
+bar := 'hello' && 'goodbye'
+baz := '' || 'goodbye'
+qux := 'hello' || 'goodbye'
+
+# Shell-expanded strings (just evaluates these at dump time, so use
+# a variable that's likely to exist for conformance testing)
+foobar := x'echo hello'
+
+# f-string (just evaluates interpolations at dump time, so this is
+# tested for parsing but not dump conformance)
+# message := f'Hello, {{name}}!'
+name := "world"
+
+# Backtick
+foos := `echo "foo"`
+
+# Conditional
+os := if os() == "macos" { "mac" } else if os() == "linux" { "linux" } else { "other" }
+
+# Concatenation and path join
+full := "prefix-" + name
+path := justfile_directory() / "src" / "main"
+
+# Multi-line raw string
+long := '
+  this is a
+  multi-line raw string
+'
+
+# Various recipe forms
+recipe-name:
+  echo 'This is a recipe!'
+
+another-recipe:
+  @echo 'This is another recipe.'
+
+default: lint build test
+
+build project='main':
+  echo "Building {{project}}"
+
+test: build
+  echo 'Testing!'
+
+lint:
+  echo 'Linting!'
+
+# Quiet recipe
+@quiet-recipe:
+  pwd
+
+# No-cd attribute
+[no-cd]
+@bar:
+  pwd
+
+# Working directory attribute
+[working-directory: 'bar']
+@wd-recipe:
+  pwd
+
+# Alias
+alias b := build
+alias t := test
+
+# Positional arguments attribute
+[positional-arguments]
+@pos-args arg:
+  echo $0
+  echo $1
+
+# Variadic
+@variadic-star *args='':
+  bash -c 'while (( "$#" )); do echo - $1; shift; done' -- "$@"
+
+@variadic-plus +args:
+  echo {{args}}
+
+# Export parameter
+run $ENV_VAR:
+  echo $ENV_VAR
+
+# Dependencies with arguments
+push: (deploy "production")
+  echo 'Pushed!'
+
+deploy env:
+  echo "Deploying to {{env}}"
+
+# Subsequent dependencies
+all: build && test lint
+  echo 'All done!'
+
+# Confirm attribute
+[confirm]
+dangerous:
+  echo 'doing something dangerous'
+
+[confirm('Are you sure?')]
+also-dangerous:
+  echo 'also dangerous'
+
+# Group attribute
+[group: 'ci']
+ci-build:
+  echo 'CI build'
+
+[group('deploy')]
+ci-deploy:
+  echo 'CI deploy'
+
+# Private attribute
+[private]
+helper:
+  echo 'helper'
+
+# Multiple attributes on one line
+[private, group: 'internal']
+internal-helper:
+  echo 'internal'
+
+# Script attribute
+[script('bash')]
+script-recipe:
+  echo "this is bash"
+  echo "still bash"
+
+# Doc attribute
+[doc('Build the project for release')]
+release:
+  echo 'releasing'
+
+# Recipe with shebang
+polyglot:
+  #!/usr/bin/env python3
+  print('Hello from python!')
+
+# Conditional in recipe body
+greet name:
+  echo {{ if name == "world" { "Hello, world!" } else { "Hello, " + name + "!" } }}
+
+# Function calls
+home := env_var("HOME")
+with_default := env_var_or_default("MISSING", "fallback")
+arch_val := arch()
+os_val := os()
+invocation := invocation_directory()
+just_dir := justfile_directory()
+just_file := justfile()
+
+# Nested function calls
+replaced := replace(replace("a.b.c", ".", "-"), "-", "_")
+
+# Complex expression
+complex := "v" + replace(trim("  1.0.0  "), ".", "-")

--- a/pkg/validator/justfile/testdata/rule110.just
+++ b/pkg/validator/justfile/testdata/rule110.just
@@ -1,0 +1,62 @@
+set unstable
+
+head(s) := if s =~ '^0' {
+  '0'
+} else if s =~ '^1' {
+  '1'
+} else {
+  '0'
+}
+
+tail(s) := if s =~ '^0' {
+  trim_start_match(s, '0')
+} else if s =~ '^1' {
+  trim_start_match(s, '1')
+} else {
+  ''
+}
+
+rule(l, c, r) := if l + c + r == '111' {
+  '0'
+} else if l + c + r == '110' {
+  '1'
+} else if l + c + r == '101' {
+  '1'
+} else if l + c + r == '100' {
+  '0'
+} else if l + c + r == '011' {
+  '1'
+} else if l + c + r == '010' {
+  '1'
+} else if l + c + r == '001' {
+  '1'
+} else {
+  '0'
+}
+
+step(l, rest, acc) := if rest == '' {
+  acc
+} else {
+  step(head(rest), tail(rest), acc + rule(l, head(rest), head(tail(rest))))
+}
+
+evolve(cells) := step('0', cells, '')
+
+pixel(c) := if c == '1' { '█' } else { ' ' }
+
+show(s) := if s == '' { '' } else { pixel(head(s)) + show(tail(s)) }
+
+dec(n) := trim_start_match(n, '.')
+
+run(cells, n) := if n == '' {
+  show(cells)
+} else {
+  show(cells) + "\n" + run(evolve(cells), dec(n))
+}
+
+initial := '0000000000000000000000000000000000000000000000000000000000001'
+
+steps := '..............................'
+
+default:
+  @echo '{{ run(initial, steps) }}'

--- a/pkg/validator/justfile/testdata/tools/mod.just
+++ b/pkg/validator/justfile/testdata/tools/mod.just
@@ -1,0 +1,5 @@
+install:
+    echo "installing tools"
+
+update:
+    echo "updating tools"

--- a/pkg/validator/justfile/testdata/with_imports.just
+++ b/pkg/validator/justfile/testdata/with_imports.just
@@ -1,0 +1,9 @@
+import 'imported.just'
+
+mod tools
+
+build:
+    echo "building"
+
+check: build lint
+    echo "all checks passed"

--- a/pkg/validator/justfile/token.go
+++ b/pkg/validator/justfile/token.go
@@ -1,0 +1,182 @@
+package gojust
+
+import "fmt"
+
+type Position struct {
+	Line   int
+	Column int
+	Offset int
+}
+
+func (p Position) String() string {
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+// StringKind identifies the type of string literal in the source.
+const (
+	StringKindQuoted           = "string"
+	StringKindRaw              = "raw string"
+	StringKindIndentedQuoted   = "indented string"
+	StringKindIndentedRaw      = "indented raw string"
+	StringKindBacktick         = "backtick"
+	StringKindIndentedBacktick = "indented backtick"
+	StringKindShellExpanded    = "shell-expanded string"
+	StringKindShellExpandedRaw = "shell-expanded raw string"
+	StringKindFormat           = "format string"
+)
+
+type tokenType int
+
+const (
+	// Literals
+	tokenIdentifier tokenType = iota
+	tokenString
+	tokenRawString
+	tokenIndentedString
+	tokenIndentedRawString
+	tokenBacktick
+	tokenIndentedBacktick
+	tokenShellExpandedString
+	tokenShellExpandedRawString
+	tokenFormatString
+
+	// Keywords
+	tokenAlias
+	tokenExport
+	tokenUnexport
+	tokenImport
+	tokenMod
+	tokenSet
+	tokenIf
+	tokenElse
+	tokenTrue
+	tokenFalse
+	tokenEager
+
+	// Operators and punctuation
+	tokenAssign        // :=
+	tokenEquals        // ==
+	tokenNotEquals     // !=
+	tokenRegexMatch    // =~
+	tokenRegexMismatch // !~
+	tokenPlus          // +
+	tokenSlash         // /
+	tokenAnd           // &&
+	tokenOr            // ||
+	tokenAt            // @
+	tokenStar          // *
+	tokenColon         // :
+	tokenComma         // ,
+	tokenDollar        // $
+	tokenQuestion      // ?
+	tokenParamAssign   // =
+	tokenBang          // !
+	tokenLParen        // (
+	tokenRParen        // )
+	tokenLBracket      // [
+	tokenRBracket      // ]
+	tokenLBrace        // {
+	tokenRBrace        // }
+	tokenInterpolStart // {{
+	tokenInterpolEnd   // }}
+	tokenAtDash        // @-
+	tokenDashAt        // -@
+	tokenDash          // -
+
+	// Whitespace and structure
+	tokenNewline
+	tokenIndent
+	tokenDedent
+	tokenComment
+	tokenText // opaque text in recipe bodies
+
+	tokenEOF
+)
+
+var tokenNames = map[tokenType]string{
+	tokenIdentifier:             "identifier",
+	tokenString:                 "string",
+	tokenRawString:              "raw string",
+	tokenIndentedString:         "indented string",
+	tokenIndentedRawString:      "indented raw string",
+	tokenBacktick:               "backtick",
+	tokenIndentedBacktick:       "indented backtick",
+	tokenShellExpandedString:    "shell-expanded string",
+	tokenShellExpandedRawString: "shell-expanded raw string",
+	tokenFormatString:           "format string",
+	tokenAlias:                  "'alias'",
+	tokenExport:                 "'export'",
+	tokenUnexport:               "'unexport'",
+	tokenImport:                 "'import'",
+	tokenMod:                    "'mod'",
+	tokenSet:                    "'set'",
+	tokenIf:                     "'if'",
+	tokenElse:                   "'else'",
+	tokenTrue:                   "'true'",
+	tokenFalse:                  "'false'",
+	tokenEager:                  "'eager'",
+	tokenAssign:                 "':='",
+	tokenEquals:                 "'=='",
+	tokenNotEquals:              "'!='",
+	tokenRegexMatch:             "'=~'",
+	tokenRegexMismatch:          "'!~'",
+	tokenPlus:                   "'+'",
+	tokenSlash:                  "'/'",
+	tokenAnd:                    "'&&'",
+	tokenOr:                     "'||'",
+	tokenAt:                     "'@'",
+	tokenStar:                   "'*'",
+	tokenColon:                  "':'",
+	tokenComma:                  "','",
+	tokenDollar:                 "'$'",
+	tokenQuestion:               "'?'",
+	tokenParamAssign:            "'='",
+	tokenBang:                   "'!'",
+	tokenLParen:                 "'('",
+	tokenRParen:                 "')'",
+	tokenLBracket:               "'['",
+	tokenRBracket:               "']'",
+	tokenLBrace:                 "'{'",
+	tokenRBrace:                 "'}'",
+	tokenInterpolStart:          "'{{'",
+	tokenInterpolEnd:            "'}}'",
+	tokenAtDash:                 "'@-'",
+	tokenDashAt:                 "'-@'",
+	tokenDash:                   "'-'",
+	tokenNewline:                "newline",
+	tokenIndent:                 "indent",
+	tokenDedent:                 "dedent",
+	tokenComment:                "comment",
+	tokenText:                   "text",
+	tokenEOF:                    "EOF",
+}
+
+func (t tokenType) String() string {
+	if name, ok := tokenNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("token(%d)", int(t))
+}
+
+type token struct {
+	Type  tokenType
+	Value string
+	Pos   Position
+}
+
+func (t token) String() string {
+	return fmt.Sprintf("%s %s at %s", t.Type, t.Value, t.Pos)
+}
+
+// tokenTypeToStringKind maps token types to their public StringKind constants.
+var tokenTypeToStringKind = map[tokenType]string{
+	tokenString:                 StringKindQuoted,
+	tokenRawString:              StringKindRaw,
+	tokenIndentedString:         StringKindIndentedQuoted,
+	tokenIndentedRawString:      StringKindIndentedRaw,
+	tokenBacktick:               StringKindBacktick,
+	tokenIndentedBacktick:       StringKindIndentedBacktick,
+	tokenShellExpandedString:    StringKindShellExpanded,
+	tokenShellExpandedRawString: StringKindShellExpandedRaw,
+	tokenFormatString:           StringKindFormat,
+}


### PR DESCRIPTION
Adds Justfile as the 16th supported file type. Validates .just files and known filenames (justfile, Justfile, .justfile) using a pure Go parser embedded as a nested module at pkg/validator/justfile/.

Addresses half of: #301