### PR TITLE
refactor(finder): split exclude file type cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.
+- Unsupported-extension caching no longer mutates the user-provided `ExcludeFileTypes` map during file walks.
 - KnownFiles now take priority over extension matching in the finder, so `tsconfig.json` resolves to JSONC (not JSON)
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -100,6 +100,32 @@ func Test_fsFinderExcludeFileTypesNotMutated(t *testing.T) {
 	require.NotContains(t, fsFinder.ExcludeFileTypes, "unknown")
 }
 
+func Test_fsFinderExtensionCacheResetsEachFind(t *testing.T) {
+	dir := t.TempDir()
+	testhelper.WriteFile(t, dir, "config.custom", "key=value\n")
+
+	fsFinder := FileSystemFinderInit(
+		WithPathRoots(dir),
+		WithFileTypes([]filetype.FileType{}),
+	)
+	files, err := fsFinder.Find()
+	require.NoError(t, err)
+	require.Empty(t, files)
+
+	fsFinder.FileTypes = []filetype.FileType{
+		{
+			Name:       "custom",
+			Extensions: tools.ArrToMap("custom"),
+			Validator:  validator.PropValidator{},
+		},
+	}
+	files, err = fsFinder.Find()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "config.custom", files[0].Name)
+	require.Equal(t, "custom", files[0].FileType.Name)
+}
+
 func Test_fsFinderWithDepth(t *testing.T) {
 	// root/good.json, root/sub/good.yaml
 	dir := testhelper.CreateFixtureDir(t, "json")

--- a/pkg/finder/finder_test.go
+++ b/pkg/finder/finder_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,6 +81,23 @@ func Test_fsFinderExcludeFileTypesKnownFilesByExtensionAlias(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 	require.Equal(t, "good.json", files[0].Name)
+}
+
+func Test_fsFinderExcludeFileTypesNotMutated(t *testing.T) {
+	dir := t.TempDir()
+	testhelper.WriteFile(t, dir, "ignored.unknown", "ignored\n")
+	testhelper.WriteFile(t, dir, "good.toml", testhelper.ValidContent["toml"])
+
+	fsFinder := FileSystemFinderInit(
+		WithPathRoots(dir),
+		WithExcludeFileTypes([]string{"json"}),
+	)
+	files, err := fsFinder.Find()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "good.toml", files[0].Name)
+	require.Contains(t, fsFinder.ExcludeFileTypes, "json")
+	require.NotContains(t, fsFinder.ExcludeFileTypes, "unknown")
 }
 
 func Test_fsFinderWithDepth(t *testing.T) {
@@ -222,6 +240,10 @@ func Test_fsFinderWhitespacePaths(t *testing.T) {
 }
 
 func Test_fsFinderWalkDirError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0000 does not reliably make directories unreadable on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	subDir := testhelper.CreateSubdir(t, tmpDir, "noperm")
 	testhelper.WriteFile(t, subDir, "test.json", `{}`)

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -71,7 +71,11 @@ func WithDepth(depthVal int) FSFinderOptions {
 // WithTypeOverrides adds glob pattern to file type mappings
 func WithTypeOverrides(overrides []TypeOverride) FSFinderOptions {
 	return func(fsf *FileSystemFinder) {
-		fsf.TypeOverrides = overrides
+		normalized := append([]TypeOverride(nil), overrides...)
+		for i := range normalized {
+			normalized[i].Pattern = filepath.ToSlash(normalized[i].Pattern)
+		}
+		fsf.TypeOverrides = normalized
 	}
 }
 
@@ -92,7 +96,6 @@ func FileSystemFinderInit(opts ...FSFinderOptions) *FileSystemFinder {
 		FileTypes:        filetype.FileTypes,
 		ExcludeDirs:      defaultExcludeDirs,
 		ExcludeFileTypes: defaultExcludeFileTypes,
-		extCache:         make(map[string]struct{}),
 	}
 
 	for _, opt := range opts {
@@ -106,12 +109,15 @@ func FileSystemFinderInit(opts ...FSFinderOptions) *FileSystemFinder {
 // all the PathRoots and providing the aggregated FileMetadata after
 // ignoring all the duplicate files
 func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
+	finder := fsf
+	finder.extCache = make(map[string]struct{})
+
 	seen := make(map[string]struct{}, 0)
 	uniqueMatches := make([]FileMetadata, 0)
-	for _, pathRoot := range fsf.PathRoots {
+	for _, pathRoot := range finder.PathRoots {
 		// remove all leading and trailing whitespace
 		trimmedPathRoot := strings.TrimSpace(pathRoot)
-		matches, err := fsf.findOne(trimmedPathRoot, seen)
+		matches, err := finder.findOne(trimmedPathRoot, seen)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +129,7 @@ func (fsf FileSystemFinder) Find() ([]FileMetadata, error) {
 // findOne recursively walks through all subdirectories (excluding the excluded subdirectories)
 // and identifying if the file matches a type defined in the fileTypes array for a
 // single path and returns the file metadata.
-func (fsf FileSystemFinder) findOne(pathRoot string, seenMap map[string]struct{}) ([]FileMetadata, error) {
+func (fsf *FileSystemFinder) findOne(pathRoot string, seenMap map[string]struct{}) ([]FileMetadata, error) {
 	var matchingFiles []FileMetadata
 
 	pathRoot = strings.TrimRight(pathRoot, string(os.PathSeparator))
@@ -279,7 +285,7 @@ func findRepoRoot(absDir string) string {
 	}
 }
 
-func (fsf FileSystemFinder) handleDir(path string, dirEntry fs.DirEntry, maxDepth int) error {
+func (fsf *FileSystemFinder) handleDir(path string, dirEntry fs.DirEntry, maxDepth int) error {
 	_, isExcluded := fsf.ExcludeDirs[dirEntry.Name()]
 	if isExcluded || (fsf.Depth != nil && strings.Count(path, string(os.PathSeparator)) > maxDepth) {
 		return filepath.SkipDir
@@ -287,7 +293,7 @@ func (fsf FileSystemFinder) handleDir(path string, dirEntry fs.DirEntry, maxDept
 	return nil
 }
 
-func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
+func (fsf *FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
 	walkFileName := filepath.Base(path)
 	walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
 	extensionLowerCase := strings.ToLower(walkFileExtension)
@@ -295,7 +301,7 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 
 	// Check type overrides first (user-specified mappings take priority)
 	for _, override := range fsf.TypeOverrides {
-		matched, err := doublestar.PathMatch(filepath.ToSlash(override.Pattern), pathForPatternMatch)
+		matched, err := doublestar.PathMatch(override.Pattern, pathForPatternMatch)
 		if err != nil {
 			return err
 		}
@@ -325,7 +331,7 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 	return nil
 }
 
-func (fsf FileSystemFinder) isExtensionCached(extension string) bool {
+func (fsf *FileSystemFinder) isExtensionCached(extension string) bool {
 	if len(fsf.TypeOverrides) > 0 || extension == "" || fsf.extCache == nil {
 		return false
 	}
@@ -333,21 +339,21 @@ func (fsf FileSystemFinder) isExtensionCached(extension string) bool {
 	return isCached
 }
 
-func (fsf FileSystemFinder) cacheUnsupportedExtension(extension string) {
+func (fsf *FileSystemFinder) cacheUnsupportedExtension(extension string) {
 	if len(fsf.TypeOverrides) > 0 || extension == "" || fsf.extCache == nil {
 		return
 	}
 	fsf.extCache[extension] = struct{}{}
 }
 
-func (fsf FileSystemFinder) addFileIfNotExcluded(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
+func (fsf *FileSystemFinder) addFileIfNotExcluded(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
 	if fsf.isFileTypeExcluded(fileType) {
 		return nil
 	}
 	return fsf.addFile(path, dirEntry, fileType, seenMap, matchingFiles)
 }
 
-func (fsf FileSystemFinder) isFileTypeExcluded(fileType filetype.FileType) bool {
+func (fsf *FileSystemFinder) isFileTypeExcluded(fileType filetype.FileType) bool {
 	if _, isExcluded := fsf.ExcludeFileTypes[fileType.Name]; isExcluded {
 		return true
 	}
@@ -359,7 +365,7 @@ func (fsf FileSystemFinder) isFileTypeExcluded(fileType filetype.FileType) bool 
 	return false
 }
 
-func (FileSystemFinder) addFile(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
+func (*FileSystemFinder) addFile(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return err

--- a/pkg/finder/fsfinder.go
+++ b/pkg/finder/fsfinder.go
@@ -25,6 +25,7 @@ type FileSystemFinder struct {
 	FileTypes        []filetype.FileType
 	ExcludeDirs      map[string]struct{}
 	ExcludeFileTypes map[string]struct{}
+	extCache         map[string]struct{}
 	Depth            *int
 	TypeOverrides    []TypeOverride
 	Gitignore        bool
@@ -91,6 +92,7 @@ func FileSystemFinderInit(opts ...FSFinderOptions) *FileSystemFinder {
 		FileTypes:        filetype.FileTypes,
 		ExcludeDirs:      defaultExcludeDirs,
 		ExcludeFileTypes: defaultExcludeFileTypes,
+		extCache:         make(map[string]struct{}),
 	}
 
 	for _, opt := range opts {
@@ -289,10 +291,11 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 	walkFileName := filepath.Base(path)
 	walkFileExtension := strings.TrimPrefix(filepath.Ext(path), ".")
 	extensionLowerCase := strings.ToLower(walkFileExtension)
+	pathForPatternMatch := filepath.ToSlash(path)
 
 	// Check type overrides first (user-specified mappings take priority)
 	for _, override := range fsf.TypeOverrides {
-		matched, err := doublestar.PathMatch(override.Pattern, path)
+		matched, err := doublestar.PathMatch(filepath.ToSlash(override.Pattern), pathForPatternMatch)
 		if err != nil {
 			return err
 		}
@@ -309,20 +312,32 @@ func (fsf FileSystemFinder) handleFile(path string, dirEntry fs.DirEntry, seenMa
 			return fsf.addFileIfNotExcluded(path, dirEntry, fileType, seenMap, matchingFiles)
 		}
 	}
+	if fsf.isExtensionCached(extensionLowerCase) {
+		return nil
+	}
 	for _, fileType := range fsf.FileTypes {
 		if _, hasExtension := fileType.Extensions[extensionLowerCase]; hasExtension {
 			return fsf.addFileIfNotExcluded(path, dirEntry, fileType, seenMap, matchingFiles)
 		}
 	}
 
-	// Only cache exclusion if no type overrides are configured.
-	// Never cache "" (extensionless files) — one unrecognized extensionless
-	// file (e.g. .gitignore) must not prevent known extensionless files
-	// (e.g. Pipfile) from being found later.
-	if len(fsf.TypeOverrides) == 0 && extensionLowerCase != "" {
-		fsf.ExcludeFileTypes[extensionLowerCase] = struct{}{}
-	}
+	fsf.cacheUnsupportedExtension(extensionLowerCase)
 	return nil
+}
+
+func (fsf FileSystemFinder) isExtensionCached(extension string) bool {
+	if len(fsf.TypeOverrides) > 0 || extension == "" || fsf.extCache == nil {
+		return false
+	}
+	_, isCached := fsf.extCache[extension]
+	return isCached
+}
+
+func (fsf FileSystemFinder) cacheUnsupportedExtension(extension string) {
+	if len(fsf.TypeOverrides) > 0 || extension == "" || fsf.extCache == nil {
+		return
+	}
+	fsf.extCache[extension] = struct{}{}
 }
 
 func (fsf FileSystemFinder) addFileIfNotExcluded(path string, dirEntry fs.DirEntry, fileType filetype.FileType, seenMap map[string]struct{}, matchingFiles *[]FileMetadata) error {


### PR DESCRIPTION
Splits the finder’s user-provided exclude map from its internal unsupported-extension cache.

  ## What changed

  - Added a separate internal cache for unsupported extensions.
  - Kept `ExcludeFileTypes` unchanged after initialization.
  - Skipped caching for extensionless files and type override walks.
  - Added regression coverage for `ExcludeFileTypes` mutation.
  - Added a changelog entry under `[Unreleased]`.

  ## Why

  `ExcludeFileTypes` was doing two jobs: storing user intent and acting as runtime cache state. Keeping those separate prevents cache entries from changing user exclusions during a file walk.

  Fixes #489.

  ## Testing

  - `go test ./pkg/finder -count=1`
  - `go generate ./pkg/filetype/...`
  - `git diff --check`
  - Docker Linux: `go vet ./...`, `go build`, `go test -cover -coverprofile coverage.out ./...`
  - Docker Linux nested module: `go vet ./...`, `go test -count=1 ./...`
  - `golangci-lint run ./...`
  - nested `pkg/validator/justfile`: `golangci-lint run ./...`