### PR TITLE
fix(formatter): normalize JSON blank lines before closing delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON and JSONC formatting removes blank lines before closing braces and brackets while preserving blank lines between members (closes #581).
 - TOML formatting now leaves entries under table headers unindented by default while preserving explicit indentation overrides (closes #558).
 - XML files without a DOCTYPE declaration are validated as syntax-only again; `ValidateSyntax` now enables DTD validation only when a DOCTYPE is present, restoring compatibility after upgrading `helium` to v0.5.1's stricter "DTD required" semantics (closes #546)
 - Local JSON Schema paths are encoded as file URLs on Windows (closes #550)

--- a/pkg/formatter/jsoncfmt/jsonc.go
+++ b/pkg/formatter/jsoncfmt/jsonc.go
@@ -142,7 +142,7 @@ func (fs *formatState) formatObject(obj *hujson.Object, depth int) {
 			// Comments in empty objects need proper indentation.
 			childIndent := "\n" + strings.Repeat(fs.indent, depth+1)
 			closeIndent := "\n" + strings.Repeat(fs.indent, depth)
-			obj.AfterExtra = reindentExtra(obj.AfterExtra, childIndent)
+			obj.AfterExtra = reindentCompactExtra(obj.AfterExtra, childIndent)
 			// Ensure closing brace is on its own line after the comment.
 			s := string(obj.AfterExtra)
 			if !strings.HasSuffix(s, closeIndent) {
@@ -161,7 +161,11 @@ func (fs *formatState) formatObject(obj *hujson.Object, depth int) {
 		m := &obj.Members[i]
 
 		// Preserve comments from BeforeExtra, apply correct indentation.
-		m.Name.BeforeExtra = reindentExtra(m.Name.BeforeExtra, childIndent)
+		if i == 0 {
+			m.Name.BeforeExtra = reindentCompactExtra(m.Name.BeforeExtra, childIndent)
+		} else {
+			m.Name.BeforeExtra = reindentExtra(m.Name.BeforeExtra, childIndent)
+		}
 		m.Name.AfterExtra = nil
 
 		// Single space between colon and value.
@@ -178,7 +182,7 @@ func (fs *formatState) formatObject(obj *hujson.Object, depth int) {
 		last.Value.AfterExtra = ensureTrailingComma(last.Value.AfterExtra)
 	}
 
-	obj.AfterExtra = reindentExtra(obj.AfterExtra, closeIndent)
+	obj.AfterExtra = reindentCompactExtra(obj.AfterExtra, closeIndent)
 	if obj.AfterExtra == nil {
 		obj.AfterExtra = hujson.Extra(closeIndent)
 	}
@@ -190,7 +194,7 @@ func (fs *formatState) formatArray(arr *hujson.Array, depth int) {
 		if hasComment(arr.AfterExtra) {
 			childIndent := "\n" + strings.Repeat(fs.indent, depth+1)
 			closeIndent := "\n" + strings.Repeat(fs.indent, depth)
-			arr.AfterExtra = reindentExtra(arr.AfterExtra, childIndent)
+			arr.AfterExtra = reindentCompactExtra(arr.AfterExtra, childIndent)
 			s := string(arr.AfterExtra)
 			if !strings.HasSuffix(s, closeIndent) {
 				arr.AfterExtra = hujson.Extra(s + closeIndent)
@@ -222,7 +226,11 @@ func (fs *formatState) formatArray(arr *hujson.Array, depth int) {
 	closeIndent := "\n" + strings.Repeat(fs.indent, depth)
 
 	for i := range arr.Elements {
-		arr.Elements[i].BeforeExtra = reindentExtra(arr.Elements[i].BeforeExtra, childIndent)
+		if i == 0 {
+			arr.Elements[i].BeforeExtra = reindentCompactExtra(arr.Elements[i].BeforeExtra, childIndent)
+		} else {
+			arr.Elements[i].BeforeExtra = reindentExtra(arr.Elements[i].BeforeExtra, childIndent)
+		}
 		arr.Elements[i].AfterExtra = clearWhitespace(arr.Elements[i].AfterExtra)
 		fs.formatValue(&arr.Elements[i], depth+1)
 	}
@@ -233,7 +241,7 @@ func (fs *formatState) formatArray(arr *hujson.Array, depth int) {
 		last.AfterExtra = ensureTrailingComma(last.AfterExtra)
 	}
 
-	arr.AfterExtra = reindentExtra(arr.AfterExtra, closeIndent)
+	arr.AfterExtra = reindentCompactExtra(arr.AfterExtra, closeIndent)
 	if arr.AfterExtra == nil {
 		arr.AfterExtra = hujson.Extra(closeIndent)
 	}
@@ -266,8 +274,7 @@ func hasComment(extra hujson.Extra) bool {
 }
 
 // reindentExtra normalizes indentation in Extra (comment/whitespace) content.
-// Blank lines between comments are collapsed — this matches prettier's behavior
-// of not preserving blank lines within structures.
+// Blank lines between sibling members are preserved.
 func reindentExtra(extra hujson.Extra, newIndent string) hujson.Extra {
 	if extra == nil {
 		return hujson.Extra(newIndent)
@@ -277,6 +284,11 @@ func reindentExtra(extra hujson.Extra, newIndent string) hujson.Extra {
 
 	// If extra is whitespace-only (no comments), replace entirely.
 	if !hasComment(extra) {
+		lineBreaks := strings.Count(s, "\n")
+		if lineBreaks > 1 {
+			indent := strings.TrimPrefix(newIndent, "\n")
+			return hujson.Extra(strings.Repeat("\n", lineBreaks) + indent)
+		}
 		return hujson.Extra(newIndent)
 	}
 
@@ -300,6 +312,15 @@ func reindentExtra(extra hujson.Extra, newIndent string) hujson.Extra {
 	b.WriteString(newIndent)
 
 	return hujson.Extra(b.String())
+}
+
+// reindentCompactExtra normalizes leading and closing trivia without
+// preserving blank lines.
+func reindentCompactExtra(extra hujson.Extra, newIndent string) hujson.Extra {
+	if extra == nil || !hasComment(extra) {
+		return hujson.Extra(newIndent)
+	}
+	return reindentExtra(extra, newIndent)
 }
 
 // clearWhitespace removes whitespace from Extra but preserves comments.

--- a/pkg/formatter/jsoncfmt/testdata/trailing_blank_lines.expected.jsonc
+++ b/pkg/formatter/jsoncfmt/testdata/trailing_blank_lines.expected.jsonc
@@ -1,0 +1,18 @@
+{
+  // Keep blank lines between logical sections.
+  "sections": {
+    "first": 1,
+
+    "second": 2
+  },
+
+  "items": [
+    {
+      "name": "one"
+    },
+
+    {
+      "name": "two"
+    }
+  ]
+}

--- a/pkg/formatter/jsoncfmt/testdata/trailing_blank_lines.input.jsonc
+++ b/pkg/formatter/jsoncfmt/testdata/trailing_blank_lines.input.jsonc
@@ -1,0 +1,23 @@
+{
+  // Keep blank lines between logical sections.
+  "sections": {
+    "first": 1,
+
+    "second": 2
+
+  },
+
+  "items": [
+    {
+      "name": "one"
+
+    },
+
+    {
+      "name": "two"
+
+    }
+
+  ]
+
+}

--- a/pkg/formatter/jsonfmt/json.go
+++ b/pkg/formatter/jsonfmt/json.go
@@ -12,7 +12,9 @@ package jsonfmt
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
+	"github.com/tailscale/hujson"
 	"github.com/tidwall/pretty"
 
 	"github.com/Boeing/config-file-validator/v3/pkg/formatter"
@@ -52,6 +54,7 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 	}
 
 	result := pretty.PrettyOptions(src, prettyOpts)
+	result = preserveMemberBlankLines(src, result)
 
 	// pretty always appends a trailing newline. Strip it if FinalNewline is false.
 	if !resolved.FinalNewline && len(result) > 0 && result[len(result)-1] == '\n' {
@@ -59,6 +62,103 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 	}
 
 	return formatter.NormalizeLineEndings(result, resolved.LineEnding), nil
+}
+
+// preserveMemberBlankLines restores blank lines between sibling members and
+// elements after tidwall/pretty has normalized the JSON structure. Whitespace
+// before closing delimiters is intentionally not copied.
+func preserveMemberBlankLines(src, formatted []byte) []byte {
+	source, err := hujson.Parse(src)
+	if err != nil {
+		return formatted
+	}
+
+	output, err := hujson.Parse(formatted)
+	if err != nil {
+		return formatted
+	}
+
+	copyMemberBlankLines(&source, &output)
+	return output.Pack()
+}
+
+func copyMemberBlankLines(source, output *hujson.Value) {
+	switch sourceValue := source.Value.(type) {
+	case *hujson.Object:
+		outputValue, ok := output.Value.(*hujson.Object)
+		if !ok {
+			return
+		}
+
+		sourceMembers := make(map[string][]int, len(sourceValue.Members))
+		for i := range sourceValue.Members {
+			key := objectMemberKey(&sourceValue.Members[i])
+			sourceMembers[key] = append(sourceMembers[key], i)
+		}
+
+		for i := range outputValue.Members {
+			outputMember := &outputValue.Members[i]
+			key := objectMemberKey(outputMember)
+			matches := sourceMembers[key]
+			if len(matches) == 0 {
+				continue
+			}
+
+			sourceIndex := matches[0]
+			sourceMembers[key] = matches[1:]
+			sourceMember := &sourceValue.Members[sourceIndex]
+
+			if i > 0 && sourceIndex > 0 {
+				outputMember.Name.BeforeExtra = preserveBlankLinePrefix(
+					sourceMember.Name.BeforeExtra,
+					outputMember.Name.BeforeExtra,
+				)
+			}
+			copyMemberBlankLines(&sourceMember.Value, &outputMember.Value)
+		}
+	case *hujson.Array:
+		outputValue, ok := output.Value.(*hujson.Array)
+		if !ok {
+			return
+		}
+
+		count := min(len(sourceValue.Elements), len(outputValue.Elements))
+		for i := range count {
+			if i > 0 {
+				outputValue.Elements[i].BeforeExtra = preserveBlankLinePrefix(
+					sourceValue.Elements[i].BeforeExtra,
+					outputValue.Elements[i].BeforeExtra,
+				)
+			}
+			copyMemberBlankLines(&sourceValue.Elements[i], &outputValue.Elements[i])
+		}
+	default:
+		// Literals have no member whitespace to preserve.
+	}
+}
+
+func objectMemberKey(member *hujson.ObjectMember) string {
+	literal, ok := member.Name.Value.(hujson.Literal)
+	if !ok {
+		return ""
+	}
+	return string(literal)
+}
+
+func preserveBlankLinePrefix(source, output hujson.Extra) hujson.Extra {
+	lineBreaks := strings.Count(string(source), "\n")
+	if lineBreaks < 2 {
+		return output
+	}
+
+	outputString := string(output)
+	lastLineBreak := strings.LastIndexByte(outputString, '\n')
+	if lastLineBreak < 0 {
+		return output
+	}
+
+	indent := outputString[lastLineBreak+1:]
+	return hujson.Extra(strings.Repeat("\n", lineBreaks) + indent)
 }
 
 // resolveOptions fills zero-value options with JSON defaults.

--- a/pkg/formatter/jsonfmt/testdata/trailing_blank_lines.expected.json
+++ b/pkg/formatter/jsonfmt/testdata/trailing_blank_lines.expected.json
@@ -1,0 +1,17 @@
+{
+  "sections": {
+    "first": 1,
+
+    "second": 2
+  },
+
+  "items": [
+    {
+      "name": "one"
+    },
+
+    {
+      "name": "two"
+    }
+  ]
+}

--- a/pkg/formatter/jsonfmt/testdata/trailing_blank_lines.input.json
+++ b/pkg/formatter/jsonfmt/testdata/trailing_blank_lines.input.json
@@ -1,0 +1,22 @@
+{
+  "sections": {
+    "first": 1,
+
+    "second": 2
+
+  },
+
+  "items": [
+    {
+      "name": "one"
+
+    },
+
+    {
+      "name": "two"
+
+    }
+
+  ]
+
+}


### PR DESCRIPTION
## Summary

- Preserve blank lines between logical JSON and JSONC members and multiline array elements.
- Remove whitespace-only lines immediately before closing braces and brackets.
- Add JSON and JSONC fixtures covering nested closers, logical section spacing, and array element spacing.
- Document the formatter fix in the changelog.

Closes #581

## Testing

- go vet ./...
- gofmt -s -l -e .
- golangci-lint run ./... (0 issues)
- go generate ./pkg/filetype/... and verify no generated diff
- CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags netgo cmd/cfv/cfv.go
- go test -count=1 -cover -coverprofile=coverage.out ./... on non-root Linux
- total coverage: 90.9%