### PR TITLE
fix(yamlfmt): keep fitting flow collections intact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YAML formatter now moves a long flow collection below its mapping key before expanding its elements, keeping the collection inline when it fits at the deeper value indentation (closes #623).
 - YAML formatter no longer produces unparseable output when a long flow collection is expanded inside a block sequence item. The sequence indicator was not counted towards the key's column, so `- key: [...]` put the bracket at the key's own column, where it is no longer that key's value — `cfv format --fix` rewrote valid documents into invalid ones while reporting success. Affects both `[` and `{`; the corrected layout matches Prettier byte for byte.
 - XML formatter no longer collapses multi-line text content into a single line. Elements containing text (like `<description>` with paragraphs) now preserve newlines and get correctly reindented. Previously, `removeInsignificantWhitespace` stripped all newlines unconditionally, causing sentences to concatenate without separators — data corruption.
 - XML formatter preserve mode (`xml-whitespace-sensitivity = "preserve"`) now indents close tags at the correct depth (matching the open tag) instead of one level too deep.

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -1472,8 +1472,9 @@ func addFlowMappingPadding(raw []byte) []byte {
 //	  ]
 //
 // Per prettier source (flow-mapping-sequence.js): when a flow collection group
-// breaks at printWidth, elements go on separate lines indented by tabWidth,
-// with trailing comma on last element.
+// breaks after a mapping key, first try the whole collection on the value's
+// next line. If it still exceeds printWidth, put each element on a separate
+// line indented by tabWidth, with a trailing comma on the last element.
 func expandLongFlowSequences(tokens []Token, maxWidth, indentWidth int) {
 	for i := range tokens {
 		if tokens[i].Kind != TokFlow {
@@ -1541,6 +1542,21 @@ func expandLongFlowSequences(tokens []Token, maxWidth, indentWidth int) {
 		keyIndent := parentIndent
 		if keyIdx >= 0 && tokens[keyIdx].Kind != TokIndent && tokens[keyIdx].Kind != TokNewline {
 			keyIndent = computeTokenLineStart(tokens, keyIdx)
+		}
+
+		// Prettier gives a value-position flow collection the extra room gained
+		// by moving it below the key before deciding to split its elements.
+		// Preserve already-multiline collections instead of trying to compact
+		// them through this single-line layout path.
+		if afterColon && !bytes.ContainsAny(raw, "\r\n") &&
+			keyIndent+indentWidth+len(raw) <= maxWidth {
+			bracketIndent := strings.Repeat(" ", keyIndent+indentWidth)
+			moved := make([]byte, 0, 1+len(bracketIndent)+len(raw))
+			moved = append(moved, '\n')
+			moved = append(moved, bracketIndent...)
+			moved = append(moved, raw...)
+			tokens[i].Raw = moved
+			continue
 		}
 
 		var expanded []byte

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -406,6 +406,23 @@ func TestNestedFlowExpansionIndent(t *testing.T) {
 	require.Equal(t, want, string(got))
 }
 
+// TestLongFlowValueStaysWholeOnOwnLine verifies that a flow collection which
+// only exceeds the width while following its key moves to the value's next
+// line without unnecessarily expanding one element per line.
+func TestLongFlowValueStaysWholeOnOwnLine(t *testing.T) {
+	t.Parallel()
+	src := []byte("items:\n  - labels: [\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]\n    name: x\n")
+	want := "items:\n  - labels:\n      [\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]\n    name: x\n"
+
+	got, err := f.Format(src, defaultOpts)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+
+	second, err := f.Format(got, defaultOpts)
+	require.NoError(t, err)
+	require.Equal(t, got, second)
+}
+
 // TestFlowMappingExpansion verifies that long flow mappings { } are expanded
 // to multiline format at printWidth, matching prettier behavior. P1 fix.
 func TestFlowMappingExpansion(t *testing.T) {


### PR DESCRIPTION
Closes #623

## Summary

- Give an over-width flow collection the extra room from moving below its mapping key before deciding whether to split its elements.
- Keep the collection intact when it fits at the deeper value indentation; collections that are still too wide continue to use the existing element-per-line layout.
- Preserve already-multiline flow collections rather than passing them through the single-line relocation path.
- Add a regression test for the reported sequence-item shape, including a second formatting pass to pin idempotency.
- Document the fix in the changelog.

For the issue reproduction, the formatter now produces the same bytes as Prettier 3:

```yaml
items:
  - labels:
      ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
    name: x
```

## Validation

- `go vet ./...`
- `gofmt -s -l -e .` — clean
- `golangci-lint run ./...` — 0 issues
- `go generate ./pkg/filetype/...`
- `go build -o /dev/null ./cmd/cfv`
- `go test -cover -coverprofile coverage.out ./...` — all packages passed, 92.3% total coverage
- `npx --yes prettier@3 --parser yaml` on the issue reproduction — byte-for-byte match

Implemented and verified with Codex assistance; the final diff and test results were reviewed before submission.
