### PR TITLE
feat(yamlfmt): add compact sequence indentation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Format configuration cascade: CLI flags > per-format config > global `[format]` config > `.editorconfig` > defaults
 - `trailing-commas` format option (`preserve` | `all` | `none`) to control trailing commas on multiline JSONC collections
 - `.editorconfig` auto-detection for `cfv format`: `indent_style`, `indent_size`, `end_of_line`, and `insert_final_newline` are resolved per file (globs, parent directories, and `root = true` are all respected). Disable with `--no-editorconfig` (closes #562)
+- `indent-sequences` YAML format option. Sequence items under mapping keys are indented by default; set it to `false` to restore the compact style (closes #582).
 - Schema validation support for JSONC files via `$schema`, `--schema-map`, and SchemaStore
 - Schema validation support for Properties files via `--schema-map` in `.cfv.toml`
 - **cfv 3.0 Phase 1**: Renamed binary from `validator` to `cfv`. This is a breaking change — no compatibility shim ships. Update scripts: `validator .` → `cfv check .`

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -689,12 +689,13 @@ func formatDefaults(formatName string) formatter.Options {
 		}
 	case "yaml":
 		return formatter.Options{
-			IndentStyle:  formatter.IndentSpaces,
-			IndentWidth:  2,
-			FinalNewline: true,
-			LineEnding:   formatter.LineEndingLF,
-			QuoteStyle:   formatter.QuotePreserve,
-			SortKeys:     false,
+			IndentStyle:     formatter.IndentSpaces,
+			IndentWidth:     2,
+			FinalNewline:    true,
+			LineEnding:      formatter.LineEndingLF,
+			QuoteStyle:      formatter.QuotePreserve,
+			SortKeys:        false,
+			IndentSequences: formatter.SequenceIndentEnabled,
 		}
 	case "toml":
 		return formatter.Options{
@@ -759,6 +760,13 @@ func applyFormatOptions(opts *formatter.Options, cfg *configfile.FormatOptions) 
 			opts.TrailingCommas = formatter.TrailingCommasNone
 		default:
 			opts.TrailingCommas = formatter.TrailingCommasPreserve
+		}
+	}
+	if cfg.IndentSequences != nil {
+		if *cfg.IndentSequences {
+			opts.IndentSequences = formatter.SequenceIndentEnabled
+		} else {
+			opts.IndentSequences = formatter.SequenceIndentDisabled
 		}
 	}
 }

--- a/cmd/cfv/testdata/format_yaml_indent_sequences.txtar
+++ b/cmd/cfv/testdata/format_yaml_indent_sequences.txtar
@@ -1,0 +1,69 @@
+# YAML sequences under mapping keys are indented by default.
+cp manifest.yaml default.yaml
+exec cfv format --fix --no-config --no-editorconfig default.yaml
+cmp default.yaml default.expected.yaml
+
+# Per-format configuration restores the compact sequence style.
+cp manifest.yaml compact.yaml
+exec cfv format --fix --config=compact.toml --no-editorconfig compact.yaml
+cmp compact.yaml compact.expected.yaml
+
+# A top-level sequence is unaffected by the option.
+exec cfv format --fix --config=compact.toml --no-editorconfig root.yaml
+cmp root.yaml root.expected.yaml
+
+# Nested mapping sequences and lists of lists each lose only the optional
+# mapping-value indentation level.
+exec cfv format --fix --config=compact.toml --no-editorconfig nested.yaml
+cmp nested.yaml nested.expected.yaml
+
+-- manifest.yaml --
+spec:
+  containers:
+  - name: app
+    image: nginx
+  - name: sidecar
+    image: envoy
+-- default.expected.yaml --
+spec:
+  containers:
+    - name: app
+      image: nginx
+    - name: sidecar
+      image: envoy
+-- compact.expected.yaml --
+spec:
+  containers:
+  - name: app
+    image: nginx
+  - name: sidecar
+    image: envoy
+-- root.yaml --
+- one
+- two
+-- root.expected.yaml --
+- one
+- two
+-- nested.yaml --
+matrix:
+  include:
+    - os: linux
+      versions:
+        - one
+        - two
+groups:
+  - - a
+    - b
+-- nested.expected.yaml --
+matrix:
+  include:
+  - os: linux
+    versions:
+    - one
+    - two
+groups:
+- - a
+  - b
+-- compact.toml --
+[format.yaml]
+indent-sequences = false

