### PR TITLE
Fix exclude-file-types for known files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - KnownFiles now take priority over extension matching in the finder, so `tsconfig.json` resolves to JSONC (not JSON)
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)
+- `--exclude-file-types` now excludes files by resolved file type, including extensionless known files like `.gitconfig` and `justfile`
 
 ## [2.2.0] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Exclude file types in the search path. JSON and JSONC are treated as a family â€
 validator --exclude-file-types=json /path/to/search
 ```
 
-Note: `--exclude-file-types` filters by file extension. Extensionless known files (like `.gitconfig` or `.babelrc`) are not affected by this flag. Use `--type-map` or `.cfv.toml` for fine-grained control.
+Note: `--exclude-file-types` filters by resolved file type. Extensionless known files (like `.gitconfig` or `.babelrc`) are excluded when they resolve to an excluded type.
 
 ![Exclude File Types Run](./img/exclude_file_types.gif)
 

--- a/cmd/validator/testdata/stress_bugs.txtar
+++ b/cmd/validator/testdata/stress_bugs.txtar
@@ -168,15 +168,13 @@ stdout '✓'
 # ============================================================
 # BUG VECTOR 10: --exclude-file-types with extensionless known files
 #
-# Excluding "ini" should skip .ini files. But .gitconfig has no
-# extension — the exclude check uses extensionLowerCase which is
-# empty string for extensionless files. Does "" match "ini"? No.
-# So .gitconfig should NOT be excluded by --exclude-file-types=ini.
+# Excluding "ini" should skip both .ini files and known files that
+# resolve to the INI type, such as .gitconfig.
 # ============================================================
 
-# .gitconfig has no extension — not excluded by extension-based filter
+# .gitconfig resolves to INI and is excluded
 exec validator --exclude-file-types=ini ext_exclude
-stdout '✓.*gitconfig'
+! stdout 'gitconfig'
 
 # .ini file IS excluded
 exec validator --exclude-file-types=ini ext_exclude

--- a/cmd/validator/testdata/stress_known_files.txtar
+++ b/cmd/validator/testdata/stress_known_files.txtar
@@ -154,9 +154,9 @@ exec validator --exclude-file-types=jsonc project
 ! stdout 'tsconfig'
 stdout '✓.*pom.xml'
 
-# Exclude ini — .gitconfig has no extension so it's not excluded by extension.
+# Exclude ini — .gitconfig resolves to INI, so it is excluded.
 exec validator --exclude-file-types=ini dotfiles
-stdout 'gitconfig'
+! stdout 'gitconfig'
 
 # ============================================================
 # PART 6: --file-types with known files

--- a/index.md
+++ b/index.md
@@ -444,7 +444,7 @@ Exclude file types in the search path. JSON and JSONC are treated as a family â€
 validator --exclude-file-types=json /path/to/search
 ```
 
-Note: `--exclude-file-types` filters by file extension. Extensionless known files (like `.gitconfig` or `.babelrc`) are not affected by this flag. Use `--type-map` or `.cfv.toml` for fine-grained control.
+Note: `--exclude-file-types` filters by resolved file type. Extensionless known files (like `.gitconfig` or `.babelrc`) are excluded when they resolve to an excluded type.
 
 ![Exclude File Types Run](./img/exclude_file_types.gif)
 

