### PR TITLE
fix(ci): include patch version in release binary names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,7 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
-          MAJOR_MINOR="${VERSION%.*}"
-          NAME="validator-v${MAJOR_MINOR}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          NAME="validator-v${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
 
           if [ "${{ matrix.goos }}" = "windows" ]; then
             zip "${NAME}.zip" validator.exe LICENSE README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release binaries now include the full semver patch version in their filename (e.g., `validator-v2.2.2-linux-amd64.tar.gz` instead of `validator-v2.2-linux-amd64.tar.gz`), fixing package managers like aqua that expect full semver in artifact URLs (closes #514).
 - TOML files with duplicate keys are now rejected as invalid (closes #504).
 - Broken symlinks are reported as validation failures instead of aborting the run (closes #505)
 - Repeating the same `--reporter` type with different output paths now writes each requested output.


### PR DESCRIPTION
The archive naming stripped the patch version in the binary name, breaking package managers like aqua that expect full semver in artifact URLs.

Fixes #514