### PR TITLE
feat(format): auto-detect .editorconfig for formatting defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--sort-keys` flag to sort mapping keys alphabetically on `cfv format`
 - `--diff` flag for previewing formatting changes without modifying files
 - Per-format configuration in `.cfv.toml` via `[format.<type>]` tables (yaml, json, jsonc, toml, hcl, xml, ini, properties, env)
-- Format configuration cascade: CLI flags > per-format config > global `[format]` config > defaults
+- Format configuration cascade: CLI flags > per-format config > global `[format]` config > `.editorconfig` > defaults
 - `trailing-commas` format option (`preserve` | `all` | `none`) to control trailing commas on multiline JSONC collections
+- `.editorconfig` auto-detection for `cfv format`: `indent_style`, `indent_size`, `end_of_line`, and `insert_final_newline` are resolved per file (globs, parent directories, and `root = true` are all respected). Disable with `--no-editorconfig` (closes #562)
 - Schema validation support for JSONC files via `$schema`, `--schema-map`, and SchemaStore
 - Schema validation support for Properties files via `--schema-map` in `.cfv.toml`
 - **cfv 3.0 Phase 1**: Renamed binary from `validator` to `cfv`. This is a breaking change — no compatibility shim ships. Update scripts: `validator .` → `cfv check .`

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -87,14 +87,15 @@ type cfvConfig struct {
 	fix    *bool
 	unsafe *bool
 	// Format option flags (cfv format only).
-	fmtIndent       *int
-	fmtUseTabs      *bool
-	fmtSortKeys     *bool
-	fmtNoSortKeys   *bool
-	fmtLineEnding   *string
-	fmtMaxLineWidth *int
-	fmtQuoteStyle   *string
-	fmtDiff         *bool
+	fmtIndent         *int
+	fmtUseTabs        *bool
+	fmtSortKeys       *bool
+	fmtNoSortKeys     *bool
+	fmtLineEnding     *string
+	fmtMaxLineWidth   *int
+	fmtQuoteStyle     *string
+	fmtDiff           *bool
+	fmtNoEditorConfig *bool
 }
 
 // reporterConfig pairs a reporter format name with an optional output path.
@@ -515,14 +516,15 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 		fixPtr       = fs.Bool("fix", false, "Rewrite files to canonical style")
 		unsafePtr    = fs.Bool("unsafe", false, "Apply unsafe formatting fixes (requires --fix) [not yet implemented]")
 		// Format option flags.
-		fmtIndentPtr       = fs.Int("indent", 0, "Override indent width (1-16). 0 = use config/default.")
-		fmtUseTabsPtr      = fs.Bool("use-tabs", false, "Use tabs for indentation")
-		fmtSortKeysPtr     = fs.Bool("sort-keys", false, "Sort object/mapping keys alphabetically")
-		fmtNoSortKeysPtr   = fs.Bool("no-sort-keys", false, "Disable key sorting (overrides config)")
-		fmtLineEndingPtr   = fs.String("line-ending", "", "Line ending: lf, crlf")
-		fmtMaxLineWidthPtr = fs.Int("max-line-width", 0, "Max line width hint (0 = unlimited)")
-		fmtQuoteStylePtr   = fs.String("quote-style", "", "Quote style: double, single, preserve")
-		fmtDiffPtr         = fs.Bool("diff", false, "Show unified diff instead of rewriting (implies no --fix)")
+		fmtIndentPtr         = fs.Int("indent", 0, "Override indent width (1-16). 0 = use config/default.")
+		fmtUseTabsPtr        = fs.Bool("use-tabs", false, "Use tabs for indentation")
+		fmtSortKeysPtr       = fs.Bool("sort-keys", false, "Sort object/mapping keys alphabetically")
+		fmtNoSortKeysPtr     = fs.Bool("no-sort-keys", false, "Disable key sorting (overrides config)")
+		fmtLineEndingPtr     = fs.String("line-ending", "", "Line ending: lf, crlf")
+		fmtMaxLineWidthPtr   = fs.Int("max-line-width", 0, "Max line width hint (0 = unlimited)")
+		fmtQuoteStylePtr     = fs.String("quote-style", "", "Quote style: double, single, preserve")
+		fmtNoEditorConfigPtr = fs.Bool("no-editorconfig", false, "Ignore .editorconfig files when resolving format options")
+		fmtDiffPtr           = fs.Bool("diff", false, "Show unified diff instead of rewriting (implies no --fix)")
 	)
 
 	fs.Var(&reporterConfigFlags, "reporter",
@@ -576,30 +578,31 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 	// Schema fields are nil for format — resolveFormatConfig does not use them.
 
 	return cfvConfig{
-		fs:               fs,
-		searchPaths:      searchPaths,
-		excludeDirs:      excludeDirsPtr,
-		excludeFileTypes: excludeTypesPtr,
-		fileTypes:        fileTypesPtr,
-		reportType:       reporterConf,
-		depth:            depthPtr,
-		groupOutput:      groupOutputPtr,
-		quiet:            quietPtr,
-		globbing:         globbingPtr,
-		configPath:       configPathPtr,
-		noConfig:         noConfigPtr,
-		gitignore:        gitignorePtr,
-		ignoreFiles:      ignoreFileConfigFlags,
-		fix:              fixPtr,
-		unsafe:           unsafePtr,
-		fmtIndent:        fmtIndentPtr,
-		fmtUseTabs:       fmtUseTabsPtr,
-		fmtSortKeys:      fmtSortKeysPtr,
-		fmtNoSortKeys:    fmtNoSortKeysPtr,
-		fmtLineEnding:    fmtLineEndingPtr,
-		fmtMaxLineWidth:  fmtMaxLineWidthPtr,
-		fmtQuoteStyle:    fmtQuoteStylePtr,
-		fmtDiff:          fmtDiffPtr,
+		fs:                fs,
+		searchPaths:       searchPaths,
+		excludeDirs:       excludeDirsPtr,
+		excludeFileTypes:  excludeTypesPtr,
+		fileTypes:         fileTypesPtr,
+		reportType:        reporterConf,
+		depth:             depthPtr,
+		groupOutput:       groupOutputPtr,
+		quiet:             quietPtr,
+		globbing:          globbingPtr,
+		configPath:        configPathPtr,
+		noConfig:          noConfigPtr,
+		gitignore:         gitignorePtr,
+		ignoreFiles:       ignoreFileConfigFlags,
+		fix:               fixPtr,
+		unsafe:            unsafePtr,
+		fmtIndent:         fmtIndentPtr,
+		fmtUseTabs:        fmtUseTabsPtr,
+		fmtSortKeys:       fmtSortKeysPtr,
+		fmtNoSortKeys:     fmtNoSortKeysPtr,
+		fmtLineEnding:     fmtLineEndingPtr,
+		fmtMaxLineWidth:   fmtMaxLineWidthPtr,
+		fmtQuoteStyle:     fmtQuoteStylePtr,
+		fmtDiff:           fmtDiffPtr,
+		fmtNoEditorConfig: fmtNoEditorConfigPtr,
 	}, nil
 }
 
@@ -610,10 +613,15 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 // buildFormatOptionsResolver builds a function that resolves format options
 // for any format name using the cascade:
 //
-//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > format-specific defaults
+//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > .editorconfig > format-specific defaults
 func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOptionsFunc {
 	var globalCfg *configfile.FormatOptions
 	var perFormatCfg map[string]*configfile.FormatOptions
+
+	var editorCfg *formatter.EditorConfig
+	if cfg.fmtNoEditorConfig == nil || !*cfg.fmtNoEditorConfig {
+		editorCfg = formatter.NewEditorConfig()
+	}
 
 	if rc.formatCfg != nil {
 		globalCfg = &rc.formatCfg.FormatOptions
@@ -630,23 +638,37 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 		}
 	}
 
-	return func(formatName string) formatter.Options {
+	return func(formatName, path string) formatter.Options {
 		// Start with format-specific defaults.
 		opts := formatDefaults(formatName)
 
-		// Layer 2: .cfv.toml [format] (global)
+		// Layer 2: .editorconfig (resolved per file)
+		if editorCfg != nil {
+			// A zero default width means the format is not indented at all
+			// (TOML keys under a table header). That is a property of the
+			// format rather than an editor preference, so a project-wide
+			// [*] indent_size must not reintroduce indentation. An explicit
+			// .cfv.toml or --indent still can, in the layers below.
+			unindented := opts.IndentWidth == 0
+			editorCfg.Apply(&opts, path)
+			if unindented {
+				opts.IndentWidth = 0
+			}
+		}
+
+		// Layer 3: .cfv.toml [format] (global)
 		if globalCfg != nil {
 			applyFormatOptions(&opts, globalCfg)
 		}
 
-		// Layer 3: .cfv.toml [format.<type>]
+		// Layer 4: .cfv.toml [format.<type>]
 		if perFormatCfg != nil {
 			if perFmt := perFormatCfg[formatName]; perFmt != nil {
 				applyFormatOptions(&opts, perFmt)
 			}
 		}
 
-		// Layer 4: CLI flags (highest priority)
+		// Layer 5: CLI flags (highest priority)
 		applyCLIFormatFlags(&opts, cfg)
 
 		return opts

--- a/cmd/cfv/testdata/format_editorconfig.txtar
+++ b/cmd/cfv/testdata/format_editorconfig.txtar
@@ -1,0 +1,78 @@
+# ============================================================
+# .editorconfig auto-detection
+# Proves: CLI flags > .cfv.toml > .editorconfig > defaults,
+# per-file globs, root = true, and --no-editorconfig.
+# ============================================================
+
+# .editorconfig indent_size = 6 replaces the default 2
+cp orig.json indent.json
+exec cfv format --fix --no-config indent.json
+exec cat indent.json
+stdout '      "key"'
+
+# --no-editorconfig falls back to the default 2
+cp orig.json indent.json
+exec cfv format --fix --no-config --no-editorconfig indent.json
+exec cat indent.json
+stdout '^  "key"'
+
+# .cfv.toml overrides .editorconfig
+cp orig.json indent.json
+exec cfv format --fix --config=cfv/indent4.toml indent.json
+exec cat indent.json
+stdout '^    "key"'
+
+# CLI flags override both
+cp orig.json indent.json
+exec cfv format --fix --config=cfv/indent4.toml --indent=8 indent.json
+exec cat indent.json
+stdout '        "key"'
+
+# Globs are matched per file: [*.yaml] wins over [*] for YAML only
+exec cfv format --fix --no-config app.yaml
+exec cat app.yaml
+stdout '^   nested:'
+
+# Formats that default to no indentation stay unindented: a project-wide
+# indent_size must not indent keys under a TOML table header
+exec cfv format --fix --no-config app.toml
+exec cat app.toml
+stdout '^host'
+
+# an explicit --indent still wins over that
+exec cfv format --fix --no-config --indent=2 app.toml
+exec cat app.toml
+stdout '^  host'
+
+# root = true stops the upward search, so the parent's indent_size = 6
+# does not apply and JSON falls back to the default 2
+cp orig.json rooted/f.json
+exec cfv format --fix --no-config rooted/f.json
+exec cat rooted/f.json
+stdout '^  "key"'
+
+-- .editorconfig --
+root = true
+
+[*]
+indent_size = 6
+
+[*.yaml]
+indent_size = 3
+-- orig.json --
+{"key":{"nested":"value"}}
+-- indent.json --
+{"key":{"nested":"value"}}
+-- app.yaml --
+key:
+    nested: value
+-- app.toml --
+[server]
+host = "example"
+-- rooted/.editorconfig --
+root = true
+-- rooted/f.json --
+{"key":{"nested":"value"}}
+-- cfv/indent4.toml --
+[format]
+indent = 4

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -874,7 +874,7 @@ func Test_FormatCleanFiles(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{
 			IndentStyle:  formatter.IndentSpaces,
 			IndentWidth:  2,
@@ -896,7 +896,7 @@ func Test_FormatUnformattedFile(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{
 			IndentStyle:  formatter.IndentSpaces,
 			IndentWidth:  2,
@@ -918,7 +918,7 @@ func Test_FormatWithFix(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep), WithFix(true))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{
 			IndentStyle:  formatter.IndentSpaces,
 			IndentWidth:  2,
@@ -944,7 +944,7 @@ func Test_FormatWithDiff(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep), WithDiff(true))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{
 			IndentStyle:  formatter.IndentSpaces,
 			IndentWidth:  2,
@@ -969,7 +969,7 @@ func Test_FormatSkipsUnparseableFiles(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{
 			IndentStyle:  formatter.IndentSpaces,
 			IndentWidth:  2,
@@ -994,7 +994,7 @@ func Test_FormatBrokenSymlink(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true}
 	})
 	require.NoError(t, err)
@@ -1018,7 +1018,7 @@ func Test_FormatNoFormatterRegistered(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true}
 	})
 	require.NoError(t, err)
@@ -1036,7 +1036,7 @@ func Test_FormatYAMLDefaults(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep))
 
-	exitStatus, err := cli.Format(func(formatName string) formatter.Options {
+	exitStatus, err := cli.Format(func(formatName, _ string) formatter.Options {
 		opts := formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true}
 		if formatName == "json" {
 			opts.SortKeys = true
@@ -1064,7 +1064,7 @@ func Test_FormatFixUnwritableDirectory(t *testing.T) {
 	rep := &captureReporter{}
 	cli := Init(WithFinder(fsFinder), WithReporters(rep), WithFix(true))
 
-	exitStatus, err := cli.Format(func(_ string) formatter.Options {
+	exitStatus, err := cli.Format(func(_, _ string) formatter.Options {
 		return formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true, SortKeys: true}
 	})
 	require.NoError(t, err)

--- a/pkg/cli/format.go
+++ b/pkg/cli/format.go
@@ -16,8 +16,10 @@ import (
 	"github.com/Boeing/config-file-validator/v3/pkg/reporter"
 )
 
-// FormatOptionsFunc returns resolved format options for a given format name.
-type FormatOptionsFunc func(formatName string) formatter.Options
+// FormatOptionsFunc returns resolved format options for a given format name
+// and file path. The path matters because .editorconfig settings are resolved
+// per file.
+type FormatOptionsFunc func(formatName, path string) formatter.Options
 
 // Format runs the formatting pipeline.
 //
@@ -84,7 +86,7 @@ func (c *CLI) Format(optsFunc FormatOptionsFunc) (int, error) {
 		wg.Go(func() {
 			for idx := range jobCh {
 				j := jobs[idx]
-				opts := optsFunc(j.formatName)
+				opts := optsFunc(j.formatName, j.path)
 				results[idx] = c.formatFile(j.path, j.name, j.fmter, opts)
 			}
 		})

--- a/pkg/formatter/editorconfig.go
+++ b/pkg/formatter/editorconfig.go
@@ -1,0 +1,81 @@
+package formatter
+
+import (
+	"strconv"
+	"sync"
+
+	editorconfig "github.com/editorconfig/editorconfig-core-go/v2"
+)
+
+// EditorConfig resolves .editorconfig settings for individual files.
+//
+// EditorConfig resolution is per-file: the properties that apply depend on the
+// file's path (glob sections) and on the .editorconfig files found walking up
+// from its directory (stopping at root = true). The zero value is not usable;
+// use NewEditorConfig.
+//
+// Safe for concurrent use.
+type EditorConfig struct {
+	mu     sync.Mutex
+	config editorconfig.Config
+}
+
+// NewEditorConfig returns an EditorConfig backed by a cached parser, so
+// .editorconfig files shared by many source files are only parsed once.
+func NewEditorConfig() *EditorConfig {
+	return &EditorConfig{
+		config: editorconfig.Config{Parser: editorconfig.NewCachedParser()},
+	}
+}
+
+// Apply overlays the .editorconfig properties that apply to path onto opts.
+// Properties that are absent, unset, or not representable as an Option are
+// left alone.
+//
+// A malformed or unreadable .editorconfig is ignored rather than reported — it
+// is not the file being formatted, and failing the run over someone else's
+// editor settings is worse than using the defaults.
+func (e *EditorConfig) Apply(opts *Options, path string) {
+	// editorconfig.Config is not safe for concurrent use (the cached parser
+	// writes to shared maps), and cfv formats files in parallel.
+	// A warning means one section was unusable, not that the whole lookup
+	// failed, so LoadGraceful lets us keep the properties that did parse.
+	e.mu.Lock()
+	def, _, err := e.config.LoadGraceful(path)
+	e.mu.Unlock()
+	if err != nil {
+		return
+	}
+
+	switch def.IndentStyle {
+	case editorconfig.IndentStyleSpaces:
+		opts.IndentStyle = IndentSpaces
+	case editorconfig.IndentStyleTab:
+		opts.IndentStyle = IndentTabs
+	default:
+		// Unset or unrecognised, so keep the caller's style.
+	}
+
+	// indent_size = tab means "use tab_width", which the library has already
+	// resolved into TabWidth for us.
+	if def.IndentSize == "tab" {
+		if def.TabWidth > 0 {
+			opts.IndentWidth = def.TabWidth
+		}
+	} else if n, err := strconv.Atoi(def.IndentSize); err == nil && n > 0 {
+		opts.IndentWidth = n
+	}
+
+	switch def.EndOfLine {
+	case editorconfig.EndOfLineLf:
+		opts.LineEnding = LineEndingLF
+	case editorconfig.EndOfLineCrLf:
+		opts.LineEnding = LineEndingCRLF
+	default:
+		// Unset, or "cr", which cfv does not emit.
+	}
+
+	if def.InsertFinalNewline != nil {
+		opts.FinalNewline = *def.InsertFinalNewline
+	}
+}

--- a/pkg/formatter/editorconfig_test.go
+++ b/pkg/formatter/editorconfig_test.go
@@ -1,0 +1,128 @@
+package formatter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Boeing/config-file-validator/v3/pkg/formatter"
+)
+
+// writeEditorConfig writes an .editorconfig with the given content into dir.
+func writeEditorConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte(content), 0o600))
+}
+
+func TestEditorConfigApply_MapsProperties(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeEditorConfig(t, dir, `root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = crlf
+insert_final_newline = false
+`)
+
+	opts := formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true}
+	formatter.NewEditorConfig().Apply(&opts, filepath.Join(dir, "config.json"))
+
+	require.Equal(t, formatter.IndentTabs, opts.IndentStyle)
+	require.Equal(t, 4, opts.IndentWidth)
+	require.Equal(t, formatter.LineEndingCRLF, opts.LineEnding)
+	require.False(t, opts.FinalNewline)
+}
+
+func TestEditorConfigApply_PerFileGlobs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeEditorConfig(t, dir, `root = true
+
+[*]
+indent_size = 2
+
+[*.yaml]
+indent_size = 8
+`)
+
+	ec := formatter.NewEditorConfig()
+
+	yamlOpts := formatter.Options{IndentWidth: 3}
+	ec.Apply(&yamlOpts, filepath.Join(dir, "app.yaml"))
+	require.Equal(t, 8, yamlOpts.IndentWidth)
+
+	jsonOpts := formatter.Options{IndentWidth: 3}
+	ec.Apply(&jsonOpts, filepath.Join(dir, "app.json"))
+	require.Equal(t, 2, jsonOpts.IndentWidth)
+}
+
+func TestEditorConfigApply_NestedOverridesParent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeEditorConfig(t, dir, "root = true\n\n[*]\nindent_size = 2\nend_of_line = lf\n")
+	nested := filepath.Join(dir, "nested")
+	writeEditorConfig(t, nested, "[*]\nindent_size = 6\n")
+
+	opts := formatter.Options{}
+	formatter.NewEditorConfig().Apply(&opts, filepath.Join(nested, "app.json"))
+
+	// Closest file wins for indent_size, parent still supplies end_of_line.
+	require.Equal(t, 6, opts.IndentWidth)
+	require.Equal(t, formatter.LineEndingLF, opts.LineEnding)
+}
+
+func TestEditorConfigApply_RootStopsUpwardSearch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeEditorConfig(t, dir, "[*]\nindent_size = 9\n")
+	nested := filepath.Join(dir, "nested")
+	writeEditorConfig(t, nested, "root = true\n\n[*]\nindent_style = space\n")
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewEditorConfig().Apply(&opts, filepath.Join(nested, "app.json"))
+
+	require.Equal(t, formatter.IndentSpaces, opts.IndentStyle)
+	require.Equal(t, 2, opts.IndentWidth, "parent .editorconfig must not be read past root = true")
+}
+
+func TestEditorConfigApply_IndentSizeTabUsesTabWidth(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeEditorConfig(t, dir, "root = true\n\n[*]\nindent_style = tab\nindent_size = tab\ntab_width = 3\n")
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewEditorConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, 3, opts.IndentWidth)
+}
+
+func TestEditorConfigApply_LeavesOptionsAloneWhenAbsent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// No .editorconfig anywhere under the temp dir, and root = true blocks any
+	// real .editorconfig above it from leaking into the test.
+	writeEditorConfig(t, dir, "root = true\n")
+
+	want := formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true}
+	got := want
+	formatter.NewEditorConfig().Apply(&got, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, want, got)
+}
+
+func TestEditorConfigApply_MalformedFileIsIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeEditorConfig(t, dir, "root = true\n\n[*\nindent_size = not-a-number\n")
+
+	want := formatter.Options{IndentWidth: 2}
+	got := want
+	formatter.NewEditorConfig().Apply(&got, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, want, got)
+}

--- a/website/docs/guides/formatting.md
+++ b/website/docs/guides/formatting.md
@@ -48,6 +48,33 @@ Running `cfv format --fix` twice always produces the same output. If a file is a
 
 ## Configuration
 
+Format settings are resolved per file, lowest priority first:
+
+`.editorconfig` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags
+
+### `.editorconfig`
+
+If your project has an `.editorconfig`, cfv reads it and uses it as the baseline,
+so formatted output matches what your editors already produce without any cfv
+configuration. The properties cfv understands:
+
+| EditorConfig property  | cfv option       |
+|------------------------|------------------|
+| `indent_style`         | Spaces or tabs   |
+| `indent_size`          | Indent width     |
+| `end_of_line`          | Line ending      |
+| `insert_final_newline` | Trailing newline |
+
+Resolution follows the EditorConfig spec: glob sections are matched against each
+file individually, `.editorconfig` files in parent directories apply to nested
+files, and `root = true` stops the upward search. Other properties are ignored,
+and an unreadable or malformed `.editorconfig` is skipped rather than failing the
+run.
+
+Pass `--no-editorconfig` to ignore `.editorconfig` entirely.
+
+### `.cfv.toml`
+
 Format settings live in `.cfv.toml` at the root of your project.
 
 Global defaults apply to all formats. Per-format sections override them:
@@ -69,13 +96,14 @@ With this config, all formats use 2-space indent with keys unsorted, except TOML
 
 ## CLI flags
 
-These flags override `.cfv.toml` settings for a single invocation:
+These flags override `.cfv.toml` and `.editorconfig` settings for a single invocation:
 
 | Flag | Effect |
 |------|--------|
 | `--indent <n>` | Set indent width |
 | `--sort-keys` | Sort keys alphabetically |
 | `--no-final-newline` | Omit trailing newline |
+| `--no-editorconfig` | Ignore `.editorconfig` files |
 
 Example: check formatting with 4-space indent regardless of config file:
 

--- a/website/docs/reference/cli-flags.md
+++ b/website/docs/reference/cli-flags.md
@@ -63,6 +63,7 @@ Checks formatting of config files. With `--fix`, rewrites files in place. With `
 | `-diff`       | bool   | `false` | Print unified diff of formatting changes. Mutually exclusive with `-fix`. |
 | `-indent`     | int    | `2`     | Override indent width (number of spaces per level).           |
 | `-sort-keys`  | bool   | `false` | Sort mapping keys alphabetically.                            |
