### PR TITLE
docs: update stale functional testing section to reference automated txtar suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,6 @@ Pull requests are the best way to propose changes to the codebase (we use [GitHu
 ## Report bugs using GitHub's [issues](https://github.com/boeing/config-file-validator/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Boeing/config-file-validator/issues/new);
 
-## Functional Testing
-Until we can automate the functional testing, you must run through the [functional testing](./functional_test.md) procedures before submitting your PR for review.
 
 ## Using AI Coding Agents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,20 @@ Pull requests are the best way to propose changes to the codebase (we use [GitHu
 ## Report bugs using GitHub's [issues](https://github.com/boeing/config-file-validator/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/Boeing/config-file-validator/issues/new);
 
+## Functional Testing
+Functional/CLI testing is automated via [`txtar`](https://pkg.go.dev/golang.org/x/tools/txtar)-based [testscript](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) tests. Run the full suite, including these, with:
+
+```go
+go test ./...
+```
+
+Or run just the CLI functional tests:
+
+```go
+go test ./cmd/validator/...
+```
+
+If you add a CLI-facing feature or fix, add a new `.txtar` file under `cmd/validator/testdata/` (see `basic.txtar` for the pattern) rather than testing manually.
 
 ## Using AI Coding Agents
 


### PR DESCRIPTION
Closes #554

## Summary
- CONTRIBUTING.md's 'Functional Testing' section pointed to `./functional_test.md`, which was removed in #429 when manual functional testing was replaced by an automated `txtar`/testscript-based suite in `cmd/validator/`.
- Updated the section (rather than removing it, per review feedback) to document how to run the automated suite (`go test ./...` or `go test ./cmd/validator/...`) and how to add new CLI test cases via `.txtar` files.