### PR TITLE
feat(format): auto-detect taplo.toml for TOML formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--sort-keys` flag to sort mapping keys alphabetically on `cfv format`
 - `--diff` flag for previewing formatting changes without modifying files
 - Per-format configuration in `.cfv.toml` via `[format.<type>]` tables (yaml, json, jsonc, toml, hcl, xml, ini, properties, env)
-- Format configuration cascade: CLI flags > per-format config > global `[format]` config > `.editorconfig` > defaults
+- Format configuration cascade: CLI flags > per-format config > global `[format]` config > `taplo.toml` > `.editorconfig` > defaults
 - `trailing-commas` format option (`preserve` | `all` | `none`) to control trailing commas on multiline JSONC collections
 - `.editorconfig` auto-detection for `cfv format`: `indent_style`, `indent_size`, `end_of_line`, and `insert_final_newline` are resolved per file (globs, parent directories, and `root = true` are all respected). Disable with `--no-editorconfig` (closes #562)
+- `taplo.toml` / `.taplo.toml` auto-detection for TOML formatting: `indent_string`, `column_width`, `trailing_newline`, `reorder_keys`, `crlf`, and `array_trailing_comma` are mapped onto the equivalent cfv options. Disable with `--no-taplo-config` (closes #564)
+- `max-line-width` and `trailing-commas` are now honored by the TOML formatter
 - Schema validation support for JSONC files via `$schema`, `--schema-map`, and SchemaStore
 - Schema validation support for Properties files via `--schema-map` in `.cfv.toml`
 - **cfv 3.0 Phase 1**: Renamed binary from `validator` to `cfv`. This is a breaking change — no compatibility shim ships. Update scripts: `validator .` → `cfv check .`

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -96,6 +96,7 @@ type cfvConfig struct {
 	fmtQuoteStyle     *string
 	fmtDiff           *bool
 	fmtNoEditorConfig *bool
+	fmtNoTaploConfig  *bool
 }
 
 // reporterConfig pairs a reporter format name with an optional output path.
@@ -524,6 +525,7 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 		fmtMaxLineWidthPtr   = fs.Int("max-line-width", 0, "Max line width hint (0 = unlimited)")
 		fmtQuoteStylePtr     = fs.String("quote-style", "", "Quote style: double, single, preserve")
 		fmtNoEditorConfigPtr = fs.Bool("no-editorconfig", false, "Ignore .editorconfig files when resolving format options")
+		fmtNoTaploConfigPtr  = fs.Bool("no-taplo-config", false, "Ignore taplo.toml files when resolving TOML format options")
 		fmtDiffPtr           = fs.Bool("diff", false, "Show unified diff instead of rewriting (implies no --fix)")
 	)
 
@@ -603,6 +605,7 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 		fmtQuoteStyle:     fmtQuoteStylePtr,
 		fmtDiff:           fmtDiffPtr,
 		fmtNoEditorConfig: fmtNoEditorConfigPtr,
+		fmtNoTaploConfig:  fmtNoTaploConfigPtr,
 	}, nil
 }
 
@@ -613,7 +616,7 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 // buildFormatOptionsResolver builds a function that resolves format options
 // for any format name using the cascade:
 //
-//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > .editorconfig > format-specific defaults
+//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > taplo.toml > .editorconfig > format-specific defaults
 func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOptionsFunc {
 	var globalCfg *configfile.FormatOptions
 	var perFormatCfg map[string]*configfile.FormatOptions
@@ -621,6 +624,11 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 	var editorCfg *formatter.EditorConfig
 	if cfg.fmtNoEditorConfig == nil || !*cfg.fmtNoEditorConfig {
 		editorCfg = formatter.NewEditorConfig()
+	}
+
+	var taploCfg *formatter.Taplo
+	if cfg.fmtNoTaploConfig == nil || !*cfg.fmtNoTaploConfig {
+		taploCfg = formatter.LoadTaplo(".")
 	}
 
 	if rc.formatCfg != nil {
@@ -656,19 +664,25 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 			}
 		}
 
-		// Layer 3: .cfv.toml [format] (global)
+		// Layer 3: taplo.toml, which only configures TOML formatting.
+		// Apply is a no-op when no taplo.toml was found.
+		if formatName == "toml" {
+			taploCfg.Apply(&opts)
+		}
+
+		// Layer 4: .cfv.toml [format] (global)
 		if globalCfg != nil {
 			applyFormatOptions(&opts, globalCfg)
 		}
 
-		// Layer 4: .cfv.toml [format.<type>]
+		// Layer 5: .cfv.toml [format.<type>]
 		if perFormatCfg != nil {
 			if perFmt := perFormatCfg[formatName]; perFmt != nil {
 				applyFormatOptions(&opts, perFmt)
 			}
 		}
 
-		// Layer 5: CLI flags (highest priority)
+		// Layer 6: CLI flags (highest priority)
 		applyCLIFormatFlags(&opts, cfg)
 
 		return opts

--- a/cmd/cfv/testdata/format_taplo.txtar
+++ b/cmd/cfv/testdata/format_taplo.txtar
@@ -1,0 +1,87 @@
+# ============================================================
+# taplo.toml auto-detection
+# Proves: CLI flags > .cfv.toml > taplo.toml > defaults,
+# TOML-only scope, .taplo.toml, and --no-taplo-config.
+# The taplo.toml is servo's, verbatim.
+# ============================================================
+
+# indent_string = "    " indents entries under a table header
+cp orig.toml app.toml
+exec cfv format --fix --no-config app.toml
+exec cat app.toml
+stdout '^    host'
+
+# --no-taplo-config falls back to the TOML default of no indentation
+cp orig.toml app.toml
+exec cfv format --fix --no-config --no-taplo-config app.toml
+exec cat app.toml
+stdout '^host'
+
+# .cfv.toml overrides taplo.toml
+cp orig.toml app.toml
+exec cfv format --fix --config=cfv/indent2.toml app.toml
+exec cat app.toml
+stdout '^  host'
+
+# CLI flags override both
+cp orig.toml app.toml
+exec cfv format --fix --config=cfv/indent2.toml --indent=8 app.toml
+exec cat app.toml
+stdout '^        host'
+
+# column_width = 120 keeps an 80-column array on one line
+cp orig-array.toml array.toml
+exec cfv format --fix --no-config array.toml
+exec cat array.toml
+stdout '^ports = \["aaaaaaaaaa"'
+
+# without taplo.toml the width is taplo's default of 80, so it expands
+cp orig-array.toml array.toml
+exec cfv format --fix --no-config --no-taplo-config array.toml
+exec cat array.toml
+stdout '^  "aaaaaaaaaa",'
+
+# taplo.toml configures TOML only, so JSON keeps the default 2-space indent
+exec cfv format --fix --no-config app.json
+exec cat app.json
+stdout '^  "key"'
+
+# .taplo.toml is discovered too
+cd dotted
+exec cfv format --fix --no-config app.toml
+exec cat app.toml
+stdout '^	host'
+
+-- taplo.toml --
+# upstream files we should not format
+exclude = ["third_party/**", "tests/**"]
+
+[formatting]
+array_auto_collapse = false
+array_auto_expand = false
+align_comments = false
+column_width = 120
+indent_string = "    "
+-- .editorconfig --
+root = true
+-- orig.toml --
+[server]
+host = "example"
+-- app.toml --
+[server]
+host = "example"
+-- orig-array.toml --
+ports = ["aaaaaaaaaa", "bbbbbbbbbb", "cccccccccc", "dddddddddd", "eeeeeeeeee", "ffffff"]
+-- array.toml --
+ports = []
+-- app.json --
+{"key":{"nested":"value"}}
+-- cfv/indent2.toml --
+[format]
+indent = 2
+-- dotted/.taplo.toml --
+[formatting]
+indent_string = "\t"
+-- dotted/app.toml --
+[server]
+host = "example"

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -31,7 +31,7 @@ type Formatter interface {
 //
 // Options are resolved by the CLI before being passed to a formatter:
 //
-//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > .editorconfig > hardcoded defaults
+//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > taplo.toml > .editorconfig > hardcoded defaults
 type Options struct {
 	// IndentStyle selects spaces or tabs. Zero value = format default.
 	IndentStyle IndentStyle

--- a/pkg/formatter/taplo.go
+++ b/pkg/formatter/taplo.go
@@ -1,0 +1,106 @@
+package formatter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// taploFileNames are the taplo configuration file names, in search order.
+var taploFileNames = []string{"taplo.toml", ".taplo.toml"}
+
+// TaploFormatting mirrors the [formatting] table of a taplo.toml, limited to
+// the options cfv can represent. A nil field means the option is unset.
+//
+// Options cfv has no equivalent for (align_entries, align_comments,
+// compact_arrays, compact_inline_tables, array_auto_expand,
+// array_auto_collapse) are ignored, so cfv may still diverge from taplo on
+// those specific behaviors.
+type TaploFormatting struct {
+	IndentString       *string `toml:"indent_string"`
+	ColumnWidth        *int    `toml:"column_width"`
+	TrailingNewline    *bool   `toml:"trailing_newline"`
+	ReorderKeys        *bool   `toml:"reorder_keys"`
+	CRLF               *bool   `toml:"crlf"`
+	ArrayTrailingComma *bool   `toml:"array_trailing_comma"`
+}
+
+// Taplo is a parsed taplo.toml. It only applies to TOML files.
+type Taplo struct {
+	Formatting TaploFormatting `toml:"formatting"`
+}
+
+// LoadTaplo returns the taplo configuration found by walking up from startDir,
+// or nil if there is none. taplo.toml is preferred over .taplo.toml.
+//
+// A malformed or unreadable file yields nil rather than an error: it is not the
+// file being formatted, and another tool's config should not fail the run.
+// Apply is a no-op on a nil *Taplo, so callers need no nil check.
+func LoadTaplo(startDir string) *Taplo {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil
+	}
+	for {
+		for _, name := range taploFileNames {
+			data, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				continue
+			}
+			var t Taplo
+			if err := toml.Unmarshal(data, &t); err != nil {
+				return nil
+			}
+			return &t
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+		dir = parent
+	}
+}
+
+// Apply overlays the taplo settings cfv can represent onto opts.
+// Unset options are left alone.
+func (t *Taplo) Apply(opts *Options) {
+	if t == nil {
+		return
+	}
+	f := t.Formatting
+
+	if f.IndentString != nil {
+		switch s := *f.IndentString; {
+		case s != "" && strings.Trim(s, "\t") == "":
+			opts.IndentStyle = IndentTabs
+		case s != "" && strings.Trim(s, " ") == "":
+			opts.IndentStyle = IndentSpaces
+			opts.IndentWidth = len(s)
+		default:
+			// Empty, or a mix of tabs and spaces: no cfv equivalent.
+		}
+	}
+	if f.ColumnWidth != nil {
+		opts.MaxLineWidth = *f.ColumnWidth
+	}
+	if f.TrailingNewline != nil {
+		opts.FinalNewline = *f.TrailingNewline
+	}
+	if f.ReorderKeys != nil {
+		opts.SortKeys = *f.ReorderKeys
+	}
+	if f.CRLF != nil {
+		opts.LineEnding = LineEndingLF
+		if *f.CRLF {
+			opts.LineEnding = LineEndingCRLF
+		}
+	}
+	if f.ArrayTrailingComma != nil {
+		opts.TrailingCommas = TrailingCommasNone
+		if *f.ArrayTrailingComma {
+			opts.TrailingCommas = TrailingCommasAll
+		}
+	}
+}

--- a/pkg/formatter/taplo_test.go
+++ b/pkg/formatter/taplo_test.go
@@ -1,0 +1,131 @@
+package formatter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Boeing/config-file-validator/v3/pkg/formatter"
+)
+
+// writeTaplo writes a taplo config file with the given name and content into dir.
+func writeTaplo(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+}
+
+func TestTaploApply_MapsOptions(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTaplo(t, dir, "taplo.toml", `[formatting]
+indent_string = "    "
+column_width = 120
+trailing_newline = false
+reorder_keys = true
+crlf = true
+array_trailing_comma = false
+`)
+
+	opts := formatter.Options{IndentWidth: 0, FinalNewline: true}
+	formatter.LoadTaplo(dir).Apply(&opts)
+
+	require.Equal(t, formatter.IndentSpaces, opts.IndentStyle)
+	require.Equal(t, 4, opts.IndentWidth)
+	require.Equal(t, 120, opts.MaxLineWidth)
+	require.False(t, opts.FinalNewline)
+	require.True(t, opts.SortKeys)
+	require.Equal(t, formatter.LineEndingCRLF, opts.LineEnding)
+	require.Equal(t, formatter.TrailingCommasNone, opts.TrailingCommas)
+}
+
+func TestTaploApply_TabIndent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTaplo(t, dir, "taplo.toml", "[formatting]\nindent_string = \"\\t\"\n")
+
+	opts := formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2}
+	formatter.LoadTaplo(dir).Apply(&opts)
+
+	require.Equal(t, formatter.IndentTabs, opts.IndentStyle)
+	require.Equal(t, 2, opts.IndentWidth, "indent width is unused for tabs and must not be overwritten")
+}
+
+func TestTaploApply_UnsupportedOptionsIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// align_entries and friends have no cfv equivalent, and [[rule]] sections
+	// are taplo's per-glob overrides — none of it must disturb the options.
+	writeTaplo(t, dir, "taplo.toml", `include = ["**/*.toml"]
+
+[formatting]
+align_entries = true
+align_comments = false
+compact_arrays = true
+array_auto_expand = false
+
+[[rule]]
+include = ["Cargo.toml"]
+`)
+
+	want := formatter.Options{IndentWidth: 2, FinalNewline: true}
+	got := want
+	formatter.LoadTaplo(dir).Apply(&got)
+
+	require.Equal(t, want, got)
+}
+
+func TestLoadTaplo_PrefersTaploTomlOverDotted(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTaplo(t, dir, "taplo.toml", "[formatting]\ncolumn_width = 100\n")
+	writeTaplo(t, dir, ".taplo.toml", "[formatting]\ncolumn_width = 50\n")
+
+	opts := formatter.Options{}
+	formatter.LoadTaplo(dir).Apply(&opts)
+
+	require.Equal(t, 100, opts.MaxLineWidth)
+}
+
+func TestLoadTaplo_FindsDottedName(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTaplo(t, dir, ".taplo.toml", "[formatting]\ncolumn_width = 50\n")
+
+	opts := formatter.Options{}
+	formatter.LoadTaplo(dir).Apply(&opts)
+
+	require.Equal(t, 50, opts.MaxLineWidth)
+}
+
+func TestLoadTaplo_WalksUpToProjectRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTaplo(t, dir, "taplo.toml", "[formatting]\nreorder_keys = true\n")
+
+	opts := formatter.Options{}
+	formatter.LoadTaplo(filepath.Join(dir, "a", "b")).Apply(&opts)
+
+	require.True(t, opts.SortKeys)
+}
+
+func TestLoadTaplo_MalformedFileIsIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTaplo(t, dir, "taplo.toml", "[formatting\nindent_string = \n")
+
+	require.Nil(t, formatter.LoadTaplo(dir))
+}
+
+func TestTaploApply_NilIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	want := formatter.Options{IndentWidth: 2, FinalNewline: true}
+	got := want
+	var taplo *formatter.Taplo
+	taplo.Apply(&got)
+
+	require.Equal(t, want, got)
+}

--- a/pkg/formatter/tomlfmt/printer.go
+++ b/pkg/formatter/tomlfmt/printer.go
@@ -300,7 +300,7 @@ func (p *Printer) printArrayMultiline(elements [][]Token, depth int) {
 	closeIndent := strings.Repeat(valueIndent, depth)
 
 	p.buf.WriteByte('[')
-	for _, elem := range elements {
+	for i, elem := range elements {
 		p.writeNewline()
 		// Separate comments from value tokens to avoid duplication.
 		// Comments are emitted on their own lines above the value.
@@ -326,7 +326,9 @@ func (p *Printer) printArrayMultiline(elements [][]Token, depth int) {
 		if len(valueTokens) > 0 {
 			p.buf.WriteString(elemIndent)
 			p.writeValueTokensTrimmed(valueTokens)
-			p.buf.WriteByte(',')
+			if p.opts.TrailingComma || i < len(elements)-1 {
+				p.buf.WriteByte(',')
+			}
 		}
 	}
 	p.writeNewline()

--- a/pkg/formatter/tomlfmt/toml.go
+++ b/pkg/formatter/tomlfmt/toml.go
@@ -56,8 +56,8 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 
 	printOpts := PrintOptions{
 		Indent:        buildIndent(opts),
-		ColumnWidth:   80,
-		TrailingComma: true,
+		ColumnWidth:   columnWidth(opts),
+		TrailingComma: opts.TrailingCommas != formatter.TrailingCommasNone,
 		AllowedBlanks: 2,
 		SortKeys:      opts.SortKeys,
 		FinalNewline:  opts.FinalNewline,
@@ -66,6 +66,15 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 
 	out := NewPrinter(printOpts).Print(groups)
 	return out, nil
+}
+
+// columnWidth returns the width at which arrays are broken onto multiple
+// lines. 0 means unset, which keeps taplo's default of 80.
+func columnWidth(opts formatter.Options) int {
+	if opts.MaxLineWidth > 0 {
+		return opts.MaxLineWidth
+	}
+	return 80
 }
 
 // buildIndent constructs the indent string from options.

--- a/pkg/formatter/tomlfmt/toml_test.go
+++ b/pkg/formatter/tomlfmt/toml_test.go
@@ -142,6 +142,41 @@ func TestIndentedTableContents(t *testing.T) {
 	require.Contains(t, string(got), "  port = ", "expected 2-space indent")
 }
 
+// TestMaxLineWidthBreaksArrays verifies MaxLineWidth decides when an array is
+// split across lines. Without it the width is taplo's default of 80.
+func TestMaxLineWidthBreaksArrays(t *testing.T) {
+	t.Parallel()
+	src := []byte("arr = [\"aaaa\", \"bbbb\", \"cccc\"]\n")
+
+	got, err := f.Format(src, defaultOpts)
+	require.NoError(t, err)
+	require.Equal(t, string(src), string(got), "array fits in 80 columns")
+
+	opts := defaultOpts
+	opts.MaxLineWidth = 10
+	got, err = f.Format(src, opts)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "\n  \"aaaa\",", "expected one element per line")
+}
+
+// TestTrailingCommasNone drops the comma after the last array element.
+func TestTrailingCommasNone(t *testing.T) {
+	t.Parallel()
+	src := []byte("arr = [\n  \"aaaa\",\n  \"bbbb\",\n]\n")
+	opts := defaultOpts
+	opts.MaxLineWidth = 10
+
+	got, err := f.Format(src, opts)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "\"bbbb\",\n]", "preserve keeps the trailing comma")
+
+	opts.TrailingCommas = formatter.TrailingCommasNone
+	got, err = f.Format(src, opts)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "\"aaaa\",\n", "commas between elements are kept")
+	require.Contains(t, string(got), "\"bbbb\"\n]", "expected no trailing comma")
+}
+
 // FuzzFormat feeds arbitrary bytes to Format and checks:
 // - No panics on any input
 // - If Format succeeds, output re-parses without error

--- a/website/docs/guides/formatting.md
+++ b/website/docs/guides/formatting.md
@@ -50,7 +50,7 @@ Running `cfv format --fix` twice always produces the same output. If a file is a
 
 Format settings are resolved per file, lowest priority first:
 
-`.editorconfig` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags
+`.editorconfig` → `taplo.toml` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags
 
 ### `.editorconfig`
 
@@ -72,6 +72,30 @@ and an unreadable or malformed `.editorconfig` is skipped rather than failing th
 run.
 
 Pass `--no-editorconfig` to ignore `.editorconfig` entirely.
+
+### `taplo.toml`
+
+Rust projects usually configure TOML formatting with [taplo](https://taplo.tamasfe.dev/).
+cfv reads the nearest `taplo.toml` (or `.taplo.toml`), searching the current
+directory and its parents, and applies it to TOML files only:
+
+| Taplo option                   | cfv option       |
+|--------------------------------|------------------|
+| `formatting.indent_string`     | Indent width, or tabs |
+| `formatting.column_width`      | Max line width   |
+| `formatting.trailing_newline`  | Trailing newline |
+| `formatting.reorder_keys`      | Sort keys        |
+| `formatting.crlf`              | Line ending      |
+| `formatting.array_trailing_comma` | Trailing commas |
+
+Everything else is ignored, including `[[rule]]` sections and the options cfv
+has no equivalent for: `align_entries`, `align_comments`, `compact_arrays`,
+`compact_inline_tables`, `array_auto_expand`, and `array_auto_collapse`. A
+project that relies on those may still see cfv diverge from taplo on those
+specific behaviors. An unreadable or malformed `taplo.toml` is skipped rather
+than failing the run.
+
+Pass `--no-taplo-config` to ignore `taplo.toml` entirely.
 
 ### `.cfv.toml`
 
@@ -96,7 +120,7 @@ With this config, all formats use 2-space indent with keys unsorted, except TOML
 
 ## CLI flags
 
-These flags override `.cfv.toml` and `.editorconfig` settings for a single invocation:
+These flags override `.cfv.toml`, `taplo.toml`, and `.editorconfig` settings for a single invocation:
 
 | Flag | Effect |
 |------|--------|
@@ -104,6 +128,7 @@ These flags override `.cfv.toml` and `.editorconfig` settings for a single invoc
 | `--sort-keys` | Sort keys alphabetically |
 | `--no-final-newline` | Omit trailing newline |
 | `--no-editorconfig` | Ignore `.editorconfig` files |
+| `--no-taplo-config` | Ignore `taplo.toml` files |
 
 Example: check formatting with 4-space indent regardless of config file:
 

--- a/website/docs/reference/cli-flags.md
+++ b/website/docs/reference/cli-flags.md
@@ -64,6 +64,7 @@ Checks formatting of config files. With `--fix`, rewrites files in place. With `
 | `-indent`     | int    | `2`     | Override indent width (number of spaces per level).           |
 | `-sort-keys`  | bool   | `false` | Sort mapping keys alphabetically.                            |
 | `-no-editorconfig` | bool | `false` | Ignore `.editorconfig` files when resolving format options. |
