### PR TITLE
fix(yamlfmt): expand flow collections under the key's real column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YAML formatter no longer produces unparseable output when a long flow collection is expanded inside a block sequence item. The sequence indicator was not counted towards the key's column, so `- key: [...]` put the bracket at the key's own column, where it is no longer that key's value — `cfv format --fix` rewrote valid documents into invalid ones while reporting success. Affects both `[` and `{`; the corrected layout matches Prettier byte for byte.
 - XML formatter no longer collapses multi-line text content into a single line. Elements containing text (like `<description>` with paragraphs) now preserve newlines and get correctly reindented. Previously, `removeInsignificantWhitespace` stripped all newlines unconditionally, causing sentences to concatenate without separators — data corruption.
 - XML formatter preserve mode (`xml-whitespace-sensitivity = "preserve"`) now indents close tags at the correct depth (matching the open tag) instead of one level too deep.
 - JSONC validator no longer mutates the input byte slice during schema validation. `ValidateSchema` and `MarshalToJSON` now clone the input before calling `hujson.Standardize`, which modifies data in-place.

--- a/cmd/cfv/testdata/format_yaml_flow_in_sequence.txtar
+++ b/cmd/cfv/testdata/format_yaml_flow_in_sequence.txtar
@@ -1,0 +1,18 @@
+# A long flow collection expanded inside a block sequence item must stay valid
+# YAML: its bracket belongs under the key, not at the key's own column.
+exec cfv format --fix --no-config .
+stdout '✓.*relabel.yaml'
+
+# The rewritten file still parses.
+exec cfv check --no-schema .
+stdout '✓.*relabel.yaml'
+! stdout '×'
+
+# Formatting again is a no-op.
+exec cfv format --no-config .
+! stdout '~'
+
+-- relabel.yaml --
+relabel_configs:
+  - values: ["first_long_element_value_aaaaaaaaaaaaaaaa", "second_long_element_value_bbbbbbbbbbbb", "third_long_element_cccccc"]
+    action: keep

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -1516,6 +1516,14 @@ func expandLongFlowSequences(tokens []Token, maxWidth, indentWidth int) {
 		// If not, the flow is inline (root-level or bare sequence item) and
 		// the bracket stays at the current column.
 		afterColon := false
+
+		// A value has to be indented past its key, and anything between the
+		// line indent and the key — a sequence indicator, say — moves the key
+		// to the right. Track the key so its real column is used instead of the
+		// line indent; otherwise a value expanded inside a sequence item lands
+		// on the key's own column, where it is no longer that key's value and
+		// the document stops parsing.
+		keyIdx := -1
 		for j := i - 1; j >= 0; j-- {
 			if tokens[j].Kind == TokIndent {
 				parentIndent = len(tokens[j].Raw)
@@ -1524,18 +1532,24 @@ func expandLongFlowSequences(tokens []Token, maxWidth, indentWidth int) {
 			if tokens[j].Kind == TokNewline {
 				break
 			}
-			if tokens[j].Kind == TokColon {
+			if tokens[j].Kind == TokColon && !afterColon {
 				afterColon = true
+				keyIdx = j - 1
 			}
+		}
+
+		keyIndent := parentIndent
+		if keyIdx >= 0 && tokens[keyIdx].Kind != TokIndent && tokens[keyIdx].Kind != TokNewline {
+			keyIndent = computeTokenLineStart(tokens, keyIdx)
 		}
 
 		var expanded []byte
 		if afterColon {
 			// Value-position: key: [long] → key:\n  [\n    elem,\n  ]
-			// Bracket on next line at parentIndent + indentWidth,
-			// elements at parentIndent + 2*indentWidth.
-			bracketIndent := strings.Repeat(" ", parentIndent+indentWidth)
-			elemIndent := strings.Repeat(" ", parentIndent+2*indentWidth)
+			// Bracket on next line at keyIndent + indentWidth,
+			// elements at keyIndent + 2*indentWidth.
+			bracketIndent := strings.Repeat(" ", keyIndent+indentWidth)
+			elemIndent := strings.Repeat(" ", keyIndent+2*indentWidth)
 
 			expanded = append(expanded, '\n')
 			expanded = append(expanded, bracketIndent...)

--- a/pkg/formatter/yamlfmt/testdata/flow_expand_in_sequence.expected.yaml
+++ b/pkg/formatter/yamlfmt/testdata/flow_expand_in_sequence.expected.yaml
@@ -1,0 +1,17 @@
+relabel_configs:
+  - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label: service
+  - values:
+      [
+        "first_long_element_value_aaaaaaaaaaaaaaaa",
+        "second_long_element_value_bbbbbbbbbbbb",
+        "third_long_element_cccccc",
+      ]
+    action: keep
+  - options:
+      {
+        region: "us-east-1",
+        bucket: "a-fairly-long-bucket-name-for-tests",
+        prefix: "another-long-value-here",
+      }
+    action: replace

--- a/pkg/formatter/yamlfmt/testdata/flow_expand_in_sequence.input.yaml
+++ b/pkg/formatter/yamlfmt/testdata/flow_expand_in_sequence.input.yaml
@@ -1,0 +1,7 @@
+relabel_configs:
+  - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label: service
+  - values: ["first_long_element_value_aaaaaaaaaaaaaaaa", "second_long_element_value_bbbbbbbbbbbb", "third_long_element_cccccc"]
+    action: keep
+  - options: {region: "us-east-1", bucket: "a-fairly-long-bucket-name-for-tests", prefix: "another-long-value-here"}
+    action: replace


### PR DESCRIPTION
Found while testing the release candidate as asked in #551, and rebased onto
37b2b6c.

## The bug

`cfv format --fix` rewrites valid YAML into YAML that no longer parses, and
reports success while doing it.

```console
$ cat relabel.yaml
relabel_configs:
  - values: ["first_long_element_value_aaaaaaaaaaaaaaaa", "second_long_element_value_bbbbbbbbbbbb", "third_long_element_cccccc"]
    action: keep

$ cfv format --fix relabel.yaml
    ✓ relabel.yaml

$ cfv check relabel.yaml
    × relabel.yaml
        error: syntax: line 3: could not find expected ':'
```

The rewritten file is:

```yaml
relabel_configs:
  - values:
    [
      "first_long_element_value_aaaaaaaaaaaaaaaa",
      ...
    ]
    action: keep
```

`values` sits at column 4 and its expanded value is put at column 4 as well, so
it is no longer that key's value.

This shape — a key inside a block sequence item whose value is a long flow
collection — is common in Prometheus and Promtail `relabel_configs`, GitHub
Actions matrices, and Kubernetes manifests. I hit it by running
`cfv format --fix` over the config files of an unrelated repository.

## Cause

`expandLongFlowSequences` takes the expansion indent from the line's
`TokIndent`, which stops before the sequence indicator. For
`  - values: [...]` that gives 2, while the key actually starts at column 4, so
the bracket lands exactly on the key instead of under it. Outside a sequence
item the two agree, which is why the existing fixtures pass.

The fix tracks the key token while walking back to the line indent and lays the
expansion out from the key's real column, so anything sitting between the indent
and the key is accounted for rather than just `- `. The result matches Prettier
byte for byte:

```yaml
relabel_configs:
  - values:
      [
        "first_long_element_value_aaaaaaaaaaaaaaaa",
        "second_long_element_value_bbbbbbbbbbbb",
        "third_long_element_cccccc",
      ]
    action: keep
```

Both `[` and `{` were affected.

## Tests

- `pkg/formatter/yamlfmt/testdata/flow_expand_in_sequence.{input,expected}.yaml`
  covers `[` and `{` inside a sequence item. `TestIdempotency` picks the golden
  file up automatically, so the same fixture also pins stability across passes.
- `cmd/cfv/testdata/format_yaml_flow_in_sequence.txtar` pins it end to end:
  format, then `cfv check` must still pass, then formatting again must be a
  no-op.

Both fail on `feat/3.0` — the txtar case fails with `× relabel.yaml`, which is
the corruption itself.

The golden file is byte-for-byte equal to `prettier --parser yaml` on the same
input, checked with Prettier 3, so it encodes the reference layout rather than
my preference.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` (Linux, `golang:1.26`) | identical to `feat/3.0` — same 4 pre-existing failures, nothing new |
| `golangci-lint run` on the changed packages | 0 issues |
| `go vet ./...`, `gofmt -s -l -e .` | clean |
| Formatter fixtures for all nine formats | pass |
| Prettier 3 parity on the new fixture | byte-for-byte identical |
| Idempotence and validity sweep over 1,124 third-party config files | 0 violations |

These all produced unparseable output before and are valid and idempotent after:
a value carrying an anchor (`key: &anc [...]`), a flow nested in a flow, a
multi-document file, a CRLF file, a quoted key, and a doubly nested sequence.
Empty collections, comments inside a collection, tags, explicit keys, and
brackets or commas inside quoted strings were checked too.

The four failures common to both branches are `Test_CLIWithUnreadableFile`,
`Test_FormatFixUnwritableDirectory`, `Test_fsFinderWalkDirError` and
`TestFetchAndCacheUnwritableDir`; each asserts that an unreadable or unwritable
path errors, which does not hold when the suite runs as root in a container.

## Two things left out

Prettier first tries the whole collection on its own line and only explodes it
element per element if that still does not fit:

```yaml
  - labels:
      ["one_value_that_fits_on_its_own_line_once_it_is_no_longer_after_the_key"]
```

`cfv` always explodes. That is a layout difference rather than a correctness
one and it would move a lot of golden files, so it is not in this PR.

Separately, and unrelated to flow collections: when a sequence indicator is
followed by more than one space, the item's sibling keys get re-indented to a
different column and the document stops parsing.

```console
$ printf 'items:\n  -   key: short\n      other: x\n' > t.yaml && cfv format --fix t.yaml && cfv check t.yaml
    × t.yaml
        error: syntax: line 1: did not find expected '-' indicator
```

It reproduces on `feat/3.0` with no flow collection involved and is untouched
here — happy to report it properly on #551 if that helps.