+| `-no-editorconfig` | bool | `false` | Ignore `.editorconfig` files when resolving format options. |
 
 ### Shared flags
 


### PR DESCRIPTION
## Summary

- resolve `.editorconfig` properties per file and use them as the formatting baseline
- add `--no-editorconfig` to skip the layer entirely
- extend `cli.FormatOptionsFunc` with the file path, since settings now depend on the file
- add unit and testscript coverage, and document the new cascade layer

Closes #562

## Motivation

Most projects already declare indent style, indent width, line endings, and final-newline policy in `.editorconfig`. Before this change `cfv format` ignored it, so a project whose editors produce 4-space indent needed a `.cfv.toml` restating the same thing to stop `cfv format --fix` reindenting everything to 2.

`.editorconfig` now slots in as a new layer below `.cfv.toml`:

`CLI flags > [format.<type>] > [format] > .editorconfig > defaults`

The `Options` doc comment in `pkg/formatter/formatter.go` already described the cascade this way, so this fills in the layer that was missing.

## Behavior

Four properties map onto existing `formatter.Options`:

| EditorConfig property | cfv option |
|---|---|
| `indent_style` | Spaces or tabs |
| `indent_size` | Indent width |
| `end_of_line` | Line ending |
| `insert_final_newline` | Trailing newline |

