### PR TITLE
fix(yamlfmt): preserve scalar document prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YAML formatting preserves column-zero document-marker prefixes in plain scalar continuations, preventing a second formatting pass from rejecting the first pass's output.
 - YAML formatter now normalizes horizontal whitespace after commas in flow sequences and mappings (closes #635).
 - YAML formatting now normalizes extra spaces after sequence indicators so mapping keys remain aligned with their siblings (closes #622).
 - YAML formatter now moves a long flow collection below its mapping key before expanding its elements, keeping the collection inline when it fits at the deeper value indentation (closes #623).

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -537,8 +537,18 @@ func reindentTokens(tokens []Token, targetWidth int, indentSequences bool) {
 			// Exceptions that stay at column 0:
 			// - Blank-line indents (followed by TokNewline) — no visible whitespace on empty lines
 			// - Document markers (--- and ...) — YAML spec requires column 0
+			// - Plain-scalar continuations beginning with a document-marker prefix.
+			//   Indenting these can make a trailing colon structural on the next parse.
+			markerPrefixedScalar := false
+			if oldIndent == 0 && i+1 < len(tokens) &&
+				(tokens[i+1].Kind == TokKey || tokens[i+1].Kind == TokValue) {
+				raw := tokens[i+1].Raw
+				markerPrefixedScalar = bytes.HasPrefix(raw, []byte("---")) ||
+					bytes.HasPrefix(raw, []byte("..."))
+			}
 			if i+1 < len(tokens) &&
-				(tokens[i+1].Kind == TokNewline || tokens[i+1].Kind == TokDocStart || tokens[i+1].Kind == TokDocEnd) {
+				(tokens[i+1].Kind == TokNewline || tokens[i+1].Kind == TokDocStart ||
+					tokens[i+1].Kind == TokDocEnd || markerPrefixedScalar) {
 				newIndent = 0
 			} else {
 				newIndent = oldIndent + lastDelta

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -121,6 +121,28 @@ func TestIdempotency(t *testing.T) {
 	}
 }
 
+func TestPlainScalarStartingWithDocumentMarkerIsIdempotent(t *testing.T) {
+	t.Parallel()
+	for _, prefix := range []string{"---", "..."} {
+		t.Run(prefix, func(t *testing.T) {
+			t.Parallel()
+			src := []byte("-:\n- 0\n" + prefix + "\"0:\n")
+
+			first, err := f.Format(src, defaultOpts)
+			require.NoError(t, err)
+
+			second, err := f.Format(first, defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, first, second)
+
+			var before, after any
+			require.NoError(t, yaml.Unmarshal(src, &before))
+			require.NoError(t, yaml.Unmarshal(first, &after))
+			require.Equal(t, before, after)
+		})
+	}
+}
+
 // TestInvalidYAMLReturnsError verifies that unparseable input returns an error.
 func TestInvalidYAMLReturnsError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- keep column-zero plain scalar continuations beginning with `---` or `...` from inheriting sequence indentation
- preserve parsed YAML values and formatter idempotency
- add focused regression coverage and the required changelog entry

Addresses defect 2 in #644.

## Root cause

The reindenter shifted every non-structural continuation by the previous structural line delta. For a column-zero scalar continuation beginning with a document-marker prefix, that shift makes a trailing colon structural on the next parse, so the formatter rejects its own first-pass output.

## Testing

- `go vet ./...`
- gofmt check
- `golangci-lint` v2.11.4: 0 issues
- `go generate ./pkg/filetype/...` with no generated diff
- `go build -o /dev/null ./cmd/cfv`
- `go test -cover -coverprofile ... ./...` (92.4% total coverage)
- `git diff --check`