### PR TITLE
fix(cli): report broken symlinks as failures instead of aborting the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TOML files with duplicate keys are now rejected as invalid (closes #504).
-- A broken symlink in a scanned directory no longer aborts the entire run; it is now reported as a failed file (closes #505).
+- Broken symlinks are reported as validation failures instead of aborting the run (closes #505)
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - TOML files with duplicate keys are now rejected as invalid (closes #504).
+- A broken symlink in a scanned directory no longer aborts the entire run; it is now reported as a failed file (closes #505).
 - Repeating the same `--reporter` type with different output paths now writes each requested output.
 - `--schema-map` now warns instead of silently skipping files whose validators do not support external schema validation.
 - `--require-schema --schema-map` now fails when a mapped file's validator does not support external schema validation.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -124,7 +124,7 @@ func (c *CLI) Run() (int, error) {
 					FileName:         f.Name,
 					FilePath:         f.Path,
 					IsValid:          false,
-					ValidationError:  fmt.Errorf("broken symlink"),
+					ValidationError:  errors.New("broken symlink"),
 					ValidationErrors: []string{"broken symlink"},
 				}
 				c.errorFound = true

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,6 +119,18 @@ func (c *CLI) Run() (int, error) {
 	for _, f := range foundFiles {
 		content, err := os.ReadFile(f.Path)
 		if err != nil {
+			if isBrokenSymlink(f.Path) {
+				report := reporter.Report{
+					FileName:         f.Name,
+					FilePath:         f.Path,
+					IsValid:          false,
+					ValidationError:  fmt.Errorf("broken symlink"),
+					ValidationErrors: []string{"broken symlink"},
+				}
+				c.errorFound = true
+				reports = append(reports, report)
+				continue
+			}
 			return 2, fmt.Errorf("unable to read file: %w", err)
 		}
 
@@ -435,4 +448,17 @@ func (c *CLI) printGroupTriple(reports []reporter.Report) error {
 	}
 
 	return reporter.PrintTripleGroupStdout(reportGroup)
+}
+
+// isBrokenSymlink reports whether path is a symlink whose target does not exist.
+func isBrokenSymlink(path string) bool {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	if fi.Mode()&fs.ModeSymlink == 0 {
+		return false
+	}
+	_, err = os.Stat(path)
+	return os.IsNotExist(err)
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -126,6 +126,7 @@ func (c *CLI) Run() (int, error) {
 					IsValid:          false,
 					ValidationError:  errors.New("broken symlink"),
 					ValidationErrors: []string{"broken symlink"},
+					ErrorType:        "other",
 				}
 				c.errorFound = true
 				reports = append(reports, report)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -227,17 +227,17 @@ func Test_CLIWithBrokenSymlink(t *testing.T) {
 	err := os.Symlink("/nonexistent_target_xyz", target)
 	require.NoError(t, err)
 
-	cap := &captureReporter{}
+	rep := &captureReporter{}
 	fsFinder := finder.FileSystemFinderInit(
 		finder.WithPathRoots(dir),
 	)
-	cli := Init(WithFinder(fsFinder), WithReporters(cap))
+	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
 	require.Equal(t, 1, exitStatus)
 
 	var failed int
-	for _, r := range cap.reports {
+	for _, r := range rep.reports {
 		if !r.IsValid {
 			failed++
 		}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -217,6 +218,31 @@ func Test_CLIWithUnreadableFile(t *testing.T) {
 	exitStatus, err := cli.Run()
 	require.Error(t, err)
 	require.Equal(t, 2, exitStatus)
+}
+
+func Test_CLIWithBrokenSymlink(t *testing.T) {
+	dir := testhelper.CreateFixtureDir(t, "json")
+
+	target := filepath.Join(dir, "broken.json")
+	err := os.Symlink("/nonexistent_target_xyz", target)
+	require.NoError(t, err)
+
+	cap := &captureReporter{}
+	fsFinder := finder.FileSystemFinderInit(
+		finder.WithPathRoots(dir),
+	)
+	cli := Init(WithFinder(fsFinder), WithReporters(cap))
+	exitStatus, err := cli.Run()
+	require.NoError(t, err)
+	require.Equal(t, 1, exitStatus)
+
+	var failed int
+	for _, r := range cap.reports {
+		if !r.IsValid {
+			failed++
+		}
+	}
+	require.Equal(t, 1, failed)
 }
 
 func Test_CLISingleGroupJSON(t *testing.T) {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -237,12 +237,15 @@ func Test_CLIWithBrokenSymlink(t *testing.T) {
 	require.Equal(t, 1, exitStatus)
 
 	var failed int
+	var errorType string
 	for _, r := range rep.reports {
 		if !r.IsValid {
 			failed++
+			errorType = r.ErrorType
 		}
 	}
 	require.Equal(t, 1, failed)
+	require.Equal(t, "other", errorType)
 }
 
 func Test_CLISingleGroupJSON(t *testing.T) {


### PR DESCRIPTION
Fixes #505.

A broken symlink has a valid extension and is reported by the finder, but \`os.ReadFile\` returns ENOENT when the target does not exist. The missing branch caused \`Run\` to return exit 2, aborting validation for all remaining files in the directory.

Added an \`isBrokenSymlink\` check: when \`ReadFile\` fails on a symlink whose target is missing, the file is recorded as a failed report (exit 1, validation error "broken symlink") and the run continues. Permission errors and other I/O failures still abort as before.