### PR TITLE
fix(formatter): preserve JSON blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON and JSONC formatting now preserves a single blank line between object properties and array elements while removing blank lines before closing delimiters (closes #588).
 - TOML formatting now leaves entries under table headers unindented by default while preserving explicit indentation overrides (closes #558).
 - XML files without a DOCTYPE declaration are validated as syntax-only again; `ValidateSyntax` now enables DTD validation only when a DOCTYPE is present, restoring compatibility after upgrading `helium` to v0.5.1's stricter "DTD required" semantics (closes #546)
 - Local JSON Schema paths are encoded as file URLs on Windows (closes #550)

--- a/pkg/formatter/jsoncfmt/jsonc.go
+++ b/pkg/formatter/jsoncfmt/jsonc.go
@@ -159,9 +159,13 @@ func (fs *formatState) formatObject(obj *hujson.Object, depth int) {
 
 	for i := range obj.Members {
 		m := &obj.Members[i]
+		preserveBlank := i > 0 && hasBlankLine(m.Name.BeforeExtra)
 
 		// Preserve comments from BeforeExtra, apply correct indentation.
 		m.Name.BeforeExtra = reindentExtra(m.Name.BeforeExtra, childIndent)
+		if preserveBlank {
+			m.Name.BeforeExtra = addBlankLine(m.Name.BeforeExtra)
+		}
 		m.Name.AfterExtra = nil
 
 		// Single space between colon and value.
@@ -222,7 +226,11 @@ func (fs *formatState) formatArray(arr *hujson.Array, depth int) {
 	closeIndent := "\n" + strings.Repeat(fs.indent, depth)
 
 	for i := range arr.Elements {
+		preserveBlank := i > 0 && hasBlankLine(arr.Elements[i].BeforeExtra)
 		arr.Elements[i].BeforeExtra = reindentExtra(arr.Elements[i].BeforeExtra, childIndent)
+		if preserveBlank {
+			arr.Elements[i].BeforeExtra = addBlankLine(arr.Elements[i].BeforeExtra)
+		}
 		arr.Elements[i].AfterExtra = clearWhitespace(arr.Elements[i].AfterExtra)
 		fs.formatValue(&arr.Elements[i], depth+1)
 	}
@@ -247,11 +255,14 @@ func isInlineArray(arr *hujson.Array) bool {
 	// trailing comma+space. This conservative bias means arrays at exactly
 	// the line limit are expanded rather than compacted.
 	totalLen := 2 // [ and ]
-	for _, el := range arr.Elements {
+	for i, el := range arr.Elements {
 		if _, ok := el.Value.(hujson.Literal); !ok {
 			return false
 		}
 		if hasComment(el.BeforeExtra) || hasComment(el.AfterExtra) {
+			return false
+		}
+		if i > 0 && hasBlankLine(el.BeforeExtra) {
 			return false
 		}
 		totalLen += len(el.Value.(hujson.Literal)) + 2
@@ -266,8 +277,7 @@ func hasComment(extra hujson.Extra) bool {
 }
 
 // reindentExtra normalizes indentation in Extra (comment/whitespace) content.
-// Blank lines between comments are collapsed — this matches prettier's behavior
-// of not preserving blank lines within structures.
+// Collection callers reinsert at most one intentional blank line between items.
 func reindentExtra(extra hujson.Extra, newIndent string) hujson.Extra {
 	if extra == nil {
 		return hujson.Extra(newIndent)
@@ -300,6 +310,29 @@ func reindentExtra(extra hujson.Extra, newIndent string) hujson.Extra {
 	b.WriteString(newIndent)
 
 	return hujson.Extra(b.String())
+}
+
+func hasBlankLine(extra hujson.Extra) bool {
+	for i := 0; i < len(extra); i++ {
+		if extra[i] != '\n' && extra[i] != '\r' {
+			continue
+		}
+		if extra[i] == '\r' && i+1 < len(extra) && extra[i+1] == '\n' {
+			i++
+		}
+		j := i + 1
+		for j < len(extra) && (extra[j] == ' ' || extra[j] == '\t') {
+			j++
+		}
+		if j < len(extra) && (extra[j] == '\n' || extra[j] == '\r') {
+			return true
+		}
+	}
+	return false
+}
+
+func addBlankLine(extra hujson.Extra) hujson.Extra {
+	return hujson.Extra("\n" + string(extra))
 }
 
 // clearWhitespace removes whitespace from Extra but preserves comments.

--- a/pkg/formatter/jsoncfmt/jsonc_test.go
+++ b/pkg/formatter/jsoncfmt/jsonc_test.go
@@ -178,6 +178,17 @@ func TestCRLF(t *testing.T) {
 	}
 }
 
+func TestCRLFPreservesBlankLines(t *testing.T) {
+	t.Parallel()
+	src := []byte("{\r\n  // Group A\r\n  \"a\": 1,\r\n\r\n  \"b\": 2\r\n}\r\n")
+	opts := jsoncfmt.DefaultOptions()
+	opts.LineEnding = formatter.LineEndingCRLF
+
+	got, err := f.Format(src, opts)
+	require.NoError(t, err)
+	require.Equal(t, "{\r\n  // Group A\r\n  \"a\": 1,\r\n\r\n  \"b\": 2\r\n}\r\n", string(got))
+}
+
 // FuzzFormat feeds arbitrary bytes to Format and checks:
 // - No panics on any input
 // - If Format succeeds, output re-parses without error

--- a/pkg/formatter/jsoncfmt/testdata/blank_lines.expected.jsonc
+++ b/pkg/formatter/jsoncfmt/testdata/blank_lines.expected.jsonc
@@ -1,0 +1,14 @@
+{
+  // App metadata
+  "name": "my-app",
+
+  "scripts": {
+    "build": "tsc"
+  },
+
+  "items": [
+    "one",
+
+    "two"
+  ]
+}

--- a/pkg/formatter/jsoncfmt/testdata/blank_lines.input.jsonc
+++ b/pkg/formatter/jsoncfmt/testdata/blank_lines.input.jsonc
@@ -1,0 +1,20 @@
+{
+  // App metadata
+  "name": "my-app",
+
+
+  "scripts": {
+    "build": "tsc"
+  },
+
+  "items": [
+    "one",
+
+
+    "two"
+
+
+  ]
+
+
+}

--- a/pkg/formatter/jsonfmt/json.go
+++ b/pkg/formatter/jsonfmt/json.go
@@ -12,7 +12,9 @@ package jsonfmt
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
+	"github.com/tailscale/hujson"
 	"github.com/tidwall/pretty"
 
 	"github.com/Boeing/config-file-validator/v3/pkg/formatter"
@@ -42,6 +44,11 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 		return nil, errors.New("json: invalid JSON input")
 	}
 
+	original, err := hujson.Parse(src)
+	if err != nil {
+		return nil, err
+	}
+
 	resolved := resolveOptions(opts)
 
 	prettyOpts := &pretty.Options{
@@ -52,6 +59,12 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 	}
 
 	result := pretty.PrettyOptions(src, prettyOpts)
+	formatted, err := hujson.Parse(result)
+	if err != nil {
+		return nil, err
+	}
+	restoreBlankLines(&original, &formatted, prettyOpts.Indent, 0)
+	result = formatted.Pack()
 
 	// pretty always appends a trailing newline. Strip it if FinalNewline is false.
 	if !resolved.FinalNewline && len(result) > 0 && result[len(result)-1] == '\n' {
@@ -86,4 +99,89 @@ func indentString(opts formatter.Options) string {
 		indent[i] = ' '
 	}
 	return string(indent)
+}
+
+// restoreBlankLines transfers blank-line boundaries from the original CST to
+// the canonical output while leaving all other whitespace under pretty's
+// control. Blank lines attach to the following object member or array element.
+func restoreBlankLines(original, formatted *hujson.Value, indent string, depth int) {
+	switch originalValue := original.Value.(type) {
+	case *hujson.Object:
+		formattedValue, ok := formatted.Value.(*hujson.Object)
+		if !ok {
+			return
+		}
+		originalIndexes := make(map[string][]int, len(originalValue.Members))
+		for i := range originalValue.Members {
+			key := objectMemberKey(&originalValue.Members[i])
+			originalIndexes[key] = append(originalIndexes[key], i)
+		}
+		occurrences := make(map[string]int, len(originalIndexes))
+		for i := range formattedValue.Members {
+			key := objectMemberKey(&formattedValue.Members[i])
+			sourceIndex := originalIndexes[key][occurrences[key]]
+			occurrences[key]++
+			sourceMember := &originalValue.Members[sourceIndex]
+			formattedMember := &formattedValue.Members[i]
+			if i > 0 && hasBlankLine(sourceMember.Name.BeforeExtra) {
+				formattedMember.Name.BeforeExtra = addBlankLine(formattedMember.Name.BeforeExtra)
+			}
+			restoreBlankLines(&sourceMember.Value, &formattedMember.Value, indent, depth+1)
+		}
+	case *hujson.Array:
+		formattedValue, ok := formatted.Value.(*hujson.Array)
+		if !ok {
+			return
+		}
+		hasBlankBoundary := false
+		for i := 1; i < len(originalValue.Elements); i++ {
+			if hasBlankLine(originalValue.Elements[i].BeforeExtra) {
+				hasBlankBoundary = true
+				break
+			}
+		}
+		if hasBlankBoundary {
+			childIndent := "\n" + strings.Repeat(indent, depth+1)
+			closeIndent := "\n" + strings.Repeat(indent, depth)
+			for i := range formattedValue.Elements {
+				formattedValue.Elements[i].BeforeExtra = hujson.Extra(childIndent)
+				if i > 0 && hasBlankLine(originalValue.Elements[i].BeforeExtra) {
+					formattedValue.Elements[i].BeforeExtra = addBlankLine(formattedValue.Elements[i].BeforeExtra)
+				}
+			}
+			formattedValue.AfterExtra = hujson.Extra(closeIndent)
+		}
+		for i := range originalValue.Elements {
+			restoreBlankLines(&originalValue.Elements[i], &formattedValue.Elements[i], indent, depth+1)
+		}
+	default:
+		// Literals have no collection boundaries to restore.
+	}
+}
+
+func objectMemberKey(member *hujson.ObjectMember) string {
+	return member.Name.Value.(hujson.Literal).String()
+}
+
+func hasBlankLine(extra hujson.Extra) bool {
+	for i := 0; i < len(extra); i++ {
+		if extra[i] != '\n' && extra[i] != '\r' {
+			continue
+		}
+		if extra[i] == '\r' && i+1 < len(extra) && extra[i+1] == '\n' {
+			i++
+		}
+		j := i + 1
+		for j < len(extra) && (extra[j] == ' ' || extra[j] == '\t') {
+			j++
+		}
+		if j < len(extra) && (extra[j] == '\n' || extra[j] == '\r') {
+			return true
+		}
+	}
+	return false
+}
+
+func addBlankLine(extra hujson.Extra) hujson.Extra {
+	return hujson.Extra("\n" + string(extra))
 }

--- a/pkg/formatter/jsonfmt/json_internal_test.go
+++ b/pkg/formatter/jsonfmt/json_internal_test.go
@@ -1,0 +1,24 @@
+package jsonfmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tailscale/hujson"
+)
+
+func TestRestoreBlankLinesIgnoresMismatchedStructures(t *testing.T) {
+	t.Parallel()
+
+	object, err := hujson.Parse([]byte("{\"key\": \"value\"}"))
+	require.NoError(t, err)
+	array, err := hujson.Parse([]byte("[\"value\"]"))
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		restoreBlankLines(&object, &array, "  ", 0)
+	})
+	require.NotPanics(t, func() {
+		restoreBlankLines(&array, &object, "  ", 0)
+	})
+}

--- a/pkg/formatter/jsonfmt/json_test.go
+++ b/pkg/formatter/jsonfmt/json_test.go
@@ -143,6 +143,17 @@ func TestCRLFLineEnding(t *testing.T) {
 	require.Contains(t, string(got), "\r\n", "expected CRLF line endings")
 }
 
+func TestCRLFPreservesBlankLines(t *testing.T) {
+	t.Parallel()
+	src := []byte("{\r\n  \"a\": 1,\r\n\r\n  \"b\": 2\r\n}\r\n")
+	opts := jsonfmt.DefaultOptions()
+	opts.LineEnding = formatter.LineEndingCRLF
+
+	got, err := f.Format(src, opts)
+	require.NoError(t, err)
+	require.Equal(t, "{\r\n  \"a\": 1,\r\n\r\n  \"b\": 2\r\n}\r\n", string(got))
+}
+
 // TestIndentWidth4 verifies 4-space indent produces correctly indented output.
 func TestIndentWidth4(t *testing.T) {
 	t.Parallel()

--- a/pkg/formatter/jsonfmt/testdata/blank_lines.expected.json
+++ b/pkg/formatter/jsonfmt/testdata/blank_lines.expected.json
@@ -1,0 +1,13 @@
+{
+  "name": "my-app",
+
+  "scripts": {
+    "build": "tsc"
+  },
+
+  "items": [
+    "one",
+
+    "two"
+  ]
+}

--- a/pkg/formatter/jsonfmt/testdata/blank_lines.input.json
+++ b/pkg/formatter/jsonfmt/testdata/blank_lines.input.json
@@ -1,0 +1,19 @@
+{
+  "name": "my-app",
+
+
+  "scripts": {
+    "build": "tsc"
+  },
+
+  "items": [
+    "one",
+
+
+    "two"
+
+
+  ]
+
+
+}


### PR DESCRIPTION
## Summary

- Preserve one intentional blank line between JSON/JSONC object properties and array elements.
- Collapse multiple consecutive blank lines to one while removing blank lines before closing delimiters.
- Keep canonical indentation, key-order behavior, JSONC comments, trailing-comma handling, and CRLF output intact.

## Testing

- go test -count=1 -covermode=atomic ./...
- go vet ./...
- golangci-lint run (0 issues)
- go generate ./... (no diff)
- CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./...
- Total coverage: 91.1%; JSON formatter coverage: 96.3%

Closes #588