### PR TITLE
fix(yamlfmt): default quoted scalars to double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - JSON and JSONC formatting removes blank lines before closing braces and brackets while preserving blank lines between members (closes #581).
+- YAML formatting now normalizes quoted scalars to double quotes by default, with conflict and escape safeguards; `quote-style = "preserve"` retains the previous behavior (closes #580).
 - TOML formatting now leaves entries under table headers unindented by default while preserving explicit indentation overrides (closes #558).
 - XML files without a DOCTYPE declaration are validated as syntax-only again; `ValidateSyntax` now enables DTD validation only when a DOCTYPE is present, restoring compatibility after upgrading `helium` to v0.5.1's stricter "DTD required" semantics (closes #546)
 - Local JSON Schema paths are encoded as file URLs on Windows (closes #550)

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -707,7 +707,7 @@ func formatDefaults(formatName string) formatter.Options {
 			IndentWidth:  2,
 			FinalNewline: true,
 			LineEnding:   formatter.LineEndingLF,
-			QuoteStyle:   formatter.QuotePreserve,
+			QuoteStyle:   formatter.QuoteDouble,
 			SortKeys:     false,
 		}
 	case "toml":

--- a/docs/design/format-config-spec.md
+++ b/docs/design/format-config-spec.md
@@ -20,7 +20,7 @@ sort-keys = false             # bool. Sort object/mapping keys alphabetically.
 trailing-newline = true       # bool. Ensure file ends with exactly one newline.
 line-ending = "lf"            # "lf" | "crlf". Line terminator.
 max-line-width = 0            # int, 0=unlimited. Hint for line wrapping.
-quote-style = "preserve"      # "double" | "single" | "preserve". Scalar quoting.
+quote-style = "double"        # "double" | "single" | "preserve". Scalar quoting.
 trailing-commas = "preserve"  # "all" | "none" | "preserve". Trailing commas on multiline collections.
 
 # Per-format overrides — same keys, override the global [format] values.
@@ -47,7 +47,7 @@ quote-style = "double"        # Force double quotes on YAML scalars
 | `trailing-newline` | bool | — | `true` | all |
 | `line-ending` | string | `"lf"`, `"crlf"` | `"lf"` | all |
 | `max-line-width` | int | 0–320 | `0` | json |
-| `quote-style` | string | `"double"`, `"single"`, `"preserve"` | `"preserve"` | yaml (json always double) |
+| `quote-style` | string | `"double"`, `"single"`, `"preserve"` | `"double"` | yaml (json always double) |
 | `trailing-commas` | string | `"all"`, `"none"`, `"preserve"` | `"preserve"` | jsonc (json forbids them) |
 
 ¹ JSON default: 2. YAML default: 2. HCL: ignored (always 2, HashiCorp canonical).

--- a/pkg/formatter/yamlfmt/testdata/quote_preserve.opts.json
+++ b/pkg/formatter/yamlfmt/testdata/quote_preserve.opts.json
@@ -1,0 +1,1 @@
+{"QuoteStyle": 0}

--- a/pkg/formatter/yamlfmt/yaml.go
+++ b/pkg/formatter/yamlfmt/yaml.go
@@ -10,7 +10,7 @@
 //
 // Defaults:
 //   - 2-space indentation
-//   - preserve existing quote style
+//   - normalize quoted scalars to double quotes
 //   - preserve key order
 //   - trailing newline
 package yamlfmt
@@ -39,6 +39,7 @@ func DefaultOptions() formatter.Options {
 		IndentStyle:  formatter.IndentSpaces,
 		IndentWidth:  2,
 		FinalNewline: true,
+		QuoteStyle:   formatter.QuoteDouble,
 	}
 }
 

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -17,6 +17,16 @@ import (
 var f = yamlfmt.Formatter{}
 var defaultOpts = yamlfmt.DefaultOptions()
 
+func TestDefaultQuoteStyleMatchesPrettier(t *testing.T) {
+	t.Parallel()
+	src := []byte("plain: unchanged\nversion: '1.0.0'\nmessage: 'say \"hi\"'\napostrophe: \"it's\"\nescape: \"line\\nnext\"\n")
+	want := "plain: unchanged\nversion: \"1.0.0\"\nmessage: 'say \"hi\"'\napostrophe: \"it's\"\nescape: \"line\\nnext\"\n"
+
+	got, err := f.Format(src, defaultOpts)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+}
+
 // yamlUnmarshal is a test helper that validates output is parseable YAML.
 func yamlUnmarshal(data []byte, v any) error {
 	return yaml.Unmarshal(data, v)

--- a/website/docs/reference/configuration-keys.md
+++ b/website/docs/reference/configuration-keys.md
@@ -55,7 +55,7 @@ The `[format]` table controls formatting behavior for `cfv format`.
 | `sort-keys`        | boolean | `false`      | Sort mapping keys alphabetically.                       |
 | `trailing-newline` | boolean | `true`       | Ensure file ends with a newline.                        |
 | `line-ending`      | string  | `"lf"`       | Line ending style: `"lf"` or `"crlf"`.                 |
-| `quote-style`      | string  | `"preserve"` | Quote style: `"preserve"`, `"double"`, or `"single"` (YAML only). |
+| `quote-style`      | string  | `"double"`   | Quote style: `"preserve"`, `"double"`, or `"single"` (YAML only). |
 | `trailing-commas`  | string  | `"preserve"` | Trailing commas on multiline collections: `"preserve"` (match the file), `"all"`, or `"none"` (JSONC only). |
 
 ### Per-format overrides


### PR DESCRIPTION
## Summary

Normalize already-quoted YAML scalars to double quotes by default, matching Prettier, while leaving plain scalars unquoted. Existing conflict avoidance keeps values containing double quotes single-quoted, and escape-sensitive strings retain their safe representation.

Closes #580

Users can restore the prior behavior with `quote-style = "preserve"`; explicit single-quote mode remains supported.

## Validation

- `go test ./...`
- `go vet ./...`
- `gofmt -s` clean
- `golangci-lint` v2.11.4: 0 issues
- Configuration reference and formatter fixtures updated