Resolution follows the spec: glob sections are matched against each path, `.editorconfig` files in parent directories apply to nested files, and `root = true` stops the upward walk. `indent_size = tab` defers to `tab_width`. `end_of_line = cr` is ignored because cfv does not emit it. Everything comes from `editorconfig-core-go`, already a direct dependency of the `.editorconfig` validator — `go.mod` is unchanged.

Because this applies in the shared options resolver rather than per formatter, all 9 formatters pick it up with no formatter-side changes.

## Notes for review

Two decisions worth a second opinion:

- **`FormatOptionsFunc` signature change.** EditorConfig resolution is per file, not per format, so the callback needs the path. This is the source of the mechanical churn in `pkg/cli/cli_test.go`.
- **Failures are swallowed.** A malformed or unreadable `.editorconfig` is skipped rather than reported: it is not the file being formatted, and someone else's editor settings should not fail the run. `LoadGraceful` is used over `Load` so a single bad section does not discard the properties that did parse. If you would rather surface a warning, that needs error plumbing through `optsFunc` and I am happy to add it.

`format` runs files through a `runtime.NumCPU()` worker pool and `editorconfig.CachedParser` has no internal locking, so lookups are serialised behind a mutex. Verified under `-race`.

## Validation

- `go vet ./...`
- `test -z "$(gofmt -s -l -e .)"`
- `golangci-lint run ./...` (0 issues)
- `go build -o /dev/null cmd/cfv/cfv.go`
- `go test ./...`
- `go test -race ./pkg/formatter/... ./pkg/cli/...`
- `go run -race ./cmd/cfv format` over 60 files sharing one `.editorconfig` — no race
- manual: `.editorconfig` indent 6 applied; `--no-editorconfig` reverted to 2; `.cfv.toml indent = 4` overrode it; `--indent 8` overrode both