### PR TITLE
ci: improve OpenSSF Scorecard (signed releases, vuln fixes, branch protection)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,9 +91,7 @@ jobs:
   test:
     needs: download
     runs-on: ubuntu-latest
-    name: Update coverage badge
-    permissions:
-      contents: write
+    name: Test and check coverage
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -101,8 +99,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -115,11 +111,9 @@ jobs:
           cd pkg/validator/justfile && go test -v -count=1 ./...
 
       - name: Check coverage
-        id: check-coverage
         env:
           COVERAGE_THRESHOLD: 90
         run: |
-          # Validate that the coverage is above or at the required threshold
           echo "Checking if test coverage is above threshold ..."
           echo "Coverage threshold: ${COVERAGE_THRESHOLD} %"
           totalCoverage=$(go tool cover -func coverage.out | grep 'total' | grep -Eo '[0-9]+\.[0-9]+')
@@ -130,33 +124,3 @@ jobs:
             echo "Current test coverage is below threshold"
             exit 1
           fi
-          echo "total_coverage=${totalCoverage}" >> "${GITHUB_OUTPUT}"
-
-      - name: Create badge img tag and apply to README files
-        id: generate-badge
-        run: |
-          # Create Badge URL
-          # Badge will always be green because of coverage threshold check
-          # so we just have to populate the total coverage
-          totalCoverage=${{ steps.check-coverage.outputs.total_coverage }}
-          BADGE_URL="https://img.shields.io/badge/Coverage-${totalCoverage}%25-brightgreen"
-          BADGE_IMG_TAG="<img id=\"cov\" src=\"${BADGE_URL}\" alt=\"Code Coverage\">"
-
-          # Update README.md
-          sed -i "/id=\"cov\"/c\\${BADGE_IMG_TAG}" README.md
-
-          # Check to see if files were updated
-          if git diff --quiet; then
-            echo "badge_updates=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "badge_updates=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Commit changes
-        if: steps.generate-badge.outputs.badge_updates == 'true' && github.event_name == 'push'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add -- README.md
-          git commit -m "chore: Updated coverage badge."
-          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Generate checksums
         working-directory: artifacts
         run: |
-          sha256sum * > SHA256SUMS
+          sha256sum ./* > SHA256SUMS
 
       - name: Upload to release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,12 @@ on:
   release:
     types: [created]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 permissions:
   contents: read
 
 jobs:
-  releases-matrix:
-    name: Release Go Binary
+  build:
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,45 +21,137 @@ jobs:
             goos: darwin
           - goarch: arm64
             goos: windows
-
-    permissions:
-      packages: write
-      contents: write
-
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
 
       - name: Update SchemaStore catalog
         run: |
           curl -sL https://www.schemastore.org/api/json/catalog.json \
             -o pkg/schemastore/catalog.json
 
-      - uses: wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b # v1.55
+      - name: Build binary
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          BINARY="validator"
+          if [ "$GOOS" = "windows" ]; then
+            BINARY="validator.exe"
+          fi
+          go build \
+            -ldflags="-w -s -extldflags '-static' -X github.com/Boeing/config-file-validator.version=${{ github.event.release.tag_name }}" \
+            -tags netgo \
+            -o "$BINARY" \
+            cmd/validator/validator.go
+
+      - name: Create archive
+        id: archive
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          MAJOR_MINOR="${VERSION%.*}"
+          NAME="validator-v${MAJOR_MINOR}-${{ matrix.goos }}-${{ matrix.goarch }}"
+
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            zip "${NAME}.zip" validator.exe LICENSE README.md
+            echo "filename=${NAME}.zip" >> "$GITHUB_OUTPUT"
+          else
+            tar czf "${NAME}.tar.gz" validator LICENSE README.md
+            echo "filename=${NAME}.tar.gz" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          go_version: 1.26
-          binary_name: "validator"
-          ldflags: -w -s -extldflags "-static" -X github.com/Boeing/config-file-validator.version=${{ github.event.release.tag_name }}
-          build_tags: -tags netgo
-          project_path: cmd/validator
-          extra_files: LICENSE README.md
+          name: ${{ steps.archive.outputs.filename }}
+          path: ${{ steps.archive.outputs.filename }}
+          retention-days: 1
+
+  release:
+    name: Upload Release Assets
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: |
+          sha256sum * > SHA256SUMS
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            artifacts/* \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+  attest:
+    name: Attestation
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: "artifacts/*"
 
   aur-publish:
+    name: Publish AUR Package
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set version in PKGBUILD
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          sed "s/pkgver=VERSION/pkgver=${VERSION}/" PKGBUILD.template > PKGBUILD
 
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3

--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -1,7 +1,7 @@
 # Maintainer: Clayton Kehoe <clayton.j.kehoe at boeing dot com>
 # Contributor : wiz64 <wiz64 dot com>
 pkgname=config-file-validator
-pkgver=2.2.0
+pkgver=VERSION
 pkgrel=1
 pkgdesc="A tool to validate the syntax and schema of configuration files"
 arch=('x86_64')

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Boeing/config-file-validator/v2
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
Targets three Scorecard checks that are dragging the score from 7.4:

## Signed-Releases (0 → 10)

Rearchitected the release workflow from a single `go-release-action` step into a proper pipeline:

```
build (matrix 7x) → upload to release + SHA256SUMS → attest provenance → AUR publish
```

- Explicit `go build` + archive creation (replaces opaque third-party action)
- `actions/attest-build-provenance` generates SLSA provenance for all release artifacts
- SHA256SUMS file uploaded alongside binaries
- All actions pinned to commit SHAs

## Vulnerabilities (4 → 10)

Bumped Go from 1.26.1 to 1.26.3. Resolves 8 stdlib CVEs (net/mail, net/http, crypto/tls, crypto/x509).

## Branch-Protection (3 → higher)

Removed the coverage badge auto-commit from `go.yml`. The test job no longer needs `contents: write` or direct push access to main. After this merges, strict branch protection rules (require reviews, no bypass) can be enabled without breaking CI.

## Other changes

- `PKGBUILD` → `PKGBUILD.template` with `pkgver=VERSION` placeholder. Release workflow seds in the actual version before publishing to AUR. No more manual version bumping before tagging.

## Testing

Create a draft pre-release tagged `v0.0.0-test` targeting this branch to verify the full pipeline end-to-end. Delete it after confirming.