### PR TITLE
fix(deps): resolve 3 npm vulnerabilities in website/package-lock.json

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9803,9 +9803,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -18586,9 +18586,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",


### PR DESCRIPTION
Bumps fast-uri 3.1.2 → 3.1.4 and svgo 3.3.3 → 3.3.4 to fix 3 high-severity vulnerabilities flagged by osv-scanner and trivy in MegaLinter. This is blocking all PR pipelines on feat/3.0.

- fast-uri: CVE-2026-13676 (host confusion via failed IDN canonicalization), CVE-2026-16221 (host confusion via backslash authority delimiter)
- svgo: GHSA-2p49-hgcm-8545 (removeScripts plugin leaves executable scripts intact)

```
npm audit fix
changed 2 packages
found 0 vulnerabilities
```