+| `-no-taplo-config` | bool | `false` | Ignore `taplo.toml` files when resolving TOML format options. |
 
 ### Shared flags
 


### PR DESCRIPTION
## Summary

- Reads the nearest `taplo.toml` or `.taplo.toml`, searching the current directory and its parents, and applies it to TOML files only
- Maps the six taplo options that have a cfv equivalent onto `formatter.Options`
- Adds `--no-taplo-config` to skip the layer
- Makes `max-line-width` and `trailing-commas` real for the TOML formatter, which is what two of the mappings needed

Closes #564

## Motivation

Rust projects configure TOML formatting with taplo, not with cfv. Running `cfv format` in one of them reformats `Cargo.toml` against cfv's defaults and fights whatever taplo already agreed on. Reading `taplo.toml` makes cfv match the project it is running in without anyone writing a `.cfv.toml`.

## Behavior

The layer sits above `.editorconfig` and below `.cfv.toml`, so the full cascade is now:

`.editorconfig` → `taplo.toml` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags

| Taplo option | cfv option |
|---|---|
| `formatting.indent_string` | indent width, or tabs |
| `formatting.column_width` | max line width |
| `formatting.trailing_newline` | trailing newline |
| `formatting.reorder_keys` | sort keys |
| `formatting.crlf` | line ending |
| `formatting.array_trailing_comma` | trailing commas |