--- a/pkg/filetype/known_files_gen.go
+++ b/pkg/filetype/known_files_gen.go
@@ -77,6 +77,8 @@ var LinguistKnownFiles = map[string][]string{
 		"Cargo.toml.orig",
 		"Gopkg.lock",
 		"Pipfile",
+		"mise.local.lock",
+		"mise.lock",
 		"pdm.lock",
 		"poetry.lock",
 		"uv.lock",

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -50,6 +50,38 @@ func Test_fsFinderExcludeFileTypes(t *testing.T) {
 	require.Len(t, files, 1)
 }
 
+func Test_fsFinderExcludeFileTypesKnownFiles(t *testing.T) {
+	dir := t.TempDir()
+	testhelper.WriteFile(t, dir, ".gitconfig", testhelper.ValidContent["ini"])
+	testhelper.WriteFile(t, dir, "config.ini", testhelper.ValidContent["ini"])
+	testhelper.WriteFile(t, dir, "good.json", testhelper.ValidContent["json"])
+
+	fsFinder := FileSystemFinderInit(
+		WithPathRoots(dir),
+		WithExcludeFileTypes([]string{"ini"}),
+	)
+	files, err := fsFinder.Find()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "good.json", files[0].Name)
+}
+
+func Test_fsFinderExcludeFileTypesKnownFilesByExtensionAlias(t *testing.T) {
+	dir := t.TempDir()
+	testhelper.WriteFile(t, dir, "justfile", "test:\n\techo test\n")
+	testhelper.WriteFile(t, dir, "task.just", "test:\n\techo test\n")
+	testhelper.WriteFile(t, dir, "good.json", testhelper.ValidContent["json"])
+
+	fsFinder := FileSystemFinderInit(
+		WithPathRoots(dir),
+		WithExcludeFileTypes([]string{"just"}),
+	)
+	files, err := fsFinder.Find()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "good.json", files[0].Name)
+}
+
 func Test_fsFinderWithDepth(t *testing.T) {
 	// root/good.json, root/sub/good.yaml
 	dir := testhelper.CreateFixtureDir(t, "json")

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -290,10 +290,6 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 	walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
 	extensionLowerCase := strings.ToLower(walkFileExtension)
 
-	if _, isExcluded := fsf.ExcludeFileTypes[extensionLowerCase]; isExcluded {
-		return nil
-	}
-
 	// Check type overrides first (user-specified mappings take priority)
 	for _, override := range fsf.TypeOverrides {
 		matched, err := doublestar.PathMatch(override.Pattern, path)
@@ -301,7 +297,7 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 			return err
 		}
 		if matched {
-			return fsf.addFile(path, dirEntry, override.FileType, seenMap, matchingFiles)
+			return fsf.addFileIfNotExcluded(path, dirEntry, override.FileType, seenMap, matchingFiles)
 		}
 	}
 
@@ -310,12 +306,12 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 	// files like tsconfig.json resolve to jsonc (not json).
 	for _, fileType := range fsf.FileTypes {
 		if _, isKnownFile := fileType.KnownFiles[walkFileName]; isKnownFile {
-			return fsf.addFile(path, dirEntry, fileType, seenMap, matchingFiles)
+			return fsf.addFileIfNotExcluded(path, dirEntry, fileType, seenMap, matchingFiles)
 		}
 	}
 	for _, fileType := range fsf.FileTypes {
 		if _, hasExtension := fileType.Extensions[extensionLowerCase]; hasExtension {
-			return fsf.addFile(path, dirEntry, fileType, seenMap, matchingFiles)
+			return fsf.addFileIfNotExcluded(path, dirEntry, fileType, seenMap, matchingFiles)
 		}
 	}
 
@@ -324,6 +320,25 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 		fsf.ExcludeFileTypes[extensionLowerCase] = struct{}{}
 	}
 	return nil
+}
+
+func (fsf FileSystemFinder) addFileIfNotExcluded(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
+	if fsf.isFileTypeExcluded(fileType) {
+		return nil
+	}
+	return fsf.addFile(path, dirEntry, fileType, seenMap, matchingFiles)
+}
+
+func (fsf FileSystemFinder) isFileTypeExcluded(fileType filetype.FileType) bool {
+	if _, isExcluded := fsf.ExcludeFileTypes[fileType.Name]; isExcluded {
+		return true
+	}
+	for extension := range fileType.Extensions {
+		if _, isExcluded := fsf.ExcludeFileTypes[extension]; isExcluded {
+			return true
+		}
+	}
+	return false
 }
 
 func (FileSystemFinder) addFile(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {


### PR DESCRIPTION
PR summary:
Fixes #456 
  ## Summary
  - Apply `--exclude-file-types` after resolving file type
  - Exclude known files like `.gitconfig` and `justfile` by resolved type
  - Add regression tests and update docs/test expectations

  ## Test
  - `go test ./pkg/finder -run
  "Test_fsFinderExcludeFileTypes|Test_fsFinderKnownFiles|Test_fsFinderLinguistKnownFiles"`

Please let me know if there are any further fixes or ammends to make. 