### PR TITLE
fix(cli): stop after global help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Global `--help` now exits after printing usage instead of running validation on the current directory.
 - Update Go and npm dependencies to resolve 22 known vulnerabilities (CVE-2026-25680, CVE-2026-48779, and others).
 - TOML files with duplicate keys are now rejected as invalid (closes #504).
 - Broken symlinks are reported as validation failures instead of aborting the run (closes #505)

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -193,7 +193,10 @@ func mainInit() int {
 	// Parse only until the first non-flag argument (the subcommand or a path).
 	// flag.ContinueOnError means unknown flags return an error rather than exiting,
 	// which lets us forward unrecognised flags to the subcommand FlagSet.
-	_ = globalFS.Parse(args)
+	globalErr := globalFS.Parse(args)
+	if errors.Is(globalErr, flag.ErrHelp) {
+		return 0
+	}
 	remaining := globalFS.Args()
 
 	if *versionFlag {

--- a/cmd/cfv/cfv_test.go
+++ b/cmd/cfv/cfv_test.go
@@ -267,6 +267,7 @@ func Test_subcommandRouter(t *testing.T) {
 	}{
 		{"version subcommand", []string{"version"}, 0},
 		{"--version flag", []string{"--version"}, 0},
+		{"--help flag", []string{"--help"}, 0},
 		{"help subcommand", []string{"help"}, 0},
 		{"help check subcommand", []string{"help", "check"}, 0},
 		{"help format subcommand", []string{"help", "format"}, 0},

--- a/cmd/cfv/testdata/basic.txtar
+++ b/cmd/cfv/testdata/basic.txtar
@@ -1,4 +1,8 @@
 # Test --help and --version
+exec cfv --help
+stdout 'Usage: cfv '
+! stdout '[✓×]'
+
 exec cfv check --help
 stdout 'Usage: cfv check'
 


### PR DESCRIPTION
## Summary

- return immediately when global flag parsing reports `flag.ErrHelp`
- add unit and testscript coverage for `cfv --help`
- document the user-visible fix in the changelog

## Reproduction

While testing the v3 release candidate for #551, running `cfv --help` printed usage and then continued into the default `check` command. In a directory containing invalid configuration files, help therefore emitted validation results and exited with status 1.

After this change, `cfv --help` prints usage, performs no validation, and exits 0.

## Validation

- `go vet ./...`
- `test -z "$(gofmt -s -l -e .)"`
- `golangci-lint run ./...` (0 issues)
- `go generate ./pkg/filetype/...`
- `go build -o /dev/null cmd/cfv/cfv.go`
- `go test -cover -coverprofile coverage.out ./...`
- `go tool cover -func coverage.out | grep total` (91.0%)