`indent_string` is all spaces → spaces at that width; all tabs → tabs; empty or mixed → left alone, since cfv has no equivalent. Everything else in the file is ignored, including `[[rule]]` sections and the options cfv cannot express (`align_entries`, `align_comments`, `compact_arrays`, `compact_inline_tables`, `array_auto_expand`, `array_auto_collapse`); a project relying on those may still see cfv diverge there, and that is documented. A malformed or unreadable `taplo.toml` is skipped rather than failing the run, for the same reason `.editorconfig` is: it is not the file being formatted.

Two of the mappings targeted options the TOML formatter declared but never read — `PrintOptions.ColumnWidth` was pinned to `80` and `PrintOptions.TrailingComma` was never referenced. Both are now taken from `Options`, so `max-line-width` and `trailing-commas` also work for TOML from `.cfv.toml` and CLI flags. Defaults are unchanged: with no `max-line-width` set the width stays 80, and `trailing-commas` still defaults to `preserve`.

## Notes for review

`indent_string` maps to cfv's `indent`, so entries under a table header get indented. Taplo splits this into `indent_string` and a separate `indent_entries` (default `false`), so a project with `indent_string = "    "` and no `indent_entries` will see indented entries under cfv where taplo leaves them flush. I followed the mapping table in the issue rather than inventing a value-indent-only concept, but it is the one place the two tools can visibly disagree.

