### PR TITLE
refactor: support recursive groupby output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactored grouped standard and JSON output to support any number of `--groupby` levels.
+- Directory grouped output now uses slash-normalized directory keys without trailing separators; files in the current directory use an empty directory key.
 
 ## [2.2.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)
 
+### Changed
+
+- Refactored grouped standard and JSON output to support any number of `--groupby` levels.
+
 ## [2.2.0] - 2026-04-27
 
 ### Added

--- a/cmd/validator/testdata/groupby.txtar
+++ b/cmd/validator/testdata/groupby.txtar
@@ -28,9 +28,18 @@ stdout 'json'
 exec validator -groupby=pass-fail,filetype,directory files
 stdout 'Passed'
 
+# Four-level grouping
+exec validator -groupby=filetype,directory,pass-fail,error-type files
+stdout 'Passed'
+
 # Groupby with JSON reporter
 exec validator -groupby=filetype --reporter=json:- files
 stdout 'totalPassed'
+
+# Four-level grouping with JSON reporter
+exec validator -groupby=filetype,directory,pass-fail,error-type --reporter=json:- files
+stdout 'totalPassed'
+stdout '"Passed"'
 
 # Invalid groupby
 ! exec validator -groupby=badvalue files

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -351,12 +351,8 @@ func toSchemaURL(schemaPath string) (string, error) {
 }
 
 func (c *CLI) printReports(reports []reporter.Report) error {
-	if len(c.groupOutput) == 1 && c.groupOutput[0] != "" {
-		return c.printGroupSingle(reports)
-	} else if len(c.groupOutput) == 2 {
-		return c.printGroupDouble(reports)
-	} else if len(c.groupOutput) == 3 {
-		return c.printGroupTriple(reports)
+	if len(c.groupOutput) > 0 && c.groupOutput[0] != "" {
+		return c.printGroup(reports)
 	}
 
 	for _, reporterObj := range c.reporters {
@@ -370,47 +366,17 @@ func (c *CLI) printReports(reports []reporter.Report) error {
 	return nil
 }
 
-func (c *CLI) printGroupSingle(reports []reporter.Report) error {
-	reportGroup, err := GroupBySingle(reports, c.groupOutput[0])
+func (c *CLI) printGroup(reports []reporter.Report) error {
+	reportGroup, err := GroupBy(reports, c.groupOutput)
 	if err != nil {
-		return fmt.Errorf("unable to group by single value: %w", err)
+		return fmt.Errorf("unable to group by value: %w", err)
 	}
 
 	for _, reporterObj := range c.reporters {
 		if _, ok := reporterObj.(*reporter.JSONReporter); ok {
-			return reporter.PrintSingleGroupJSON(reportGroup)
+			return reporter.PrintGroupJSON(reportGroup)
 		}
 	}
 
-	return reporter.PrintSingleGroupStdout(reportGroup)
-}
-
-func (c *CLI) printGroupDouble(reports []reporter.Report) error {
-	reportGroup, err := GroupByDouble(reports, c.groupOutput)
-	if err != nil {
-		return fmt.Errorf("unable to group by double value: %w", err)
-	}
-
-	for _, reporterObj := range c.reporters {
-		if _, ok := reporterObj.(*reporter.JSONReporter); ok {
-			return reporter.PrintDoubleGroupJSON(reportGroup)
-		}
-	}
-
-	return reporter.PrintDoubleGroupStdout(reportGroup)
-}
-
-func (c *CLI) printGroupTriple(reports []reporter.Report) error {
-	reportGroup, err := GroupByTriple(reports, c.groupOutput)
-	if err != nil {
-		return fmt.Errorf("unable to group by triple value: %w", err)
-	}
-
-	for _, reporterObj := range c.reporters {
-		if _, ok := reporterObj.(*reporter.JSONReporter); ok {
-			return reporter.PrintTripleGroupJSON(reportGroup)
-		}
-	}
-
-	return reporter.PrintTripleGroupStdout(reportGroup)
+	return reporter.PrintGroupStdout(reportGroup)
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -258,6 +258,22 @@ func Test_CLITripleGroupJSON(t *testing.T) {
 	require.Equal(t, 0, exitStatus)
 }
 
+func Test_CLIQuadGroupJSON(t *testing.T) {
+	file := testhelper.CreateFixtureFile(t, "json")
+
+	fsFinder := finder.FileSystemFinderInit(
+		finder.WithPathRoots(file),
+	)
+	cli := Init(
+		WithFinder(fsFinder),
+		WithReporters(reporter.NewJSONReporter("")),
+		WithGroupOutput([]string{"filetype", "directory", "pass-fail", "error-type"}),
+	)
+	exitStatus, err := cli.Run()
+	require.NoError(t, err)
+	require.Equal(t, 0, exitStatus)
+}
+
 func Test_CLISchemaMapValid(t *testing.T) {
 	dir := t.TempDir()
 	testhelper.WriteFile(t, dir, "config.json", `{"host": "db", "port": 5432}`)

--- a/pkg/cli/group_output.go
+++ b/pkg/cli/group_output.go
@@ -2,12 +2,17 @@ package cli
 
 import (
 	"fmt"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Boeing/config-file-validator/v2/pkg/reporter"
 )
 
-// Group Reports by File Type
+// GroupNode aliases the reporter grouping tree used by grouped output.
+type GroupNode = reporter.GroupNode
+
+// GroupByFileType groups reports by file extension.
 func GroupByFileType(reports []reporter.Report) map[string][]reporter.Report {
 	reportByFile := make(map[string][]reporter.Report)
 
@@ -28,7 +33,7 @@ func GroupByFileType(reports []reporter.Report) map[string][]reporter.Report {
 	return reportByFile
 }
 
-// Group Reports by Pass-Fail
+// GroupByPassFail groups reports by pass or fail status.
 func GroupByPassFail(reports []reporter.Report) map[string][]reporter.Report {
 	reportByPassOrFail := make(map[string][]reporter.Report)
 
@@ -43,7 +48,7 @@ func GroupByPassFail(reports []reporter.Report) map[string][]reporter.Report {
 	return reportByPassOrFail
 }
 
-// Group Reports by Error Type (syntax, schema, or passed)
+// GroupByErrorType groups reports by error type.
 func GroupByErrorType(reports []reporter.Report) map[string][]reporter.Report {
 	reportByErrorType := make(map[string][]reporter.Report)
 
@@ -58,21 +63,16 @@ func GroupByErrorType(reports []reporter.Report) map[string][]reporter.Report {
 	return reportByErrorType
 }
 
-// Group Reports by Directory
+// GroupByDirectory groups reports by containing directory.
 func GroupByDirectory(reports []reporter.Report) map[string][]reporter.Report {
 	reportByDirectory := make(map[string][]reporter.Report)
 	for _, report := range reports {
-		directory := ""
-		// Check if the filepath is in Windows format
-		if strings.Contains(report.FilePath, "\\") {
-			directoryPath := strings.Split(report.FilePath, "\\")
-			directory = strings.Join(directoryPath[:len(directoryPath)-1], "\\")
-			directory = directory + "\\"
-		} else {
-			directoryPath := strings.Split(report.FilePath, "/")
-			directory = strings.Join(directoryPath[:len(directoryPath)-1], "/")
-			directory = directory + "/"
+		normalizedPath := strings.ReplaceAll(report.FilePath, "\\", string(filepath.Separator))
+		directory := filepath.Dir(normalizedPath)
+		if directory == "." {
+			directory = ""
 		}
+		directory = filepath.ToSlash(directory)
 
 		reportByDirectory[directory] = append(reportByDirectory[directory], report)
 	}
@@ -80,63 +80,51 @@ func GroupByDirectory(reports []reporter.Report) map[string][]reporter.Report {
 	return reportByDirectory
 }
 
-// Group Reports by single grouping
-func GroupBySingle(reports []reporter.Report, groupBy string) (map[string][]reporter.Report, error) {
-	var groupReport map[string][]reporter.Report
-
-	// Group by the groupings in reverse order
-	// This allows for the first grouping to be the outermost grouping
-	for i := len(groupBy) - 1; i >= 0; i-- {
-		switch groupBy {
-		case "pass-fail":
-			groupReport = GroupByPassFail(reports)
-		case "filetype":
-			groupReport = GroupByFileType(reports)
-		case "directory":
-			groupReport = GroupByDirectory(reports)
-		case "error-type":
-			groupReport = GroupByErrorType(reports)
-		default:
-			return nil, fmt.Errorf("unable to group by %s", groupBy)
-		}
-	}
-	return groupReport, nil
+// GroupBy groups reports into a recursive tree for any number of grouping levels.
+func GroupBy(reports []reporter.Report, groupBy []string) (*GroupNode, error) {
+	return groupByLevel("", reports, groupBy)
 }
 
-// Group Reports for two groupings
-func GroupByDouble(reports []reporter.Report, groupBy []string) (map[string]map[string][]reporter.Report, error) {
-	groupReport := make(map[string]map[string][]reporter.Report)
+func groupByLevel(key string, reports []reporter.Report, groupBy []string) (*GroupNode, error) {
+	node := &GroupNode{Key: key}
+	if len(groupBy) == 0 {
+		node.Reports = reports
+		return node, nil
+	}
 
-	firstGroup, err := GroupBySingle(reports, groupBy[0])
+	groupedReports, err := groupReports(reports, groupBy[0])
 	if err != nil {
 		return nil, err
 	}
-	for key := range firstGroup {
-		groupReport[key] = make(map[string][]reporter.Report)
-		groupReport[key], err = GroupBySingle(firstGroup[key], groupBy[1])
+
+	keys := make([]string, 0, len(groupedReports))
+	for key := range groupedReports {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		child, err := groupByLevel(key, groupedReports[key], groupBy[1:])
 		if err != nil {
 			return nil, err
 		}
+		node.Children = append(node.Children, child)
 	}
 
-	return groupReport, nil
+	return node, nil
 }
 
-// Group Reports for three groupings
-func GroupByTriple(reports []reporter.Report, groupBy []string) (map[string]map[string]map[string][]reporter.Report, error) {
-	groupReport := make(map[string]map[string]map[string][]reporter.Report)
-
-	firstGroup, err := GroupBySingle(reports, groupBy[0])
-	if err != nil {
-		return nil, err
+func groupReports(reports []reporter.Report, groupBy string) (map[string][]reporter.Report, error) {
+	switch groupBy {
+	case "pass-fail":
+		return GroupByPassFail(reports), nil
+	case "filetype":
+		return GroupByFileType(reports), nil
+	case "directory":
+		return GroupByDirectory(reports), nil
+	case "error-type":
+		return GroupByErrorType(reports), nil
+	default:
+		return nil, fmt.Errorf("unable to group by %s", groupBy)
 	}
-	for key := range firstGroup {
-		groupReport[key] = make(map[string]map[string][]reporter.Report)
-		groupReport[key], err = GroupByDouble(firstGroup[key], groupBy[1:])
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return groupReport, nil
 }

--- a/pkg/cli/group_output_test.go
+++ b/pkg/cli/group_output_test.go
@@ -28,6 +28,7 @@ func Test_ValidGroupOutput(t *testing.T) {
 		{"triple directory,pass-fail,filetype", []string{"directory", "pass-fail", "filetype"}},
 		{"triple filetype,directory,pass-fail", []string{"filetype", "directory", "pass-fail"}},
 		{"triple pass-fail,filetype,directory", []string{"pass-fail", "filetype", "directory"}},
+		{"quad filetype,directory,pass-fail,error-type", []string{"filetype", "directory", "pass-fail", "error-type"}},
 	}
 
 	for _, tc := range cases {
@@ -131,6 +132,46 @@ func Test_GroupByFileType(t *testing.T) {
 	require.Len(t, result, 2)
 	require.Len(t, result["yaml"], 2, "yml and yaml should be grouped together")
 	require.Len(t, result["json"], 1)
+}
+
+func Test_GroupBySupportsFourLevels(t *testing.T) {
+	t.Parallel()
+
+	reports := []reporter.Report{
+		{
+			FileName: "good.json",
+			FilePath: "/configs/app/good.json",
+			IsValid:  true,
+		},
+		{
+			FileName:  "bad.json",
+			FilePath:  "/configs/app/bad.json",
+			IsValid:   false,
+			ErrorType: "syntax",
+		},
+	}
+
+	root, err := GroupBy(reports, []string{"filetype", "directory", "pass-fail", "error-type"})
+	require.NoError(t, err)
+
+	jsonNode := requireChild(t, root, "json")
+	dirNode := requireChild(t, jsonNode, "/configs/app")
+	passedNode := requireChild(t, dirNode, "Passed")
+	require.Len(t, requireChild(t, passedNode, "Passed").Reports, 1)
+	failedNode := requireChild(t, dirNode, "Failed")
+	require.Len(t, requireChild(t, failedNode, "syntax").Reports, 1)
+}
+
+func requireChild(t *testing.T, node *GroupNode, key string) *GroupNode {
+	t.Helper()
+
+	for _, child := range node.Children {
+		if child.Key == key {
+			return child
+		}
+	}
+	require.Failf(t, "missing group", "missing child %q under %q", key, node.Key)
+	return nil
 }
 
 func Test_GroupByErrorType(t *testing.T) {

--- a/pkg/reporter/group_node.go
+++ b/pkg/reporter/group_node.go
@@ -1,0 +1,57 @@
+package reporter
+
+import "slices"
+
+func groupNodeFromSingle(groupReports map[string][]Report) *GroupNode {
+	root := &GroupNode{}
+	for _, group := range sortedKeys(groupReports) {
+		root.Children = append(root.Children, &GroupNode{
+			Key:     group,
+			Reports: groupReports[group],
+		})
+	}
+	return root
+}
+
+func groupNodeFromDouble(groupReports map[string]map[string][]Report) *GroupNode {
+	root := &GroupNode{}
+	for _, group := range sortedKeys(groupReports) {
+		child := &GroupNode{Key: group}
+		for _, groupTwo := range sortedKeys(groupReports[group]) {
+			child.Children = append(child.Children, &GroupNode{
+				Key:     groupTwo,
+				Reports: groupReports[group][groupTwo],
+			})
+		}
+		root.Children = append(root.Children, child)
+	}
+	return root
+}
+
+func groupNodeFromTriple(groupReports map[string]map[string]map[string][]Report) *GroupNode {
+	root := &GroupNode{}
+	for _, group := range sortedKeys(groupReports) {
+		child := &GroupNode{Key: group}
+		for _, groupTwo := range sortedKeys(groupReports[group]) {
+			grandchild := &GroupNode{Key: groupTwo}
+			for _, groupThree := range sortedKeys(groupReports[group][groupTwo]) {
+				grandchild.Children = append(grandchild.Children, &GroupNode{
+					Key:     groupThree,
+					Reports: groupReports[group][groupTwo][groupThree],
+				})
+			}
+			child.Children = append(child.Children, grandchild)
+		}
+		root.Children = append(root.Children, child)
+	}
+	return root
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -34,24 +34,10 @@ type reportJSON struct {
 }
 
 type groupReportJSON struct {
-	Files       map[string][]fileStatus `json:"files"`
-	Summary     map[string][]summary    `json:"summary"`
-	TotalPassed int                     `json:"totalPassed"`
-	TotalFailed int                     `json:"totalFailed"`
-}
-
-type doubleGroupReportJSON struct {
-	Files       map[string]map[string][]fileStatus `json:"files"`
-	Summary     map[string]map[string][]summary    `json:"summary"`
-	TotalPassed int                                `json:"totalPassed"`
-	TotalFailed int                                `json:"totalFailed"`
-}
-
-type tripleGroupReportJSON struct {
-	Files       map[string]map[string]map[string][]fileStatus `json:"files"`
-	Summary     map[string]map[string]map[string][]summary    `json:"summary"`
-	TotalPassed int                                           `json:"totalPassed"`
-	TotalFailed int                                           `json:"totalFailed"`
+	Files       map[string]any `json:"files"`
+	Summary     map[string]any `json:"summary"`
+	TotalPassed int            `json:"totalPassed"`
+	TotalFailed int            `json:"totalFailed"`
 }
 
 // Print implements the Reporter interface by outputting
@@ -81,120 +67,84 @@ func (jr JSONReporter) Print(reports []Report) error {
 	return nil
 }
 
-// Prints the report for when one group is passed in the groupby flag
-func PrintSingleGroupJSON(groupReports map[string][]Report) error {
-	var jsonReport groupReportJSON
-	totalPassed := 0
-	totalFailed := 0
-	jsonReport.Files = make(map[string][]fileStatus)
-	jsonReport.Summary = make(map[string][]summary)
+// PrintGroupJSON prints a recursive grouped report to stdout as JSON.
+func PrintGroupJSON(groupReports *GroupNode) error {
+	files, summaries, totalSummary, err := createGroupJSON(groupReports)
+	if err != nil {
+		return err
+	}
 
-	for group, reports := range groupReports {
-		report, err := createJSONReport(reports)
+	jsonReport := groupReportJSON{
+		Files:       files,
+		Summary:     summaries,
+		TotalPassed: totalSummary.Passed,
+		TotalFailed: totalSummary.Failed,
+	}
+	jsonBytes, err := json.MarshalIndent(jsonReport, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+func createGroupJSON(node *GroupNode) (files map[string]any, summaries map[string]any, total summary, err error) {
+	files = make(map[string]any)
+	summaries = make(map[string]any)
+
+	for _, child := range node.Children {
+		childFiles, childSummary, reportSummary, err := createGroupJSONNode(child)
 		if err != nil {
-			return err
+			return nil, nil, summary{}, err
 		}
-
-		jsonReport.Files[group] = report.Files
-		jsonReport.Summary[group] = append(jsonReport.Summary[group], report.Summary)
-
-		totalPassed += report.Summary.Passed
-		totalFailed += report.Summary.Failed
-
+		files[child.Key] = childFiles
+		summaries[child.Key] = childSummary
+		total.Passed += reportSummary.Passed
+		total.Failed += reportSummary.Failed
 	}
 
-	jsonReport.TotalPassed = totalPassed
-	jsonReport.TotalFailed = totalFailed
-
-	jsonBytes, err := json.MarshalIndent(jsonReport, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(jsonBytes))
-	return nil
+	return files, summaries, total, nil
 }
 
-// Prints the report for when two groups are passed in the groupby flag
+func createGroupJSONNode(node *GroupNode) (files any, summaries any, total summary, err error) {
+	if len(node.Children) == 0 {
+		report, err := createJSONReport(node.Reports)
+		if err != nil {
+			return nil, nil, summary{}, err
+		}
+		return report.Files, []summary{report.Summary}, report.Summary, nil
+	}
+
+	childFiles := make(map[string]any)
+	childSummaries := make(map[string]any)
+	for _, child := range node.Children {
+		files, summaries, reportSummary, err := createGroupJSONNode(child)
+		if err != nil {
+			return nil, nil, summary{}, err
+		}
+		childFiles[child.Key] = files
+		childSummaries[child.Key] = summaries
+		total.Passed += reportSummary.Passed
+		total.Failed += reportSummary.Failed
+	}
+
+	return childFiles, childSummaries, total, nil
+}
+
+// PrintSingleGroupJSON prints a grouped JSON report with one grouping level.
+func PrintSingleGroupJSON(groupReports map[string][]Report) error {
+	return PrintGroupJSON(groupNodeFromSingle(groupReports))
+}
+
+// PrintDoubleGroupJSON prints a grouped JSON report with two grouping levels.
 func PrintDoubleGroupJSON(groupReports map[string]map[string][]Report) error {
-	var jsonReport doubleGroupReportJSON
-	totalPassed := 0
-	totalFailed := 0
-	jsonReport.Files = make(map[string]map[string][]fileStatus)
-	jsonReport.Summary = make(map[string]map[string][]summary)
-
-	for group, group2 := range groupReports {
-		jsonReport.Files[group] = make(map[string][]fileStatus, 0)
-		jsonReport.Summary[group] = make(map[string][]summary, 0)
-		for group2, reports := range group2 {
-			report, err := createJSONReport(reports)
-			if err != nil {
-				return err
-			}
-
-			jsonReport.Files[group][group2] = report.Files
-			jsonReport.Summary[group][group2] = append(jsonReport.Summary[group][group2], report.Summary)
-
-			totalPassed += report.Summary.Passed
-			totalFailed += report.Summary.Failed
-
-		}
-	}
-
-	jsonReport.TotalPassed = totalPassed
-	jsonReport.TotalFailed = totalFailed
-
-	jsonBytes, err := json.MarshalIndent(jsonReport, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(jsonBytes))
-	return nil
+	return PrintGroupJSON(groupNodeFromDouble(groupReports))
 }
 
-// Prints the report for when three groups are passed in the groupby flag
+// PrintTripleGroupJSON prints a grouped JSON report with three grouping levels.
 func PrintTripleGroupJSON(groupReports map[string]map[string]map[string][]Report) error {
-	var jsonReport tripleGroupReportJSON
-	totalPassed := 0
-	totalFailed := 0
-	jsonReport.Files = make(map[string]map[string]map[string][]fileStatus)
-	jsonReport.Summary = make(map[string]map[string]map[string][]summary)
-
-	for group, group2 := range groupReports {
-		jsonReport.Files[group] = make(map[string]map[string][]fileStatus, 0)
-		jsonReport.Summary[group] = make(map[string]map[string][]summary, 0)
-
-		for group2, group3 := range group2 {
-			jsonReport.Files[group][group2] = make(map[string][]fileStatus, 0)
-			jsonReport.Summary[group][group2] = make(map[string][]summary, 0)
-
-			for group3, reports := range group3 {
-				report, err := createJSONReport(reports)
-				if err != nil {
-					return err
-				}
-
-				jsonReport.Files[group][group2][group3] = report.Files
-				jsonReport.Summary[group][group2][group3] = append(jsonReport.Summary[group][group2][group3], report.Summary)
-
-				totalPassed += report.Summary.Passed
-				totalFailed += report.Summary.Failed
-
-			}
-
-		}
-	}
-
-	jsonReport.TotalPassed = totalPassed
-	jsonReport.TotalFailed = totalFailed
-
-	jsonBytes, err := json.MarshalIndent(jsonReport, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(jsonBytes))
-	return nil
+	return PrintGroupJSON(groupNodeFromTriple(groupReports))
 }
 
 // Creates the json report

--- a/pkg/reporter/json_reporter.go
+++ b/pkg/reporter/json_reporter.go
@@ -35,10 +35,10 @@ type reportJSON struct {
 }
 
 type groupReportJSON struct {
-	Files       map[string]any `json:"files"`
-	Summary     map[string]any `json:"summary"`
-	TotalPassed int            `json:"totalPassed"`
-	TotalFailed int            `json:"totalFailed"`
+	Files       any `json:"files"`
+	Summary     any `json:"summary"`
+	TotalPassed int `json:"totalPassed"`
+	TotalFailed int `json:"totalFailed"`
 }
 
 // Print implements the Reporter interface by outputting
@@ -90,22 +90,25 @@ func PrintGroupJSON(groupReports *GroupNode) error {
 	return nil
 }
 
-func createGroupJSON(node *GroupNode) (files map[string]any, summaries map[string]any, total summary, err error) {
-	files = make(map[string]any)
-	summaries = make(map[string]any)
+func createGroupJSON(node *GroupNode) (files any, summaries any, total summary, err error) {
+	if len(node.Children) == 0 {
+		return createGroupJSONNode(node)
+	}
 
+	groupFiles := make(map[string]any)
+	groupSummaries := make(map[string]any)
 	for _, child := range node.Children {
 		childFiles, childSummary, reportSummary, err := createGroupJSONNode(child)
 		if err != nil {
 			return nil, nil, summary{}, err
 		}
-		files[child.Key] = childFiles
-		summaries[child.Key] = childSummary
+		groupFiles[child.Key] = childFiles
+		groupSummaries[child.Key] = childSummary
 		total.Passed += reportSummary.Passed
 		total.Failed += reportSummary.Failed
 	}
 
-	return files, summaries, total, nil
+	return groupFiles, groupSummaries, total, nil
 }
 
 func createGroupJSONNode(node *GroupNode) (files any, summaries any, total summary, err error) {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -25,3 +25,10 @@ type Report struct {
 type Reporter interface {
 	Print(reports []Report) error
 }
+
+// GroupNode stores a recursive report grouping tree.
+type GroupNode struct {
+	Key      string
+	Children []*GroupNode
+	Reports  []Report
+}

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,6 +52,57 @@ var (
 
 	mixedReports = []Report{validReport, invalidReport, multiLineErrorReport}
 )
+
+func captureStdout(t *testing.T, writeOutput func() error) (string, error) {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = writer
+	printErr := writeOutput()
+	os.Stdout = originalStdout
+
+	require.NoError(t, writer.Close())
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	return string(output), printErr
+}
+
+func decodeJSONOutput(t *testing.T, output string) map[string]any {
+	t.Helper()
+
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	return report
+}
+
+func requireJSONMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+
+	actual, ok := value.(map[string]any)
+	require.Truef(t, ok, "expected JSON object, got %T", value)
+	return actual
+}
+
+func requireJSONArray(t *testing.T, value any) []any {
+	t.Helper()
+
+	actual, ok := value.([]any)
+	require.Truef(t, ok, "expected JSON array, got %T", value)
+	return actual
+}
+
+func requireJSONNumber(t *testing.T, value any, expected float64) {
+	t.Helper()
+
+	actual, ok := value.(float64)
+	require.Truef(t, ok, "expected JSON number, got %T", value)
+	require.InDelta(t, expected, actual, 0.000001)
+}
 
 // --- Basic Print tests ---
 
@@ -176,31 +229,50 @@ func Test_sarifReportToFile(t *testing.T) {
 // --- Grouped stdout tests ---
 
 func Test_stdoutGroupedReports(t *testing.T) {
-	singleGroup := map[string][]Report{
-		"xml": mixedReports,
-	}
-	err := PrintSingleGroupStdout(singleGroup)
+	output, err := captureStdout(t, func() error {
+		return PrintSingleGroupStdout(map[string][]Report{
+			"xml": mixedReports,
+		})
+	})
 	require.NoError(t, err)
+	assert.Contains(t, output, "xml\n")
+	assert.Contains(t, output, "/fake/path/good.xml")
+	assert.Contains(t, output, "Summary: 1 succeeded, 2 failed")
+	assert.Contains(t, output, "Total Summary: 1 succeeded, 2 failed")
 
 	// With "Passed"/"Failed" keys to hit checkGroupsForPassFail returning false
-	passfailGroup := map[string][]Report{
-		"Passed": {validReport},
-		"Failed": {invalidReport},
-	}
-	err = PrintSingleGroupStdout(passfailGroup)
+	output, err = captureStdout(t, func() error {
+		return PrintSingleGroupStdout(map[string][]Report{
+			"Passed": {validReport},
+			"Failed": {invalidReport},
+		})
+	})
 	require.NoError(t, err)
+	assert.Contains(t, output, "Passed\n")
+	assert.Contains(t, output, "Failed\n")
+	assert.Contains(t, output, "Total Summary: 1 succeeded, 1 failed")
+	require.Equal(t, 1, strings.Count(output, "Summary:"))
 
-	doubleGroup := map[string]map[string][]Report{
-		"xml": {"directory": mixedReports},
-	}
-	err = PrintDoubleGroupStdout(doubleGroup)
+	output, err = captureStdout(t, func() error {
+		return PrintDoubleGroupStdout(map[string]map[string][]Report{
+			"xml": {"directory": mixedReports},
+		})
+	})
 	require.NoError(t, err)
+	assert.Contains(t, output, "xml\n")
+	assert.Contains(t, output, "    directory\n")
+	assert.Contains(t, output, "Total Summary: 1 succeeded, 2 failed")
 
-	tripleGroup := map[string]map[string]map[string][]Report{
-		"xml": {"directory": {"pass-fail": mixedReports}},
-	}
-	err = PrintTripleGroupStdout(tripleGroup)
+	output, err = captureStdout(t, func() error {
+		return PrintTripleGroupStdout(map[string]map[string]map[string][]Report{
+			"xml": {"directory": {"pass-fail": mixedReports}},
+		})
+	})
 	require.NoError(t, err)
+	assert.Contains(t, output, "xml\n")
+	assert.Contains(t, output, "    directory\n")
+	assert.Contains(t, output, "        pass-fail\n")
+	assert.Contains(t, output, "Total Summary: 1 succeeded, 2 failed")
 
 	groupTree := &GroupNode{
 		Children: []*GroupNode{
@@ -222,30 +294,76 @@ func Test_stdoutGroupedReports(t *testing.T) {
 			},
 		},
 	}
-	err = PrintGroupStdout(groupTree)
+	output, err = captureStdout(t, func() error {
+		return PrintGroupStdout(groupTree)
+	})
 	require.NoError(t, err)
+	assert.Contains(t, output, "xml\n")
+	assert.Contains(t, output, "    directory\n")
+	assert.Contains(t, output, "/fake/path/good.xml")
+	assert.Contains(t, output, "Total Summary: 1 succeeded, 0 failed")
+}
+
+func Test_stdoutGroupedLeafRootDoesNotDuplicateSummary(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return PrintGroupStdout(&GroupNode{
+			Reports: []Report{validReport, invalidReport},
+		})
+	})
+	require.NoError(t, err)
+	assert.Contains(t, output, "/fake/path/good.xml")
+	assert.Contains(t, output, "/fake/path/bad.xml")
+	assert.Contains(t, output, "Total Summary: 1 succeeded, 1 failed")
+	require.Equal(t, 1, strings.Count(output, "Summary:"))
 }
 
 // --- Grouped JSON tests ---
 
 func Test_jsonGroupedReports(t *testing.T) {
-	singleGroup := map[string][]Report{
-		"xml": mixedReports,
-	}
-	err := PrintSingleGroupJSON(singleGroup)
+	output, err := captureStdout(t, func() error {
+		return PrintSingleGroupJSON(map[string][]Report{
+			"xml": mixedReports,
+		})
+	})
 	require.NoError(t, err)
+	report := decodeJSONOutput(t, output)
+	requireJSONNumber(t, report["totalPassed"], 1)
+	requireJSONNumber(t, report["totalFailed"], 2)
+	xmlFiles := requireJSONArray(t, requireJSONMap(t, report["files"])["xml"])
+	require.Len(t, xmlFiles, 3)
+	firstFile := requireJSONMap(t, xmlFiles[0])
+	require.Equal(t, "/fake/path/good.xml", firstFile["path"])
+	xmlSummaries := requireJSONArray(t, requireJSONMap(t, report["summary"])["xml"])
+	require.Len(t, xmlSummaries, 1)
+	xmlSummary := requireJSONMap(t, xmlSummaries[0])
+	requireJSONNumber(t, xmlSummary["passed"], 1)
+	requireJSONNumber(t, xmlSummary["failed"], 2)
 
-	doubleGroup := map[string]map[string][]Report{
-		"xml": {"directory": mixedReports},
-	}
-	err = PrintDoubleGroupJSON(doubleGroup)
+	output, err = captureStdout(t, func() error {
+		return PrintDoubleGroupJSON(map[string]map[string][]Report{
+			"xml": {"directory": mixedReports},
+		})
+	})
 	require.NoError(t, err)
+	report = decodeJSONOutput(t, output)
+	requireJSONNumber(t, report["totalPassed"], 1)
+	requireJSONNumber(t, report["totalFailed"], 2)
+	doubleFiles := requireJSONMap(t, requireJSONMap(t, report["files"])["xml"])
+	require.Len(t, requireJSONArray(t, doubleFiles["directory"]), 3)
+	doubleSummaries := requireJSONMap(t, requireJSONMap(t, report["summary"])["xml"])
+	require.Len(t, requireJSONArray(t, doubleSummaries["directory"]), 1)
 
-	tripleGroup := map[string]map[string]map[string][]Report{
-		"xml": {"directory": {"pass-fail": mixedReports}},
-	}
-	err = PrintTripleGroupJSON(tripleGroup)
+	output, err = captureStdout(t, func() error {
+		return PrintTripleGroupJSON(map[string]map[string]map[string][]Report{
+			"xml": {"directory": {"pass-fail": mixedReports}},
+		})
+	})
 	require.NoError(t, err)
+	report = decodeJSONOutput(t, output)
+	requireJSONNumber(t, report["totalPassed"], 1)
+	requireJSONNumber(t, report["totalFailed"], 2)
+	tripleFiles := requireJSONMap(t, requireJSONMap(t, requireJSONMap(t, report["files"])["xml"])["directory"])
+	require.Len(t, requireJSONArray(t, tripleFiles["pass-fail"]), 3)
 
 	groupTree := &GroupNode{
 		Children: []*GroupNode{
@@ -267,8 +385,36 @@ func Test_jsonGroupedReports(t *testing.T) {
 			},
 		},
 	}
-	err = PrintGroupJSON(groupTree)
+	output, err = captureStdout(t, func() error {
+		return PrintGroupJSON(groupTree)
+	})
 	require.NoError(t, err)
+	report = decodeJSONOutput(t, output)
+	requireJSONNumber(t, report["totalPassed"], 1)
+	requireJSONNumber(t, report["totalFailed"], 0)
+	treeFiles := requireJSONMap(t, requireJSONMap(t, requireJSONMap(t, requireJSONMap(t, report["files"])["xml"])["directory"])["Passed"])
+	require.Len(t, requireJSONArray(t, treeFiles["Passed"]), 1)
+}
+
+func Test_jsonGroupedLeafRootIncludesReports(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return PrintGroupJSON(&GroupNode{
+			Reports: []Report{validReport, invalidReport},
+		})
+	})
+	require.NoError(t, err)
+	report := decodeJSONOutput(t, output)
+	requireJSONNumber(t, report["totalPassed"], 1)
+	requireJSONNumber(t, report["totalFailed"], 1)
+	files := requireJSONArray(t, report["files"])
+	require.Len(t, files, 2)
+	firstFile := requireJSONMap(t, files[0])
+	require.Equal(t, "/fake/path/good.xml", firstFile["path"])
+	summaries := requireJSONArray(t, report["summary"])
+	require.Len(t, summaries, 1)
+	reportSummary := requireJSONMap(t, summaries[0])
+	requireJSONNumber(t, reportSummary["passed"], 1)
+	requireJSONNumber(t, reportSummary["failed"], 1)
 }
 
 // --- Reporter file output tests (shared pattern) ---

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -201,6 +201,29 @@ func Test_stdoutGroupedReports(t *testing.T) {
 	}
 	err = PrintTripleGroupStdout(tripleGroup)
 	require.NoError(t, err)
+
+	groupTree := &GroupNode{
+		Children: []*GroupNode{
+			{
+				Key: "xml",
+				Children: []*GroupNode{
+					{
+						Key: "directory",
+						Children: []*GroupNode{
+							{
+								Key: "Passed",
+								Children: []*GroupNode{
+									{Key: "Passed", Reports: []Report{validReport}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = PrintGroupStdout(groupTree)
+	require.NoError(t, err)
 }
 
 // --- Grouped JSON tests ---
@@ -222,6 +245,29 @@ func Test_jsonGroupedReports(t *testing.T) {
 		"xml": {"directory": {"pass-fail": mixedReports}},
 	}
 	err = PrintTripleGroupJSON(tripleGroup)
+	require.NoError(t, err)
+
+	groupTree := &GroupNode{
+		Children: []*GroupNode{
+			{
+				Key: "xml",
+				Children: []*GroupNode{
+					{
+						Key: "directory",
+						Children: []*GroupNode{
+							{
+								Key: "Passed",
+								Children: []*GroupNode{
+									{Key: "Passed", Reports: []Report{validReport}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = PrintGroupJSON(groupTree)
 	require.NoError(t, err)
 }
 

--- a/pkg/reporter/stdout_reporter.go
+++ b/pkg/reporter/stdout_reporter.go
@@ -38,75 +38,60 @@ func (sr StdoutReporter) Print(reports []Report) error {
 	return nil
 }
 
-// There is repeated code in the following two functions. Trying to consolidate
-// the code into one function is difficult because of the output format
+// PrintGroupStdout prints a recursive grouped report to stdout.
+func PrintGroupStdout(groupReport *GroupNode) error {
+	totalSummary := printGroupNodeStdout(groupReport, nil, 0)
+	fmt.Printf("Total Summary: %d succeeded, %d failed\n", totalSummary.Passed, totalSummary.Failed)
+	return nil
+}
+
+func printGroupNodeStdout(node *GroupNode, groupPath []string, depth int) summary {
+	totalSummary := summary{}
+
+	for _, child := range node.Children {
+		fmt.Printf("%s%s\n", strings.Repeat("    ", depth), child.Key)
+		childSummary := printGroupNodeStdout(child, append(groupPath, child.Key), depth+1)
+		totalSummary.Passed += childSummary.Passed
+		totalSummary.Failed += childSummary.Failed
+	}
+
+	if len(node.Children) > 0 {
+		return totalSummary
+	}
+
+	stdoutReport := createStdoutReport(node.Reports, depth)
+	totalSummary.Passed += stdoutReport.Summary.Passed
+	totalSummary.Failed += stdoutReport.Summary.Failed
+	fmt.Println(stdoutReport.Text)
+	if checkGroupsForPassFail(groupPath...) {
+		summaryDepth := depth - 1
+		if summaryDepth < 0 {
+			summaryDepth = 0
+		}
+		fmt.Printf(
+			"%sSummary: %d succeeded, %d failed\n\n",
+			strings.Repeat("    ", summaryDepth),
+			stdoutReport.Summary.Passed,
+			stdoutReport.Summary.Failed,
+		)
+	}
+
+	return totalSummary
+}
+
+// PrintSingleGroupStdout prints a grouped report with one grouping level.
 func PrintSingleGroupStdout(groupReport map[string][]Report) error {
-	totalSuccessCount := 0
-	totalFailureCount := 0
-
-	for group, reports := range groupReport {
-		fmt.Printf("%s\n", group)
-		stdoutReport := createStdoutReport(reports, 1)
-		totalSuccessCount += stdoutReport.Summary.Passed
-		totalFailureCount += stdoutReport.Summary.Failed
-		fmt.Println(stdoutReport.Text)
-		if checkGroupsForPassFail(group) {
-			fmt.Printf("Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
-		}
-	}
-
-	fmt.Printf("Total Summary: %d succeeded, %d failed\n", totalSuccessCount, totalFailureCount)
-	return nil
+	return PrintGroupStdout(groupNodeFromSingle(groupReport))
 }
 
-// Prints the report for when two groups are passed in the groupby flag
+// PrintDoubleGroupStdout prints a grouped report with two grouping levels.
 func PrintDoubleGroupStdout(groupReport map[string]map[string][]Report) error {
-	totalSuccessCount := 0
-	totalFailureCount := 0
-
-	for group, reports := range groupReport {
-		fmt.Printf("%s\n", group)
-		for group2, reports2 := range reports {
-			fmt.Printf("    %s\n", group2)
-			stdoutReport := createStdoutReport(reports2, 2)
-			totalSuccessCount += stdoutReport.Summary.Passed
-			totalFailureCount += stdoutReport.Summary.Failed
-			fmt.Println(stdoutReport.Text)
-			if checkGroupsForPassFail(group, group2) {
-				fmt.Printf("    Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
-			}
-		}
-	}
-
-	fmt.Printf("Total Summary: %d succeeded, %d failed\n", totalSuccessCount, totalFailureCount)
-
-	return nil
+	return PrintGroupStdout(groupNodeFromDouble(groupReport))
 }
 
-// Prints the report for when three groups are passed in the groupby flag
+// PrintTripleGroupStdout prints a grouped report with three grouping levels.
 func PrintTripleGroupStdout(groupReport map[string]map[string]map[string][]Report) error {
-	totalSuccessCount := 0
-	totalFailureCount := 0
-
-	for groupOne, header := range groupReport {
-		fmt.Printf("%s\n", groupOne)
-		for groupTwo, subheader := range header {
-			fmt.Printf("    %s\n", groupTwo)
-			for groupThree, reports := range subheader {
-				fmt.Printf("        %s\n", groupThree)
-				stdoutReport := createStdoutReport(reports, 3)
-				totalSuccessCount += stdoutReport.Summary.Passed
-				totalFailureCount += stdoutReport.Summary.Failed
-				fmt.Println(stdoutReport.Text)
-				if checkGroupsForPassFail(groupOne, groupTwo, groupThree) {
-					fmt.Printf("        Summary: %d succeeded, %d failed\n\n", stdoutReport.Summary.Passed, stdoutReport.Summary.Failed)
-				}
-			}
-		}
-	}
-
-	fmt.Printf("Total Summary: %d succeeded, %d failed\n", totalSuccessCount, totalFailureCount)
-	return nil
+	return PrintGroupStdout(groupNodeFromTriple(groupReport))
 }
 
 // Checks if any of the provided groups are "Passed" or "Failed".

--- a/pkg/reporter/stdout_reporter.go
+++ b/pkg/reporter/stdout_reporter.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -50,7 +51,7 @@ func printGroupNodeStdout(node *GroupNode, groupPath []string, depth int) summar
 
 	for _, child := range node.Children {
 		fmt.Printf("%s%s\n", strings.Repeat("    ", depth), child.Key)
-		childSummary := printGroupNodeStdout(child, append(groupPath, child.Key), depth+1)
+		childSummary := printGroupNodeStdout(child, append(slices.Clone(groupPath), child.Key), depth+1)
 		totalSummary.Passed += childSummary.Passed
 		totalSummary.Failed += childSummary.Failed
 	}
@@ -63,7 +64,7 @@ func printGroupNodeStdout(node *GroupNode, groupPath []string, depth int) summar
 	totalSummary.Passed += stdoutReport.Summary.Passed
 	totalSummary.Failed += stdoutReport.Summary.Failed
 	fmt.Println(stdoutReport.Text)
-	if checkGroupsForPassFail(groupPath...) {
+	if len(groupPath) > 0 && checkGroupsForPassFail(groupPath...) {
 		summaryDepth := depth - 1
 		if summaryDepth < 0 {
 			summaryDepth = 0


### PR DESCRIPTION
## Summary

  Refactors grouped output so `--groupby` can handle any number of levels using a recursive grouping tree instead of separate fixed-depth paths.

  This removes the one-, two-, and three-level dispatch logic and routes both standard and JSON grouped reports through the same recursive structure.

  Fixes #487.

  ## Changes

  - Added recursive `GroupBy` support for arbitrary grouping depth
  - Updated standard and JSON grouped reporters to walk the grouping tree
  - Kept compatibility wrappers for the existing one-, two-, and three-level reporter helpers
  - Added 4-level `--groupby` coverage for standard and JSON output
  - Updated the changelog

  ## Testing

  - `go test ./pkg/cli -run "Test_ValidGroupOutput|Test_GroupByFileType|Test_GroupBySupportsFourLevels|
  Test_CLIQuadGroupJSON|TestScript/groupby"`
  - `go test ./pkg/reporter -run "Test_stdoutGroupedReports|Test_jsonGroupedReports"`
  - `go vet ./pkg/cli ./pkg/reporter`
  - `git diff --check`