### PR TITLE
fix(validator): reject TOML files with duplicate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TOML files with duplicate keys are now rejected as invalid (closes #505).
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- TOML files with duplicate keys are now rejected as invalid (closes #505).
+- TOML files with duplicate keys are now rejected as invalid (closes #504).
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.

--- a/pkg/validator/toml.go
+++ b/pkg/validator/toml.go
@@ -24,6 +24,9 @@ func (TomlValidator) ValidateSyntax(b []byte) (bool, error) {
 			Column: col,
 		}
 	}
+	if err != nil {
+		return false, err
+	}
 	return true, nil
 }
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -132,6 +132,7 @@ var testData = []struct {
 	{"invalidXml", []byte("<xml\n"), false, XMLValidator{}},
 	{"invalidToml", []byte("name = 123__456"), false, TomlValidator{}},
 	{"validToml", []byte("name = 123"), true, TomlValidator{}},
+	{"tomlDuplicateKey", []byte("key = 1\nkey = 2\n"), false, TomlValidator{}},
 	{"validIni", []byte(`{[Version]\nCatalog=hidden\n}`), true, IniValidator{}},
 	{"invalidIni", []byte(`\nCatalog hidden\n`), false, IniValidator{}},
 	{"validProperties", []byte("key=value\nkey2=${key}"), true, PropValidator{}},


### PR DESCRIPTION
Fixes #504.

go-toml/v2 returns a plain \`error\` (not \`*toml.DecodeError\`) for duplicate keys and duplicate table headers. The missing fallback caused \`ValidateSyntax\` to return \`(true, nil)\`, silently passing files that should fail.

Added a fallback \`if err != nil\` check after the \`DecodeError\` branch and a regression test case (\`tomlDuplicateKey\`).