--- a/docs/design/format-config-spec.md
+++ b/docs/design/format-config-spec.md
@@ -22,6 +22,7 @@ line-ending = "lf"            # "lf" | "crlf". Line terminator.
 max-line-width = 0            # int, 0=unlimited. Hint for line wrapping.
 quote-style = "preserve"      # "double" | "single" | "preserve". Scalar quoting.
 trailing-commas = "preserve"  # "all" | "none" | "preserve". Trailing commas on multiline collections.
+indent-sequences = true       # bool. Indent YAML sequences under mapping keys.
 
 # Per-format overrides — same keys, override the global [format] values.
 [format.json]
@@ -49,6 +50,7 @@ quote-style = "double"        # Force double quotes on YAML scalars
 | `max-line-width` | int | 0–320 | `0` | json |
 | `quote-style` | string | `"double"`, `"single"`, `"preserve"` | `"preserve"` | yaml (json always double) |
 | `trailing-commas` | string | `"all"`, `"none"`, `"preserve"` | `"preserve"` | jsonc (json forbids them) |
+| `indent-sequences` | bool | — | `true` | yaml |
 
 ¹ JSON default: 2. YAML default: 2. HCL: ignored (always 2, HashiCorp canonical).
 ² JSON default: `true` (sorted). YAML default: `false` (preserve order).

--- a/pkg/configfile/configfile.go
+++ b/pkg/configfile/configfile.go
@@ -67,6 +67,7 @@ type FormatOptions struct {
 	MaxLineWidth    *int    `toml:"max-line-width"`
 	QuoteStyle      *string `toml:"quote-style"`
 	TrailingCommas  *string `toml:"trailing-commas"`
+	IndentSequences *bool   `toml:"indent-sequences"`
 }
 
 // ValidatorOptions holds per-validator configuration.

--- a/pkg/configfile/configfile_test.go
+++ b/pkg/configfile/configfile_test.go
@@ -214,6 +214,7 @@ trailing-newline = true
 line-ending = "lf"
 max-line-width = 80
 quote-style = "double"
+indent-sequences = false
 `)
 
 	cfg, err := Load(filepath.Join(dir, FileName))
@@ -225,6 +226,7 @@ quote-style = "double"
 	require.Equal(t, "lf", *cfg.Format.LineEnding)
 	require.Equal(t, 80, *cfg.Format.MaxLineWidth)
 	require.Equal(t, "double", *cfg.Format.QuoteStyle)
+	require.False(t, *cfg.Format.IndentSequences)
 }
 
 func TestLoadFormatPerType(t *testing.T) {
@@ -241,6 +243,7 @@ indent = 4
 [format.yaml]
 quote-style = "single"
 indent = 3
+indent-sequences = false
 `)
 
 	cfg, err := Load(filepath.Join(dir, FileName))
@@ -258,6 +261,7 @@ indent = 3
 	require.NotNil(t, cfg.Format.YAML)
 	require.Equal(t, 3, *cfg.Format.YAML.Indent)
 	require.Equal(t, "single", *cfg.Format.YAML.QuoteStyle)
+	require.False(t, *cfg.Format.YAML.IndentSequences)
 }
 
 func TestLoadFormatUnknownKey(t *testing.T) {

--- a/pkg/configfile/schema.json
+++ b/pkg/configfile/schema.json
@@ -203,6 +203,10 @@
           ],
           "description": "Trailing commas on multiline collections. Only affects JSONC. Default: preserve (match the style already used by the file)."
         },
+        "indent-sequences": {
+          "type": "boolean",
+          "description": "Indent YAML sequences used as mapping values by one additional level. Default: true."
+        },
         "json": {
           "$ref": "#/$defs/format-options"
         },
@@ -285,6 +289,9 @@
             "none",
             "preserve"
           ]
+        },
+        "indent-sequences": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -70,7 +70,24 @@ type Options struct {
 	// TrailingCommas controls trailing commas on multiline collections.
 	// Only applies to formats that permit them (JSONC).
 	TrailingCommas TrailingCommas
+
+	// IndentSequences controls whether YAML sequences used as mapping values
+	// receive an additional indentation level.
+	IndentSequences SequenceIndent
 }
+
+// SequenceIndent controls indentation of YAML sequences under mapping keys.
+type SequenceIndent int
+
+const (
+	// SequenceIndentDefault means the formatter uses its own convention.
+	SequenceIndentDefault SequenceIndent = iota
+	// SequenceIndentEnabled indents sequences one level under mapping keys.
+	SequenceIndentEnabled
+	// SequenceIndentDisabled keeps sequence indicators aligned with the key's
+	// value indentation.
+	SequenceIndentDisabled
+)
 
 // TrailingCommas controls trailing commas on multiline collections.
 type TrailingCommas int

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -46,7 +46,8 @@ func printFormatted(tokens []Token, opts formatter.Options, src []byte) ([]byte,
 	}
 
 	// Reindent: structural tokens get depth×width; continuations shift by parent delta.
