### PR TITLE
fix(format): preserve JSON/JSONC key order by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - KnownFiles now take priority over extension matching in the finder, so `tsconfig.json` resolves to JSONC (not JSON)
 - Extension exclusion cache no longer prevents known files from being found
 - Linguist known files that conflict with dedicated validators are automatically excluded (e.g. `.editorconfig` stays with EditorConfig, not INI)
+- `cfv format` no longer sorts JSON/JSONC object keys by default, matching the behavior of prettier, biome, and deno fmt. Original key order is now preserved unless `sort-keys = true` is set in `.cfv.toml` or `--sort-keys` is passed on the CLI.
 
 ### Changed
 

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -662,7 +662,7 @@ func formatDefaults(formatName string) formatter.Options {
 			IndentWidth:  2,
 			FinalNewline: true,
 			LineEnding:   formatter.LineEndingLF,
-			SortKeys:     true,
+			SortKeys:     false,
 			QuoteStyle:   formatter.QuotePreserve,
 		}
 	case "yaml":

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -654,11 +654,9 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 }
 
 // formatDefaults returns the hardcoded default options for a specific format.
-// json and yaml share a case for now since their defaults are currently
-// identical; split them out again when they diverge
 func formatDefaults(formatName string) formatter.Options {
 	switch formatName {
-	case "json", "yaml":
+	case "json":
 		return formatter.Options{
 			IndentStyle:  formatter.IndentSpaces,
 			IndentWidth:  2,
@@ -666,6 +664,15 @@ func formatDefaults(formatName string) formatter.Options {
 			LineEnding:   formatter.LineEndingLF,
 			SortKeys:     false,
 			QuoteStyle:   formatter.QuotePreserve,
+		}
+	case "yaml":
+		return formatter.Options{
+			IndentStyle:  formatter.IndentSpaces,
+			IndentWidth:  2,
+			FinalNewline: true,
+			LineEnding:   formatter.LineEndingLF,
+			QuoteStyle:   formatter.QuotePreserve,
+			SortKeys:     false,
 		}
 	default:
 		return formatter.Options{

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -632,7 +632,7 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 
 	return func(formatName string) formatter.Options {
 		// Start with format-specific defaults.
-		opts := formatDefaults(formatName)
+		opts := formatDefaults()
 
 		// Layer 2: .cfv.toml [format] (global)
 		if globalCfg != nil {
@@ -654,34 +654,14 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 }
 
 // formatDefaults returns the hardcoded default options for a specific format.
-func formatDefaults(formatName string) formatter.Options {
-	switch formatName {
-	case "json":
-		return formatter.Options{
-			IndentStyle:  formatter.IndentSpaces,
-			IndentWidth:  2,
-			FinalNewline: true,
-			LineEnding:   formatter.LineEndingLF,
-			SortKeys:     false,
-			QuoteStyle:   formatter.QuotePreserve,
-		}
-	case "yaml":
-		return formatter.Options{
-			IndentStyle:  formatter.IndentSpaces,
-			IndentWidth:  2,
-			FinalNewline: true,
-			LineEnding:   formatter.LineEndingLF,
-			SortKeys:     false,
-			QuoteStyle:   formatter.QuotePreserve,
-		}
-	default:
-		return formatter.Options{
-			IndentStyle:  formatter.IndentSpaces,
-			IndentWidth:  2,
-			FinalNewline: true,
-			LineEnding:   formatter.LineEndingLF,
-			QuoteStyle:   formatter.QuotePreserve,
-		}
+func formatDefaults() formatter.Options {
+	return formatter.Options{
+		IndentStyle:  formatter.IndentSpaces,
+		IndentWidth:  2,
+		FinalNewline: true,
+		LineEnding:   formatter.LineEndingLF,
+		SortKeys:     false,
+		QuoteStyle:   formatter.QuotePreserve,
 	}
 }
 

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -631,8 +631,8 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 	}
 
 	return func(formatName string) formatter.Options {
-		// Start with format-specific defaults.
-		opts := formatDefaults()
+		// Start with the hardcoded defaults, shared by all formats.
+		opts := formatterDefaultOpts()
 
 		// Layer 2: .cfv.toml [format] (global)
 		if globalCfg != nil {
@@ -653,8 +653,8 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 	}
 }
 
-// formatDefaults returns the hardcoded default options for a specific format.
-func formatDefaults() formatter.Options {
+// formatterDefaultOpts returns the hardcoded default options shared by all formats.
+func formatterDefaultOpts() formatter.Options {
 	return formatter.Options{
 		IndentStyle:  formatter.IndentSpaces,
 		IndentWidth:  2,

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -631,8 +631,8 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 	}
 
 	return func(formatName string) formatter.Options {
-		// Start with the hardcoded defaults, shared by all formats.
-		opts := formatterDefaultOpts()
+		// Start with format-specific defaults.
+		opts := formatDefaults(formatName)
 
 		// Layer 2: .cfv.toml [format] (global)
 		if globalCfg != nil {
@@ -653,15 +653,28 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 	}
 }
 
-// formatterDefaultOpts returns the hardcoded default options shared by all formats.
-func formatterDefaultOpts() formatter.Options {
-	return formatter.Options{
-		IndentStyle:  formatter.IndentSpaces,
-		IndentWidth:  2,
-		FinalNewline: true,
-		LineEnding:   formatter.LineEndingLF,
-		SortKeys:     false,
-		QuoteStyle:   formatter.QuotePreserve,
+// formatDefaults returns the hardcoded default options for a specific format.
+// json and yaml share a case for now since their defaults are currently
+// identical; split them out again when they diverge
+func formatDefaults(formatName string) formatter.Options {
+	switch formatName {
+	case "json", "yaml":
+		return formatter.Options{
+			IndentStyle:  formatter.IndentSpaces,
+			IndentWidth:  2,
+			FinalNewline: true,
+			LineEnding:   formatter.LineEndingLF,
+			SortKeys:     false,
+			QuoteStyle:   formatter.QuotePreserve,
+		}
+	default:
+		return formatter.Options{
+			IndentStyle:  formatter.IndentSpaces,
+			IndentWidth:  2,
+			FinalNewline: true,
+			LineEnding:   formatter.LineEndingLF,
+			QuoteStyle:   formatter.QuotePreserve,
+		}
 	}
 }
 

--- a/cmd/cfv/testdata/format_config_cascade.txtar
+++ b/cmd/cfv/testdata/format_config_cascade.txtar
@@ -27,10 +27,10 @@ stdout '        "key"'
 
 # --- SORT-KEYS ---
 
-# Default: JSON sorts keys (a before b before z)
+# Default: JSON preserves original key order (z first)
 cp sortkeys_orig.json sortkeys_test.json
 exec cfv format --fix --no-config .
-cmp sortkeys_test.json sortkeys_sorted.json
+cmp sortkeys_test.json sortkeys_unsorted.json
 
 # Global sort-keys = false preserves original order (z first)
 cp sortkeys_orig.json sortkeys_test.json

--- a/pkg/formatter/jsonfmt/json.go
+++ b/pkg/formatter/jsonfmt/json.go
@@ -5,7 +5,7 @@
 //
 // Defaults:
 //   - 2-space indentation
-//   - sorted keys
+//   - original key order preserved
 //   - trailing newline
 package jsonfmt
 
@@ -31,7 +31,7 @@ func DefaultOptions() formatter.Options {
 		IndentStyle:  formatter.IndentSpaces,
 		IndentWidth:  2,
 		FinalNewline: true,
-		SortKeys:     true,
+		SortKeys:     false,
 	}
 }
 

--- a/pkg/formatter/jsonfmt/testdata/compact_to_pretty.expected.json
+++ b/pkg/formatter/jsonfmt/testdata/compact_to_pretty.expected.json
@@ -1,7 +1,7 @@
 {
   "key": "value",
+  "number": 42,
   "nested": {
     "a": 1
-  },
-  "number": 42
+  }
 }

--- a/pkg/formatter/jsonfmt/testdata/mixed_types.expected.json
+++ b/pkg/formatter/jsonfmt/testdata/mixed_types.expected.json
@@ -1,14 +1,14 @@
 {
+  "str": "hello",
+  "num": 42,
+  "float": 3.14,
+  "bool": true,
+  "null": null,
   "arr": [
     1,
     2
   ],
-  "bool": true,
-  "float": 3.14,
-  "null": null,
-  "num": 42,
   "obj": {
     "a": 1
-  },
-  "str": "hello"
+  }
 }

--- a/pkg/formatter/jsonfmt/testdata/sort_keys.opts.json
+++ b/pkg/formatter/jsonfmt/testdata/sort_keys.opts.json
@@ -1,0 +1,1 @@
+{"SortKeys": true}

--- a/pkg/formatter/jsonfmt/testdata/unicode.expected.json
+++ b/pkg/formatter/jsonfmt/testdata/unicode.expected.json
@@ -1,5 +1,5 @@
 {
-  "arabic": "مرحبا",
+  "emoji": "🎉",
   "chinese": "中文",
-  "emoji": "🎉"
+  "arabic": "مرحبا"
 }


### PR DESCRIPTION
Closes #556

## Fix

- `formatDefaults` in `cmd/cfv/cfv.go`: JSON's `SortKeys` default changed to `false`.
- `jsonfmt.DefaultOptions()` now returns `SortKeys: false`.
- JSONC already defaulted to `SortKeys: false`, no change needed.
- `sort-keys = true` in `.cfv.toml` or `--sort-keys` still enables sorting.

## Tests

- Added `sort_keys.opts.json` fixture to opt that fixture into sorting explicitly.
- Regenerated `compact_to_pretty`, `mixed_types`, `unicode` expected fixtures for the new default.
- Updated `format_config_cascade.txtar` default-behavior case.
- `golangci-lint run ./...`: 0 issues. `go test ./...`: passes.

## Acceptance criteria

- [x] JSON preserves key order by default
- [x] JSONC preserves key order by default (already correct)
- [x] `sort-keys = true` enables sorting
- [x] Tests updated
- [x] CHANGELOG updated