### PR TITLE
fix: reject duplicate reporter output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.
+- Multiple reporters targeting the same output file now fail during startup instead of silently overwriting a report.
 - KnownFiles now take priority over extension matching in the finder, so `tsconfig.json` resolves to JSONC (not JSON)
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)

--- a/cmd/validator/testdata/reporters.txtar
+++ b/cmd/validator/testdata/reporters.txtar
@@ -31,11 +31,9 @@ exec validator --reporter=json:first.json --reporter=json:second.json good.json
 exists first.json
 exists second.json
 
-# Duplicate reporter type to the same file leaves one valid report
-exec validator --reporter=json:same.json --reporter=json:same.json good.json
-exists same.json
-exec validator same.json
-stdout '✓'
+# Duplicate reporter output file fails before validation
+! exec validator --reporter=json:same.json --reporter=json:same.json good.json
+stdout 'multiple reporters target the same output file: same.json'
 
 # Invalid reporter
 ! exec validator --reporter=bad good.json

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -41,6 +41,7 @@ import (
 	"log"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -424,7 +425,26 @@ func parseReporterFlags(flags reporterFlags) ([]reporterConfig, error) {
 		conf = append(conf, reporterConfig{reportType: "standard"})
 	}
 
+	if err := validateUniqueReporterOutputDestinations(conf); err != nil {
+		return nil, err
+	}
+
 	return conf, nil
+}
+
+func validateUniqueReporterOutputDestinations(conf []reporterConfig) error {
+	seen := make(map[string]struct{}, len(conf))
+	for _, reporterConf := range conf {
+		if reporterConf.outputDest == "" {
+			continue
+		}
+		outputDest := filepath.Clean(reporterConf.outputDest)
+		if _, ok := seen[outputDest]; ok {
+			return fmt.Errorf("multiple reporters target the same output file: %s", outputDest)
+		}
+		seen[outputDest] = struct{}{}
+	}
+	return nil
 }
 
 // isFlagSet verifies if a given flag has been set or not

--- a/cmd/validator/validator_test.go
+++ b/cmd/validator/validator_test.go
@@ -70,6 +70,32 @@ func Test_getFlagsValues(t *testing.T) {
 	require.Equal(t, []string{"."}, cfg.searchPaths)
 }
 
+func Test_getFlagsRejectsDuplicateReporterOutputDest(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		outputDest string
+	}{
+		{
+			name:       "same output path",
+			args:       []string{"--reporter=json:same.json", "--reporter=junit:same.json", "."},
+			outputDest: "same.json",
+		},
+		{
+			name:       "cleaned output path",
+			args:       []string{"--reporter=json:./same.json", "--reporter=junit:same.json", "."},
+			outputDest: "same.json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := getFlags(tc.args)
+			require.ErrorContains(t, err, "multiple reporters target the same output file: "+tc.outputDest)
+		})
+	}
+}
+
 func Test_getExcludeFileTypes(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Fixes #488

## Summary
- Reject duplicate non-empty reporter output paths during flag parsing.
- Keep repeated stdout reporters allowed because they do not target an output file.
- Update reporter regression coverage and the changelog.

## Test
- `go test ./cmd/validator -run 'Test_getFlagsRejectsDuplicateReporterOutputDest|TestScript/reporters' -count=1`
- Full AGENTS.md pipeline in a non-root `golang:1.26.3` container: `go vet`, nested `go vet`, `gofmt`, `golangci-lint run ./...`, `go generate`, `go build`, root tests, nested go-just tests, and coverage total 93.4%