### PR TITLE
feat(format): auto-detect .prettierrc for JSON/JSONC/YAML formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--sort-keys` flag to sort mapping keys alphabetically on `cfv format`
 - `--diff` flag for previewing formatting changes without modifying files
 - Per-format configuration in `.cfv.toml` via `[format.<type>]` tables (yaml, json, jsonc, toml, hcl, xml, ini, properties, env)
-- Format configuration cascade: CLI flags > per-format config > global `[format]` config > `taplo.toml` > `.editorconfig` > defaults
+- Format configuration cascade: CLI flags > per-format config > global `[format]` config > `taplo.toml` / `.prettierrc` > `.editorconfig` > defaults
 - `trailing-commas` format option (`all` | `none` | `preserve`) to control trailing commas on expanded JSONC collections
 - `.editorconfig` auto-detection for `cfv format`: `indent_style`, `indent_size`, `end_of_line`, and `insert_final_newline` are resolved per file (globs, parent directories, and `root = true` are all respected). Disable with `--no-editorconfig` (closes #562)
 - `taplo.toml` / `.taplo.toml` auto-detection for TOML formatting: `indent_string`, `column_width`, `trailing_newline`, `reorder_keys`, `crlf`, and `array_trailing_comma` are mapped onto the equivalent cfv options. Disable with `--no-taplo-config` (closes #564)
+- `.prettierrc` auto-detection for `cfv format`: `tabWidth`, `useTabs`, `printWidth`, `endOfLine`, `trailingComma`, and `singleQuote` are read from `.prettierrc`, `.prettierrc.json`, `.prettierrc.yaml`/`.yml`, or `.prettierrc.toml` (closest directory wins; JS-based configs are skipped, not an error). Slots into the cascade between `.editorconfig` and `.cfv.toml`. Disable with `--no-prettier-config` (closes #563)
 - `max-line-width` and `trailing-commas` are now honored by the TOML formatter
 - Schema validation support for JSONC files via `$schema`, `--schema-map`, and SchemaStore
 - Schema validation support for Properties files via `--schema-map` in `.cfv.toml`

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -99,6 +99,7 @@ type cfvConfig struct {
 	fmtDiff           *bool
 	fmtNoEditorConfig *bool
 	fmtNoTaploConfig  *bool
+	fmtNoPrettier     *bool
 }
 
 // reporterConfig pairs a reporter format name with an optional output path.
@@ -540,6 +541,7 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 		fmtQuoteStylePtr     = fs.String("quote-style", "", "Quote style: double, single, preserve")
 		fmtNoEditorConfigPtr = fs.Bool("no-editorconfig", false, "Ignore .editorconfig files when resolving format options")
 		fmtNoTaploConfigPtr  = fs.Bool("no-taplo-config", false, "Ignore taplo.toml files when resolving TOML format options")
+		fmtNoPrettierPtr     = fs.Bool("no-prettier-config", false, "Ignore .prettierrc files when resolving format options")
 		fmtDiffPtr           = fs.Bool("diff", false, "Show unified diff instead of rewriting (implies no --fix)")
 	)
 
@@ -620,6 +622,7 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 		fmtDiff:           fmtDiffPtr,
 		fmtNoEditorConfig: fmtNoEditorConfigPtr,
 		fmtNoTaploConfig:  fmtNoTaploConfigPtr,
+		fmtNoPrettier:     fmtNoPrettierPtr,
 	}, nil
 }
 
@@ -630,7 +633,10 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 // buildFormatOptionsResolver builds a function that resolves format options
 // for any format name using the cascade:
 //
-//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > taplo.toml > .editorconfig > format-specific defaults
+//	CLI flags > .cfv.toml [format.<type>] > .cfv.toml [format] > taplo.toml / .prettierrc > .editorconfig > format-specific defaults
+//
+// taplo.toml only applies to TOML files and .prettierrc only applies to
+// JSON/JSONC/YAML files, so the two never compete for the same file.
 func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOptionsFunc {
 	var globalCfg *configfile.FormatOptions
 	var perFormatCfg map[string]*configfile.FormatOptions
@@ -643,6 +649,11 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 	var taploCfg *formatter.Taplo
 	if cfg.fmtNoTaploConfig == nil || !*cfg.fmtNoTaploConfig {
 		taploCfg = formatter.LoadTaplo(".")
+	}
+
+	var prettierCfg *formatter.PrettierConfig
+	if cfg.fmtNoPrettier == nil || !*cfg.fmtNoPrettier {
+		prettierCfg = formatter.NewPrettierConfig()
 	}
 
 	if rc.formatCfg != nil {
@@ -664,18 +675,25 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 		// Start with format-specific defaults.
 		opts := formatDefaults(formatName)
 
+		// A zero default width means the format is not indented at all
+		// (TOML keys under a table header). That is a property of the
+		// format rather than an editor/tool preference, so neither
+		// .editorconfig nor .prettierrc may reintroduce indentation. An
+		// explicit .cfv.toml or --indent still can, in the layers below.
+		unindented := opts.IndentWidth == 0
+
 		// Layer 2: .editorconfig (resolved per file)
 		if editorCfg != nil {
-			// A zero default width means the format is not indented at all
-			// (TOML keys under a table header). That is a property of the
-			// format rather than an editor preference, so a project-wide
-			// [*] indent_size must not reintroduce indentation. An explicit
-			// .cfv.toml or --indent still can, in the layers below.
-			unindented := opts.IndentWidth == 0
 			editorCfg.Apply(&opts, path)
-			if unindented {
-				opts.IndentWidth = 0
-			}
+		}
+
+		// Layer 2.1: .prettierrc (resolved per file)
+		if prettierCfg != nil {
+			prettierCfg.Apply(&opts, path)
+		}
+
+		if unindented {
+			opts.IndentWidth = 0
 		}
 
 		// Layer 3: taplo.toml, which only configures TOML formatting.

--- a/cmd/cfv/testdata/format_prettierconfig.txtar
+++ b/cmd/cfv/testdata/format_prettierconfig.txtar
@@ -1,0 +1,111 @@
+# ============================================================
+# .prettierrc auto-detection
+# Proves: CLI flags > .cfv.toml > .prettierrc > .editorconfig > defaults,
+# discovery priority within a directory, closest-directory-wins, JSON/YAML/
+# TOML formats, unsupported JS configs skipped, and --no-prettier-config.
+# ============================================================
+
+# .prettierrc.json tabWidth = 4 replaces the default 2
+cp orig.json indent.json
+exec cfv format --fix --no-config indent.json
+exec cat indent.json
+stdout '^    "key"'
+
+# --no-prettier-config falls back to the default 2
+cp orig.json indent.json
+exec cfv format --fix --no-config --no-prettier-config indent.json
+exec cat indent.json
+stdout '^  "key"'
+
+# .cfv.toml overrides .prettierrc
+cp orig.json indent.json
+exec cfv format --fix --config=cfv/indent6.toml indent.json
+exec cat indent.json
+stdout '^      "key"'
+
+# CLI flags override both
+cp orig.json indent.json
+exec cfv format --fix --config=cfv/indent6.toml --indent=8 indent.json
+exec cat indent.json
+stdout '^        "key"'
+
+# .prettierrc.json overrides .editorconfig
+cp orig.json ec/indent.json
+exec cfv format --fix --no-config ec/indent.json
+exec cat ec/indent.json
+stdout '^    "key"'
+
+# bare .prettierrc (JSON content) is discovered ahead of .prettierrc.yaml
+exec cfv format --fix --no-config bare/app.json
+exec cat bare/app.json
+stdout '^     "k"'
+
+# YAML .prettierrc.yaml maps singleQuote / printWidth
+exec cfv format --fix --no-config yamlcfg/app.yaml
+exec cat yamlcfg/app.yaml
+stdout 'key: .value.'
+
+# TOML .prettierrc.toml maps tabWidth
+exec cfv format --fix --no-config tomlcfg/app.jsonc
+exec cat tomlcfg/app.jsonc
+stdout '^   "key"'
+
+# nested directory's .prettierrc wins over the parent's
+exec cfv format --fix --no-config nested/child/app.json
+exec cat nested/child/app.json
+stdout '^  "key"'
+
+# unsupported .prettierrc.js is skipped; parent's supported config applies
+exec cfv format --fix --no-config jsskip/child/app.json
+exec cat jsskip/child/app.json
+stdout '^   "key"'
+
+-- orig.json --
+{"key":"value"}
+-- .prettierrc.json --
+{"tabWidth": 4}
+-- cfv/indent6.toml --
+[format]
+indent = 6
+
+-- ec/.editorconfig --
+root = true
+
+[*]
+indent_size = 6
+-- ec/.prettierrc.json --
+{"tabWidth": 4}
+-- ec/orig.json --
+{"key":"value"}
+
+-- bare/.prettierrc --
+{"tabWidth": 5}
+-- bare/.prettierrc.yaml --
+tabWidth: 9
+-- bare/app.json --
+{"k":"v"}
+
+-- yamlcfg/.prettierrc.yaml --
+printWidth: 40
+singleQuote: true
+-- yamlcfg/app.yaml --
+key: "value"
+
+-- tomlcfg/.prettierrc.toml --
+tabWidth = 3
+-- tomlcfg/app.jsonc --
+{"key":"value"}
+
+-- nested/.prettierrc.json --
+{"tabWidth": 8}
+-- nested/child/.prettierrc.json --
+{"tabWidth": 2}
+-- nested/child/app.json --
+{"key":"value"}
+
+-- jsskip/.prettierrc.json --
+{"tabWidth": 3}
+-- jsskip/child/.prettierrc.js --
+module.exports = { tabWidth: 4 };
+-- jsskip/child/app.json --
+{"key":"value"}

--- a/pkg/formatter/prettierconfig.go
+++ b/pkg/formatter/prettierconfig.go
@@ -1,0 +1,213 @@
+package formatter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/tailscale/hujson"
+	"gopkg.in/yaml.v3"
+)
+
+// prettierConfigNames lists supported .prettierrc file names, in discovery
+// priority order within a single directory.
+//
+// .prettierrc.js, .prettierrc.cjs, .prettierrc.mjs, and prettier.config.*
+// require JS evaluation and are intentionally not supported: they are
+// skipped rather than treated as an error, and the search continues
+// upward in case a supported file exists in a parent directory.
+var prettierConfigNames = []string{
+	".prettierrc",
+	".prettierrc.json",
+	".prettierrc.yaml",
+	".prettierrc.yml",
+	".prettierrc.toml",
+}
+
+// prettierRC holds the subset of prettier options cfv maps onto formatter.Options.
+// Pointer fields distinguish "not set in the file" from "set to zero/false".
+type prettierRC struct {
+	TabWidth      *int    `json:"tabWidth"      yaml:"tabWidth"      toml:"tabWidth"`
+	UseTabs       *bool   `json:"useTabs"       yaml:"useTabs"       toml:"useTabs"`
+	PrintWidth    *int    `json:"printWidth"    yaml:"printWidth"    toml:"printWidth"`
+	EndOfLine     *string `json:"endOfLine"     yaml:"endOfLine"     toml:"endOfLine"`
+	TrailingComma *string `json:"trailingComma" yaml:"trailingComma" toml:"trailingComma"`
+	SingleQuote   *bool   `json:"singleQuote"   yaml:"singleQuote"   toml:"singleQuote"`
+}
+
+// PrettierConfig resolves .prettierrc settings for individual files.
+//
+// Resolution is per-file: cfv walks up from the file's directory and uses
+// the nearest directory containing a supported .prettierrc variant. Unlike
+// .editorconfig, prettier configs are not merged across directory levels —
+// the closest file found entirely determines the result.
+//
+// The zero value is not usable; use NewPrettierConfig.
+//
+// Safe for concurrent use.
+type PrettierConfig struct {
+	mu sync.Mutex
+	// dirCache maps a starting directory to the resolved config found by
+	// walking up from it (nil = none found).
+	dirCache map[string]*prettierRC
+	// fileCache maps a candidate config file's path to its parsed contents
+	// (nil = file absent or malformed), so a config shared by many
+	// directories in a walk is only parsed once.
+	fileCache map[string]*prettierRC
+}
+
+// NewPrettierConfig returns a PrettierConfig backed by a cache, so a
+// .prettierrc shared by many source files is only parsed once.
+func NewPrettierConfig() *PrettierConfig {
+	return &PrettierConfig{
+		dirCache:  make(map[string]*prettierRC),
+		fileCache: make(map[string]*prettierRC),
+	}
+}
+
+// Apply overlays the resolved .prettierrc properties for path onto opts.
+// Properties that are absent, unset, or not representable as an Option are
+// left alone. A missing, malformed, or unsupported (JS-based) config is
+// ignored rather than reported.
+func (p *PrettierConfig) Apply(opts *Options, path string) {
+	p.mu.Lock()
+	rc := p.resolve(filepath.Dir(path))
+	p.mu.Unlock()
+	if rc == nil {
+		return
+	}
+
+	if rc.TabWidth != nil && *rc.TabWidth > 0 {
+		opts.IndentWidth = *rc.TabWidth
+	}
+	if rc.UseTabs != nil {
+		if *rc.UseTabs {
+			opts.IndentStyle = IndentTabs
+		} else {
+			opts.IndentStyle = IndentSpaces
+		}
+	}
+	if rc.PrintWidth != nil {
+		opts.MaxLineWidth = *rc.PrintWidth
+	}
+	if rc.EndOfLine != nil {
+		switch *rc.EndOfLine {
+		case "lf":
+			opts.LineEnding = LineEndingLF
+		case "crlf":
+			opts.LineEnding = LineEndingCRLF
+		default:
+			// "auto" (preserve existing) and "cr" have no cfv equivalent.
+		}
+	}
+	if rc.TrailingComma != nil {
+		switch *rc.TrailingComma {
+		case "all":
+			opts.TrailingCommas = TrailingCommasAll
+		case "none":
+			opts.TrailingCommas = TrailingCommasNone
+		default:
+			opts.TrailingCommas = TrailingCommasPreserve
+		}
+	}
+	if rc.SingleQuote != nil {
+		if *rc.SingleQuote {
+			opts.QuoteStyle = QuoteSingle
+		} else {
+			opts.QuoteStyle = QuoteDouble
+		}
+	}
+}
+
+// resolve returns the parsed .prettierrc that applies to files in dir,
+// walking up the directory tree and caching results per starting directory.
+// Not safe for concurrent use; callers must hold p.mu.
+func (p *PrettierConfig) resolve(dir string) *prettierRC {
+	if rc, ok := p.dirCache[dir]; ok {
+		return rc
+	}
+
+	rc := p.discover(dir)
+	p.dirCache[dir] = rc
+	return rc
+}
+
+func (p *PrettierConfig) discover(dir string) *prettierRC {
+	for {
+		if rc := p.parseDir(dir); rc != nil {
+			return rc
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+		dir = parent
+	}
+}
+
+// parseDir looks for a supported .prettierrc variant directly in dir and
+// parses the first one found, in priority order. It does not recurse.
+func (p *PrettierConfig) parseDir(dir string) *prettierRC {
+	for _, name := range prettierConfigNames {
+		path := filepath.Join(dir, name)
+
+		if rc, ok := p.fileCache[path]; ok {
+			if rc != nil {
+				return rc
+			}
+			continue
+		}
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			p.fileCache[path] = nil
+			continue
+		}
+
+		rc := parsePrettierRC(name, src)
+		p.fileCache[path] = rc
+		if rc != nil {
+			return rc
+		}
+	}
+	return nil
+}
+
+// parsePrettierRC parses src according to name's format. A malformed file
+// returns nil rather than an error, matching the "ignore, don't fail the
+// run" behavior used for .editorconfig.
+func parsePrettierRC(name string, src []byte) *prettierRC {
+	var rc prettierRC
+
+	switch name {
+	case ".prettierrc.yaml", ".prettierrc.yml":
+		if err := yaml.Unmarshal(src, &rc); err != nil {
+			return nil
+		}
+	case ".prettierrc.toml":
+		if err := toml.Unmarshal(src, &rc); err != nil {
+			return nil
+		}
+	default:
+		// .prettierrc and .prettierrc.json: auto-detect by trying JSON
+		// first (tolerating comments/trailing commas via hujson), then
+		// falling back to YAML since a bare .prettierrc may be either.
+		std, err := hujson.Standardize(src)
+		if err == nil {
+			if err := json.Unmarshal(std, &rc); err == nil {
+				return &rc
+			}
+		}
+		if name == ".prettierrc" {
+			if err := yaml.Unmarshal(src, &rc); err == nil {
+				return &rc
+			}
+		}
+		return nil
+	}
+
+	return &rc
+}

--- a/pkg/formatter/prettierconfig_test.go
+++ b/pkg/formatter/prettierconfig_test.go
@@ -1,0 +1,174 @@
+package formatter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Boeing/config-file-validator/v3/pkg/formatter"
+)
+
+// writePrettierRC writes name (e.g. ".prettierrc.json") with the given
+// content into dir.
+func writePrettierRC(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+}
+
+func TestPrettierConfigApply_JSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.json", `{
+		"tabWidth": 4,
+		"useTabs": false,
+		"printWidth": 100,
+		"endOfLine": "crlf",
+		"trailingComma": "all",
+		"singleQuote": true
+	}`)
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "config.jsonc"))
+
+	require.Equal(t, 4, opts.IndentWidth)
+	require.Equal(t, formatter.IndentSpaces, opts.IndentStyle)
+	require.Equal(t, 100, opts.MaxLineWidth)
+	require.Equal(t, formatter.LineEndingCRLF, opts.LineEnding)
+	require.Equal(t, formatter.TrailingCommasAll, opts.TrailingCommas)
+	require.Equal(t, formatter.QuoteSingle, opts.QuoteStyle)
+}
+
+func TestPrettierConfigApply_BareFileAutoDetectsJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc", `{"tabWidth": 8}`)
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, 8, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_BareFileFallsBackToYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc", "tabWidth: 6\nuseTabs: true\n")
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, 6, opts.IndentWidth)
+	require.Equal(t, formatter.IndentTabs, opts.IndentStyle)
+}
+
+func TestPrettierConfigApply_YAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.yaml", "printWidth: 120\nsingleQuote: false\n")
+
+	opts := formatter.Options{QuoteStyle: formatter.QuoteSingle}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.yaml"))
+
+	require.Equal(t, 120, opts.MaxLineWidth)
+	require.Equal(t, formatter.QuoteDouble, opts.QuoteStyle)
+}
+
+func TestPrettierConfigApply_YML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.yml", "tabWidth: 3\n")
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.yaml"))
+
+	require.Equal(t, 3, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_TOML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.toml", "tabWidth = 4\nendOfLine = \"lf\"\n")
+
+	opts := formatter.Options{IndentWidth: 2, LineEnding: formatter.LineEndingCRLF}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.toml"))
+
+	require.Equal(t, 4, opts.IndentWidth)
+	require.Equal(t, formatter.LineEndingLF, opts.LineEnding)
+}
+
+func TestPrettierConfigApply_DiscoveryPriorityWithinDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// .prettierrc must win over .prettierrc.json in the same directory.
+	writePrettierRC(t, dir, ".prettierrc", `{"tabWidth": 5}`)
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": 9}`)
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, 5, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_ClosestDirectoryWins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": 2}`)
+	nested := filepath.Join(dir, "nested")
+	writePrettierRC(t, nested, ".prettierrc.json", `{"tabWidth": 7}`)
+
+	opts := formatter.Options{IndentWidth: 3}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(nested, "app.json"))
+
+	require.Equal(t, 7, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_WalksUpWhenNotFoundLocally(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": 6}`)
+	nested := filepath.Join(dir, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(nested, "app.json"))
+
+	require.Equal(t, 6, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_UnsupportedJSConfigIsSkippedNotError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.js", "module.exports = { tabWidth: 4 };\n")
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	// No supported config found: options are left untouched, and applying
+	// must not error or panic.
+	require.Equal(t, 2, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_MalformedFileIsIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": `)
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, 2, opts.IndentWidth)
+}
+
+func TestPrettierConfigApply_LeavesOptionsAloneWhenAbsent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	want := formatter.Options{IndentStyle: formatter.IndentSpaces, IndentWidth: 2, FinalNewline: true}
+	got := want
+	formatter.NewPrettierConfig().Apply(&got, filepath.Join(dir, "app.json"))
+
+	require.Equal(t, want, got)
+}

--- a/website/docs/guides/formatting.md
+++ b/website/docs/guides/formatting.md
@@ -50,7 +50,9 @@ Running `cfv format --fix` twice always produces the same output. If a file is a
 
 Format settings are resolved per file, lowest priority first:
 
-`.editorconfig` → `taplo.toml` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags
+`.editorconfig` → `taplo.toml` / `.prettierrc` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags
+
+`taplo.toml` only applies to TOML files and `.prettierrc` only applies to JSON/JSONC/YAML files, so the two never compete for the same file.
 
 ### `.editorconfig`
 
@@ -97,6 +99,46 @@ than failing the run.
 
 Pass `--no-taplo-config` to ignore `taplo.toml` entirely.
 
+### `.prettierrc`
+
+If your project has a `.prettierrc` (or one of its static variants), cfv reads
+it and layers it on top of `.editorconfig`, so JSON, JSONC, and YAML files
+format to match your existing Prettier settings without duplicating them in
+`.cfv.toml`. The options cfv understands:
+
+| Prettier option | cfv option        | Notes                                |
+|------------------|-------------------|---------------------------------------|
+| `tabWidth`       | Indent width      |                                       |
+| `useTabs`        | Spaces or tabs    |                                       |
+| `printWidth`     | Max line width    |                                       |
+| `endOfLine`      | Line ending       | `lf` / `crlf` map; `auto`/`cr` are ignored |
+| `trailingComma`  | Trailing commas   | JSONC only; `all` / `none`            |
+| `singleQuote`    | Quote style       | YAML only                             |
+
+Supported file formats, checked in this order in each directory (first match wins):
+
+1. `.prettierrc` (JSON content tried first, then YAML)
+2. `.prettierrc.json`
+3. `.prettierrc.yaml` / `.prettierrc.yml`
+4. `.prettierrc.toml`
+
+cfv walks up from each file's directory and uses the nearest directory that
+has a supported config; unlike `.editorconfig`, prettier configs are not
+merged across directory levels — the closest one found fully determines the
+result.
+
+**Known limitations (v1):**
+
+- `.prettierrc.js`, `.prettierrc.cjs`, `.prettierrc.mjs`, and
+  `prettier.config.*` require JS evaluation and are not supported. They are
+  skipped silently (not an error), and the search continues upward for a
+  supported config.
+- A `"prettier"` key in `package.json` is not yet read.
+- The `overrides` array is not supported — only top-level options apply.
+- A malformed config file is skipped rather than failing the run.
+
+Pass `--no-prettier-config` to ignore `.prettierrc` entirely.
+
 ### `.cfv.toml`
 
 Format settings live in `.cfv.toml` at the root of your project.
@@ -137,7 +179,7 @@ file to all expanded collections.
 
 ## CLI flags
 
-These flags override `.cfv.toml`, `taplo.toml`, and `.editorconfig` settings for a single invocation:
+These flags override `.cfv.toml`, `taplo.toml`, `.prettierrc`, and `.editorconfig` settings for a single invocation:
 
 | Flag | Effect |
 |------|--------|
@@ -146,6 +188,7 @@ These flags override `.cfv.toml`, `taplo.toml`, and `.editorconfig` settings for
 | `--no-final-newline` | Omit trailing newline |
 | `--no-editorconfig` | Ignore `.editorconfig` files |
 | `--no-taplo-config` | Ignore `taplo.toml` files |
+| `--no-prettier-config` | Ignore `.prettierrc` files |
 
 Example: check formatting with 4-space indent regardless of config file:
 

--- a/website/docs/reference/cli-flags.md
+++ b/website/docs/reference/cli-flags.md
@@ -66,6 +66,7 @@ Checks formatting of config files. With `--fix`, rewrites files in place. With `
 | `-sort-keys`  | bool   | `false` | Sort mapping keys alphabetically.                            |
 | `-no-editorconfig` | bool | `false` | Ignore `.editorconfig` files when resolving format options. |
 | `-no-taplo-config` | bool | `false` | Ignore `taplo.toml` files when resolving TOML format options. |
+| `-no-prettier-config` | bool | `false` | Ignore `.prettierrc` files when resolving format options. |
 
 ### Shared flags
 


### PR DESCRIPTION
## Summary
- Adds `.prettierrc` auto-detection so JSON, JSONC, and YAML formatting can pick up existing Prettier settings without duplicating them in `.cfv.toml`
- Supports `.prettierrc` (JSON-or-YAML content, auto-detected), `.prettierrc.json`, `.prettierrc.yaml`/`.yml`, and `.prettierrc.toml`; discovery walks up from each file's directory and the closest directory's config wins (no cross-directory merging)
- Maps `tabWidth` → indent, `useTabs` → indent style, `printWidth` → max line width, `endOfLine` → line ending, `trailingComma` → trailing commas (JSONC), `singleQuote` → quote style (YAML)
- Slots into the existing cascade: `.editorconfig` → `.prettierrc` → `.cfv.toml [format]` → `.cfv.toml [format.<type>]` → CLI flags
- `.prettierrc.js`/`.cjs`/`.mjs` and `prettier.config.*` are skipped silently (not an error) since they require JS evaluation; the upward search continues past them
- Adds `--no-prettier-config` to disable the feature entirely
- Not in scope for this PR (per issue): `"prettier"` key in `package.json`, and Prettier's `overrides` array

## Test plan
- [x] `go test ./...` passes
- [x] New unit tests in `pkg/formatter/prettierconfig_test.go` cover each config format, discovery priority within a directory, closest-directory-wins, upward search, unsupported JS configs, and malformed files
- [x] New end-to-end golden test `cmd/cfv/testdata/format_prettierconfig.txtar` covers the full cascade (`.editorconfig` → `.prettierrc` → `.cfv.toml` → CLI flags) and `--no-prettier-config`
- [x] `gofmt`/`go vet` clean
- [x] Docs updated: `website/docs/guides/formatting.md`, `website/docs/reference/cli-flags.md`, `CHANGELOG.md`

Closes #563