-	reindentTokens(tokens, targetWidth)
+	reindentTokens(tokens, targetWidth,
+		opts.IndentSequences != formatter.SequenceIndentDisabled)
 
 	// Apply quote style preference.
 	if opts.QuoteStyle != formatter.QuotePreserve {
@@ -81,9 +82,10 @@ func printFormatted(tokens []Token, opts formatter.Options, src []byte) ([]byte,
 // =============================================================================
 
 type lineMetadata struct {
-	depth     int
-	inSeq     bool
-	seqOffset int // number of ancestor non-dash sequence levels contributing +2 each
+	depth               int
+	inSeq               bool
+	seqOffset           int // number of ancestor non-dash sequence levels contributing +2 each
+	sequenceIndentDepth int // mapping-value sequence levels affecting indentation
 }
 
 // buildASTMetadata walks the yaml.v3 Node tree and returns metadata for each
@@ -98,16 +100,16 @@ func buildASTMetadata(src []byte) (map[int]lineMetadata, error) {
 		return nil, fmt.Errorf("cannot determine document structure: %w", err)
 	}
 	meta := make(map[int]lineMetadata)
-	collectMetadata(&root, meta, 0, false, 0)
+	collectMetadata(&root, meta, 0, false, 0, 0)
 	return meta, nil
 }
 
 //nolint:revive // inSeq is a recursive state parameter, not a control flag
-func collectMetadata(n *yaml.Node, meta map[int]lineMetadata, depth int, inSeq bool, seqOffset int) {
+func collectMetadata(n *yaml.Node, meta map[int]lineMetadata, depth int, inSeq bool, seqOffset, sequenceIndentDepth int) {
 	switch n.Kind {
 	case yaml.DocumentNode:
 		for _, c := range n.Content {
-			collectMetadata(c, meta, depth, false, seqOffset)
+			collectMetadata(c, meta, depth, false, seqOffset, sequenceIndentDepth)
 		}
 	case yaml.MappingNode:
 		for i := 0; i < len(n.Content); i += 2 {
@@ -116,7 +118,10 @@ func collectMetadata(n *yaml.Node, meta map[int]lineMetadata, depth int, inSeq b
 			// This prevents flow values ({a: 1}) on the same line as
 			// their parent key from overwriting the parent's metadata.
 			if existing, ok := meta[key.Line]; !ok || existing.depth > depth {
-				meta[key.Line] = lineMetadata{depth: depth, inSeq: inSeq, seqOffset: seqOffset}
+				meta[key.Line] = lineMetadata{
+					depth: depth, inSeq: inSeq, seqOffset: seqOffset,
+					sequenceIndentDepth: sequenceIndentDepth,
+				}
 			}
 			if i+1 < len(n.Content) {
 				// Children of a non-dash seq key inherit seqOffset+1 because
@@ -125,7 +130,12 @@ func collectMetadata(n *yaml.Node, meta map[int]lineMetadata, depth int, inSeq b
 				if inSeq {
 					childOffset = seqOffset + 1
 				}
-				collectMetadata(n.Content[i+1], meta, depth+1, false, childOffset)
+				childSequenceIndentDepth := sequenceIndentDepth
+				if n.Content[i+1].Kind == yaml.SequenceNode {
+					childSequenceIndentDepth++
+				}
+				collectMetadata(n.Content[i+1], meta, depth+1, false,
+					childOffset, childSequenceIndentDepth)
 			}
 		}
 	case yaml.SequenceNode:
@@ -133,15 +143,20 @@ func collectMetadata(n *yaml.Node, meta map[int]lineMetadata, depth int, inSeq b
 			// Record the start line of each sequence item at this depth.
 			if item.Line > 0 {
 				if existing, ok := meta[item.Line]; !ok || existing.depth > depth {
-					meta[item.Line] = lineMetadata{depth: depth, inSeq: true, seqOffset: seqOffset}
+					meta[item.Line] = lineMetadata{
+						depth: depth, inSeq: true, seqOffset: seqOffset,
+						sequenceIndentDepth: sequenceIndentDepth,
+					}
 				}
 			}
 			if item.Kind == yaml.SequenceNode {
 				// Nested sequence: inner items are one level deeper.
 				// Don't increment seqOffset — the dash handles positioning.
-				collectMetadata(item, meta, depth+1, true, seqOffset)
+				collectMetadata(item, meta, depth+1, true, seqOffset,
+					sequenceIndentDepth)
 			} else {
-				collectMetadata(item, meta, depth, true, seqOffset)
+				collectMetadata(item, meta, depth, true, seqOffset,
+					sequenceIndentDepth)
 			}
 		}
 	case yaml.ScalarNode, yaml.AliasNode:
@@ -149,7 +164,10 @@ func collectMetadata(n *yaml.Node, meta map[int]lineMetadata, depth int, inSeq b
 		// pair) need metadata so their lines get proper ASTDepth.
 		if inSeq && n.Line > 0 {
 			if existing, ok := meta[n.Line]; !ok || existing.depth > depth {
-				meta[n.Line] = lineMetadata{depth: depth, inSeq: true, seqOffset: seqOffset}
+				meta[n.Line] = lineMetadata{
+					depth: depth, inSeq: true, seqOffset: seqOffset,
+					sequenceIndentDepth: sequenceIndentDepth,
+				}
 			}
 		}
 	default:
@@ -173,12 +191,14 @@ func assignASTMetadata(tokens []Token, meta map[int]lineMetadata) {
 		tokens[i].ASTDepth = lm.depth
 		tokens[i].InSeq = lm.inSeq
 		tokens[i].SeqOffset = lm.seqOffset
+		tokens[i].SequenceIndentDepth = lm.sequenceIndentDepth
 		// Propagate to preceding indent token (reindent operates on indent tokens).
 		indentIdx := findPrecedingIndent(tokens, i)
 		if indentIdx >= 0 {
 			tokens[indentIdx].ASTDepth = lm.depth
 			tokens[indentIdx].InSeq = lm.inSeq
 			tokens[indentIdx].SeqOffset = lm.seqOffset
+			tokens[indentIdx].SequenceIndentDepth = lm.sequenceIndentDepth
 		}
 	}
 
@@ -199,6 +219,7 @@ func assignASTMetadata(tokens []Token, meta map[int]lineMetadata) {
 			tokens[indentIdx].ASTDepth = lm.depth
 			tokens[indentIdx].InSeq = lm.inSeq
 			tokens[indentIdx].SeqOffset = lm.seqOffset
+			tokens[indentIdx].SequenceIndentDepth = lm.sequenceIndentDepth
 		}
 	}
 
@@ -218,6 +239,7 @@ func assignASTMetadata(tokens []Token, meta map[int]lineMetadata) {
 				tokens[i].ASTDepth = tokens[j].ASTDepth
 				tokens[i].InSeq = tokens[j].InSeq
 				tokens[i].SeqOffset = tokens[j].SeqOffset
+				tokens[i].SequenceIndentDepth = tokens[j].SequenceIndentDepth
 				// When the comment precedes a sequence-item dash, it should align
 				// with the dash (item indent), not the item's content (base + 2).
 				tokens[i].AtSeqItem = lineHasDash(tokens, j)
@@ -230,8 +252,15 @@ func assignASTMetadata(tokens []Token, meta map[int]lineMetadata) {
 // computeNewIndent returns the target indentation for a structural line.
 //
 //nolint:revive // inSeq/hasDash are structural properties, not control flags
-func computeNewIndent(astDepth int, inSeq, hasDash bool, seqOffset, targetWidth int) int {
+func computeNewIndent(astDepth int, inSeq, hasDash bool, seqOffset,
+	sequenceIndentDepth, targetWidth int, indentSequences bool) int {
 	base := astDepth*targetWidth + seqOffset*2
+	if !indentSequences {
+		base -= sequenceIndentDepth * targetWidth
+		if base < 0 {
+			base = 0
+		}
+	}
 	if inSeq && !hasDash {
 		return base + 2
 	}
@@ -345,7 +374,7 @@ func collectStructuralLines(n *yaml.Node, lines map[int]bool) {
 // Continuation tokens (ASTDepth < 0 or non-structural): shift by same delta as
 // last structural token. Block scalars following a shifted indent also get
 // their content shifted.
-func reindentTokens(tokens []Token, targetWidth int) {
+func reindentTokens(tokens []Token, targetWidth int, indentSequences bool) {
 	lastDelta := 0
 
 	for i := range tokens {
@@ -357,7 +386,9 @@ func reindentTokens(tokens []Token, targetWidth int) {
 		var newIndent int
 		if tokens[i].Structural && tokens[i].ASTDepth >= 0 {
 			hasDash := lineHasDash(tokens, i) || tokens[i].AtSeqItem
-			newIndent = computeNewIndent(tokens[i].ASTDepth, tokens[i].InSeq, hasDash, tokens[i].SeqOffset, targetWidth)
+			newIndent = computeNewIndent(tokens[i].ASTDepth, tokens[i].InSeq,
+				hasDash, tokens[i].SeqOffset, tokens[i].SequenceIndentDepth,
+				targetWidth, indentSequences)
 			lastDelta = newIndent - oldIndent
 		} else {
 			newIndent = oldIndent + lastDelta

--- a/pkg/formatter/yamlfmt/tokenizer.go
+++ b/pkg/formatter/yamlfmt/tokenizer.go
@@ -53,6 +53,9 @@ type Token struct {
 	InSeq      bool // true if this key is inside a sequence item (dash-relative indent)
 	SeqOffset  int  // number of ancestor non-dash sequence levels contributing +2 each
 	AtSeqItem  bool // true for a standalone comment that precedes a sequence-item dash
+	// SequenceIndentDepth is the number of ancestor sequences that are direct
+	// mapping values and therefore contribute optional indentation.
+	SequenceIndentDepth int
 }
 
 // tokenize lexes YAML source into a flat token stream.

--- a/pkg/formatter/yamlfmt/yaml.go
+++ b/pkg/formatter/yamlfmt/yaml.go
@@ -36,9 +36,10 @@ var _ formatter.Formatter = Formatter{}
 // DefaultOptions returns the default formatting options for YAML.
 func DefaultOptions() formatter.Options {
 	return formatter.Options{
-		IndentStyle:  formatter.IndentSpaces,
-		IndentWidth:  2,
-		FinalNewline: true,
+		IndentStyle:     formatter.IndentSpaces,
+		IndentWidth:     2,
+		FinalNewline:    true,
+		IndentSequences: formatter.SequenceIndentEnabled,
 	}
 }
 
@@ -112,6 +113,9 @@ func resolveOptions(opts formatter.Options) formatter.Options {
 	}
 	if opts.IndentWidth == 0 {
 		opts.IndentWidth = defaults.IndentWidth
+	}
+	if opts.IndentSequences == formatter.SequenceIndentDefault {
+		opts.IndentSequences = defaults.IndentSequences
 	}
 	return opts
 }

--- a/website/docs/reference/configuration-keys.md
+++ b/website/docs/reference/configuration-keys.md
@@ -57,6 +57,7 @@ The `[format]` table controls formatting behavior for `cfv format`.
 | `line-ending`      | string  | `"lf"`       | Line ending style: `"lf"` or `"crlf"`.                 |
 | `quote-style`      | string  | `"preserve"` | Quote style: `"preserve"`, `"double"`, or `"single"` (YAML only). |
 | `trailing-commas`  | string  | `"preserve"` | Trailing commas on multiline collections: `"preserve"` (match the file), `"all"`, or `"none"` (JSONC only). |
+| `indent-sequences` | boolean | `true`       | Indent YAML sequences used as mapping values by one additional level. Set to `false` for compact sequence indentation. |
 
 ### Per-format overrides
 
@@ -70,6 +71,7 @@ sort-keys = false
 [format.yaml]
 indent = 2
 quote-style = "double"
+indent-sequences = false
 
 [format.json]
 indent = 4


### PR DESCRIPTION
## Summary

- Keep the existing Prettier-compatible default that indents YAML sequences under mapping keys.
- Add `[format.yaml] indent-sequences = false` for users who prefer compact sequence indentation.
- Preserve top-level sequence indentation and handle nested mapping sequences and lists of lists correctly.
- Wire the option through formatter defaults, TOML configuration, schema validation, CLI option resolution, documentation, and the changelog.

## Behavior

Default output:

```yaml
spec:
  containers:
    - name: app
      image: nginx
```

With this configuration:

```toml
[format.yaml]
indent-sequences = false
```

The formatter emits:

```yaml
spec:
  containers:
  - name: app
    image: nginx
```

## Testing

- `go test ./pkg/configfile ./pkg/formatter/yamlfmt -count=1`
- `go test ./cmd/cfv -run TestScript/format_yaml_indent_sequences -count=1`
- `go vet ./...`
- repository-wide `gofmt -s -l -e .` check
- `go generate ./pkg/filetype/...` with no generated diff
- Linux static cross-build of `cmd/cfv/cfv.go`
- `golangci-lint run ./...` with zero findings
- `git diff --check`

Fixes #582