The `.editorconfig` layer has a guard that treats a zero/default `indent_size` as "leave unindented". I deliberately did not carry that over: `taplo.toml` is TOML-specific and explicit, so an `indent_string` in it is a statement of intent, not an editor-wide default that happened to apply.

## Acceptance criteria

- [x] cfv discovers `taplo.toml` and `.taplo.toml`
- [x] All 6 mappable options are applied correctly
- [x] `.cfv.toml` overrides taplo settings
- [x] `--no-taplo-config` flag to disable
- [x] Unsupported options are silently ignored
- [x] Tests with real `taplo.toml` from servo or swc
- [x] Documentation updated

The end-to-end test in `cmd/cfv/testdata/format_taplo.txtar` embeds servo's `taplo.toml` verbatim and covers indent from taplo, `--no-taplo-config`, `.cfv.toml` override, `--indent` override, `column_width = 120` keeping an 80-column array inline, JSON being unaffected, and discovery of the dotted `.taplo.toml` from a subdirectory.

## Validation

- `go build ./...`
- `go vet ./...`
- `test -z "$(gofmt -s -l -e .)"`
- `golangci-lint run ./... --timeout=10m` — 0 issues
- `go test ./...` — run on Windows; the `pkg/formatter/...` and `cmd/cfv` suites pass, and the handful of POSIX-path and symlink-privilege failures elsewhere are identical to those on `feat/3.0` at `44f9b54` with this branch stashed

Assisted by Claude Code.