### PR TITLE
fix(tomlfmt): preserve aligned inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - JSON and JSONC formatting removes blank lines before closing braces and brackets while preserving blank lines between members (closes #581).
+- TOML formatting now preserves intentionally aligned inline comment columns across consecutive entries while normalizing isolated comments (closes #586).
 - TOML formatting now leaves entries under table headers unindented by default while preserving explicit indentation overrides (closes #558).
 - XML files without a DOCTYPE declaration are validated as syntax-only again; `ValidateSyntax` now enables DTD validation only when a DOCTYPE is present, restoring compatibility after upgrading `helium` to v0.5.1's stricter "DTD required" semantics (closes #546)
 - Local JSON Schema paths are encoded as file URLs on Windows (closes #550)

--- a/pkg/formatter/tomlfmt/printer.go
+++ b/pkg/formatter/tomlfmt/printer.go
@@ -50,6 +50,7 @@ func (p *Printer) Print(groups []Group) []byte {
 	if p.opts.SortKeys {
 		groups = p.sortGroups(groups)
 	}
+	alignedCommentColumns := findAlignedCommentColumns(groups)
 
 	inTable := false
 	started := false // tracks whether we've emitted any non-blank content
@@ -104,7 +105,7 @@ func (p *Printer) Print(groups []Group) []byte {
 				p.buf.WriteString(p.opts.Indent)
 				entryDepth = 1
 			}
-			p.printEntry(group, entryDepth)
+			p.printEntry(group, entryDepth, alignedCommentColumns[i])
 		default:
 			// Unknown group kind — skip.
 		}
@@ -164,7 +165,7 @@ func (p *Printer) printTableHeader(group Group) {
 
 // printEntry writes a key = value entry with normalized spacing.
 // depth is the current indentation depth (0 for top-level, 1 for inside a table).
-func (p *Printer) printEntry(group Group, depth int) {
+func (p *Printer) printEntry(group Group, depth, commentColumn int) {
 	tokens := group.Tokens
 
 	// Split entry tokens into: key tokens, equals, value tokens, trailing comment, newline.
@@ -196,7 +197,7 @@ func (p *Printer) printEntry(group Group, depth int) {
 
 	// Emit trailing comment if present.
 	if commentStart >= 0 {
-		p.buf.WriteString(" ")
+		p.writeCommentSpacing(commentColumn)
 		for i := commentStart; i < len(tokens); i++ {
 			tok := tokens[i]
 			if tok.Kind == Comment {
@@ -206,6 +207,64 @@ func (p *Printer) printEntry(group Group, depth int) {
 	}
 
 	p.writeNewline()
+}
+
+// findAlignedCommentColumns returns the original comment column for runs of
+// two or more consecutive entries whose inline comments share that column.
+// Isolated comments deliberately get zero so arbitrary padding is normalized.
+func findAlignedCommentColumns(groups []Group) []int {
+	columns := make([]int, len(groups))
+	for start := 0; start < len(groups); {
+		column, ok := inlineCommentColumn(groups[start])
+		if !ok {
+			start++
+			continue
+		}
+		end := start + 1
+		for end < len(groups) {
+			nextColumn, nextOK := inlineCommentColumn(groups[end])
+			if !nextOK || nextColumn != column {
+				break
+			}
+			end++
+		}
+		if end-start >= 2 {
+			for i := start; i < end; i++ {
+				columns[i] = column
+			}
+		}
+		start = end
+	}
+	return columns
+}
+
+func inlineCommentColumn(group Group) (int, bool) {
+	if group.Kind != GroupEntry {
+		return 0, false
+	}
+	column := 0
+	for _, tok := range group.Tokens {
+		if tok.Kind == Comment {
+			return column, true
+		}
+		if tok.Kind == Newline {
+			return 0, false
+		}
+		column += len(tok.Raw)
+	}
+	return 0, false
+}
+
+func (p *Printer) writeCommentSpacing(targetColumn int) {
+	spaces := 1
+	if targetColumn > 0 {
+		lineStart := bytes.LastIndexByte(p.buf.Bytes(), '\n') + 1
+		currentColumn := p.buf.Len() - lineStart
+		if targetColumn > currentColumn {
+			spaces = targetColumn - currentColumn
+		}
+	}
+	p.buf.WriteString(strings.Repeat(" ", spaces))
 }
 
 // printValue writes value tokens. For simple values, emit verbatim.

--- a/pkg/formatter/tomlfmt/toml_test.go
+++ b/pkg/formatter/tomlfmt/toml_test.go
@@ -117,6 +117,16 @@ func TestInlineCommentPreserved(t *testing.T) {
 	require.Contains(t, string(got), "port = 8080", "spacing not normalized")
 }
 
+func TestAlignedInlineComments(t *testing.T) {
+	t.Parallel()
+	src := []byte("allow-unsafe = true       # old default\ngenerate-hashes = false   # pip bug\nstrip-extras = true       # reduce churn\nsingle = true        # normalize me\n")
+	want := "allow-unsafe = true       # old default\ngenerate-hashes = false   # pip bug\nstrip-extras = true       # reduce churn\nsingle = true # normalize me\n"
+
+	got, err := f.Format(src, defaultOpts)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+}
+
 // TestCRLFLineEnding verifies CRLF line endings are applied.
 func TestCRLFLineEnding(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes #586

Preserves intentionally aligned inline-comment columns across consecutive TOML entries while normalizing isolated comments. Full Go tests, go vet, gofmt, and golangci-lint v2.11.4 pass.