### PR TITLE
fix: warn when schema-map skips unsupported validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
+- `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - KnownFiles now take priority over extension matching in the finder, so `tsconfig.json` resolves to JSONC (not JSON)
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
+- `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.
 - KnownFiles now take priority over extension matching in the finder, so `tsconfig.json` resolves to JSONC (not JSON)
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)

--- a/cmd/validator/testdata/schema_map.txtar
+++ b/cmd/validator/testdata/schema_map.txtar
@@ -15,6 +15,11 @@ stdout '✓'
 exec validator --schema-map=config.json:schema.json other.json
 stdout '✓'
 
+# --schema-map warns and still passes when matched file type has no schema support
+exec validator --schema-map=.env:schema.json .env
+stdout '✓'
+stdout 'warning: --schema-map matched this file'
+
 # Document $schema takes priority over --schema-map
 exec validator --schema-map=with_schema.json:strict_schema.json with_schema.json
 stdout '✓'
@@ -50,6 +55,8 @@ stderr 'invalid schema-map format'
 {"name": "nested", "version": "2.0"}
 -- other.json --
 {"anything": "goes"}
+-- .env --
+KEY=VALUE
 -- with_schema.json --
 {
   "$schema": "schema.json",

--- a/cmd/validator/testdata/schema_map.txtar
+++ b/cmd/validator/testdata/schema_map.txtar
@@ -20,6 +20,12 @@ exec validator --schema-map=.env:schema.json .env
 stdout '✓'
 stdout 'warning: --schema-map matched this file'
 
+# --schema-map fails unsupported schema validators when schema is required
+! exec validator --require-schema --schema-map=.env:schema.json .env
+stdout '×'
+stdout 'error: schema: --schema-map matched this file'
+! stdout 'warning: --schema-map matched this file'
+
 # Document $schema takes priority over --schema-map
 exec validator --schema-map=with_schema.json:strict_schema.json with_schema.json
 stdout '✓'

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -281,6 +281,11 @@ func (c *CLI) validateSchema(v validator.Validator, content []byte, filePath str
 	if schemaPath, ok := c.lookupSchemaMap(filePath); ok {
 		valid, skipped, err := validateWithExternal(v, content, schemaPath)
 		if skipped {
+			if c.requireSchema {
+				return false, nil, &validator.SchemaErrors{
+					Items: []string{schemaMapUnsupportedError(schemaPath)},
+				}
+			}
 			return valid, []string{schemaMapUnsupportedWarning(schemaPath)}, nil
 		}
 		return valid, nil, err
@@ -350,6 +355,10 @@ func validateWithExternal(v validator.Validator, content []byte, schemaPath stri
 
 func schemaMapUnsupportedWarning(schemaPath string) string {
 	return fmt.Sprintf("--schema-map matched this file, but its validator does not support schema validation; skipping schema %q", schemaPath)
+}
+
+func schemaMapUnsupportedError(schemaPath string) string {
+	return fmt.Sprintf("--schema-map matched this file, but its validator does not support schema validation for schema %q", schemaPath)
 }
 
 func toSchemaURL(schemaPath string) (string, error) {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -143,8 +143,9 @@ func (c *CLI) validate(content []byte, ft filetype.FileType, name, path string) 
 	isValid, syntaxErr := ft.Validator.ValidateSyntax(content)
 
 	var schemaErr error
+	var warnings []string
 	if isValid {
-		isValid, schemaErr = c.validateSchema(ft.Validator, content, path)
+		isValid, warnings, schemaErr = c.validateSchema(ft.Validator, content, path)
 	}
 
 	err := syntaxErr
@@ -174,6 +175,7 @@ func (c *CLI) validate(content []byte, ft filetype.FileType, name, path string) 
 		ValidationError:  err,
 		ValidationErrors: validationErrors,
 		Notes:            notes,
+		Warnings:         warnings,
 		ErrorType:        errorType,
 		IsQuiet:          c.quiet,
 		StartLine:        line,
@@ -263,33 +265,38 @@ func checkJSONCFallback(syntaxErr error, ft filetype.FileType, content []byte, n
 	return nil
 }
 
-func (c *CLI) validateSchema(v validator.Validator, content []byte, filePath string) (bool, error) {
+func (c *CLI) validateSchema(v validator.Validator, content []byte, filePath string) (bool, []string, error) {
 	if c.noSchema {
-		return true, nil
+		return true, nil, nil
 	}
 
 	sv, hasSV := v.(validator.SchemaValidator)
 	if hasSV {
 		valid, err := sv.ValidateSchema(content, filePath)
 		if !errors.Is(err, validator.ErrNoSchema) {
-			return valid, err
+			return valid, nil, err
 		}
 	}
 
 	if schemaPath, ok := c.lookupSchemaMap(filePath); ok {
-		return validateWithExternal(v, content, schemaPath)
+		valid, skipped, err := validateWithExternal(v, content, schemaPath)
+		if skipped {
+			return valid, []string{schemaMapUnsupportedWarning(schemaPath)}, nil
+		}
+		return valid, nil, err
 	}
 
 	if c.schemaStore != nil {
 		if schemaPath, ok := c.schemaStore.Resolve(filePath); ok {
-			return validateWithExternal(v, content, schemaPath)
+			valid, _, err := validateWithExternal(v, content, schemaPath)
+			return valid, nil, err
 		}
 	}
 
 	if hasSV && c.requireSchema {
-		return false, validator.ErrNoSchema
+		return false, nil, validator.ErrNoSchema
 	}
-	return true, nil
+	return true, nil, nil
 }
 
 func (c *CLI) lookupSchemaMap(filePath string) (string, bool) {
@@ -312,31 +319,37 @@ func (c *CLI) lookupSchemaMap(filePath string) (string, bool) {
 	return "", false
 }
 
-func validateWithExternal(v validator.Validator, content []byte, schemaPath string) (bool, error) {
+func validateWithExternal(v validator.Validator, content []byte, schemaPath string) (valid bool, skipped bool, err error) {
 	if _, ok := v.(validator.XMLSchemaValidator); ok {
 		absSchema, err := filepath.Abs(schemaPath)
 		if err != nil {
-			return false, fmt.Errorf("resolving schema path: %w", err)
+			return false, false, fmt.Errorf("resolving schema path: %w", err)
 		}
-		return validator.ValidateXSD(content, absSchema)
+		valid, err := validator.ValidateXSD(content, absSchema)
+		return valid, false, err
 	}
 
 	jm, ok := v.(validator.JSONMarshaler)
 	if !ok {
-		return true, nil
+		return true, true, nil
 	}
 
 	schemaURL, err := toSchemaURL(schemaPath)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	docJSON, err := jm.MarshalToJSON(content)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
-	return validator.JSONSchemaValidate(schemaURL, docJSON)
+	valid, err = validator.JSONSchemaValidate(schemaURL, docJSON)
+	return valid, false, err
+}
+
+func schemaMapUnsupportedWarning(schemaPath string) string {
+	return fmt.Sprintf("--schema-map matched this file, but its validator does not support schema validation; skipping schema %q", schemaPath)
 }
 
 func toSchemaURL(schemaPath string) (string, error) {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -426,6 +426,32 @@ func Test_CLISchemaMapUnsupportedValidatorWarnsAndPasses(t *testing.T) {
 	require.Contains(t, capturingReporter.reports[0].Warnings[0], "does not support schema validation")
 }
 
+func Test_CLISchemaMapUnsupportedValidatorFailsWithRequireSchema(t *testing.T) {
+	dir := t.TempDir()
+	envFile := testhelper.WriteFile(t, dir, ".env", "KEY=VALUE\n")
+	schema := testhelper.WriteFile(t, dir, "schema.json", `{"type": "object"}`)
+
+	fsFinder := finder.FileSystemFinderInit(
+		finder.WithPathRoots(envFile),
+	)
+	capturingReporter := &captureReporter{}
+	cli := Init(
+		WithFinder(fsFinder),
+		WithReporters(capturingReporter),
+		WithSchemaMap(map[string]string{".env": schema}),
+		WithRequireSchema(true),
+	)
+	exitStatus, err := cli.Run()
+	require.NoError(t, err)
+	require.Equal(t, 1, exitStatus)
+	require.Len(t, capturingReporter.reports, 1)
+	require.False(t, capturingReporter.reports[0].IsValid)
+	require.Empty(t, capturingReporter.reports[0].Warnings)
+	require.Equal(t, "schema", capturingReporter.reports[0].ErrorType)
+	require.Contains(t, capturingReporter.reports[0].ValidationErrors[0], "--schema-map matched this file")
+	require.Contains(t, capturingReporter.reports[0].ValidationErrors[0], "does not support schema validation")
+}
+
 func Test_CLISchemaStoreValid(t *testing.T) {
 	dir := t.TempDir()
 	bundle := setupMiniSchemaStore(t)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/Boeing/config-file-validator/v2/pkg/validator"
 )
 
+type captureReporter struct {
+	reports []reporter.Report
+}
+
+func (r *captureReporter) Print(reports []reporter.Report) error {
+	r.reports = reports
+	return nil
+}
+
 func Test_CLI(t *testing.T) {
 	dir := testhelper.CreateFixtureDir(t, "json", "yaml", "toml")
 
@@ -391,6 +400,30 @@ func Test_CLISchemaMapUnmatched(t *testing.T) {
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
 	require.Equal(t, 0, exitStatus)
+}
+
+func Test_CLISchemaMapUnsupportedValidatorWarnsAndPasses(t *testing.T) {
+	dir := t.TempDir()
+	envFile := testhelper.WriteFile(t, dir, ".env", "KEY=VALUE\n")
+	schema := testhelper.WriteFile(t, dir, "schema.json", `{"type": "object"}`)
+
+	fsFinder := finder.FileSystemFinderInit(
+		finder.WithPathRoots(envFile),
+	)
+	capturingReporter := &captureReporter{}
+	cli := Init(
+		WithFinder(fsFinder),
+		WithReporters(capturingReporter),
+		WithSchemaMap(map[string]string{".env": schema}),
+	)
+	exitStatus, err := cli.Run()
+	require.NoError(t, err)
+	require.Equal(t, 0, exitStatus)
+	require.Len(t, capturingReporter.reports, 1)
+	require.True(t, capturingReporter.reports[0].IsValid)
+	require.Len(t, capturingReporter.reports[0].Warnings, 1)
+	require.Contains(t, capturingReporter.reports[0].Warnings[0], "--schema-map matched this file")
+	require.Contains(t, capturingReporter.reports[0].Warnings[0], "does not support schema validation")
 }
 
 func Test_CLISchemaStoreValid(t *testing.T) {

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -17,10 +17,11 @@ func NewJSONReporter(outputDest string) *JSONReporter {
 }
 
 type fileStatus struct {
-	Path   string   `json:"path"`
-	Status string   `json:"status"`
-	Errors []string `json:"errors,omitempty"`
-	Notes  []string `json:"notes,omitempty"`
+	Path     string   `json:"path"`
+	Status   string   `json:"status"`
+	Errors   []string `json:"errors,omitempty"`
+	Notes    []string `json:"notes,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 type summary struct {
@@ -215,10 +216,11 @@ func createJSONReport(reports []Report) (reportJSON, error) {
 		}
 
 		jsonReport.Files = append(jsonReport.Files, fileStatus{
-			Path:   report.FilePath,
-			Status: status,
-			Errors: errs,
-			Notes:  report.Notes,
+			Path:     report.FilePath,
+			Status:   status,
+			Errors:   errs,
+			Notes:    report.Notes,
+			Warnings: report.Warnings,
 		})
 
 		currentPassed := 0

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -9,6 +9,7 @@ type Report struct {
 	ValidationError  error
 	ValidationErrors []string
 	Notes            []string
+	Warnings         []string
 	ErrorType        string
 	IsQuiet          bool
 	StartLine        int

--- a/pkg/reporter/stdout_reporter.go
+++ b/pkg/reporter/stdout_reporter.go
@@ -142,6 +142,10 @@ func createStdoutReport(reports []Report, indentSize int) reportStdout {
 			result.Text += color.New(color.FgGreen).Sprintf("%s✓ %s\n", indent, report.FilePath)
 			result.Summary.Passed++
 		}
+		for _, w := range report.Warnings {
+			paddedString := padErrorString(w)
+			result.Text += color.New(color.FgYellow).Sprintf("%swarning: %v\n", errIndent, paddedString)
+		}
 	}
 
 	return result


### PR DESCRIPTION
Fixes #490.

## Summary

`--schema-map` matches previously returned a clean pass when the matched validator could not consume an external schema. This changes that silent skip into a non-fatal report warning while preserving syntax validation and the existing zero exit status for valid files.

The warning is produced only for explicit `--schema-map` matches whose validator lacks external schema support, so unmatched files and normal schema-free validation paths remain quiet. The report model now carries warnings through the standard stdout reporter and JSON output. The focused test exercises an explicit `.env` schema-map match so the unsupported-validator path stays covered.

## Verification

- `go test ./pkg/cli ./pkg/reporter -count=1`
- `go test ./cmd/validator -run TestScript/schema_map -count=1 -v`
- `go test ./pkg/cli -run Test_CLISchemaMapUnsupportedValidatorWarnsAndPasses -count=1`
- `git diff --check`

I also ran `go test ./cmd/validator -count=1`; it failed in `TestScript/gitignore` because the existing `norepo` case expected `b.json` but only emitted `a.json`. That failure appears unrelated to this schema-map path; the focused `schema_map` test passes.
