### PR TITLE
fix(jsonfmt): expand arrays with homogeneous nested composites (#630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON and JSONC formatting now expands arrays whose elements are all arrays (or all objects) with more than one child each, matching prettier's `shouldBreak` rule regardless of line width (closes #630).
 - YAML formatting preserves nested sequence depth when an outer sequence indicator has no inline value.
 - YAML formatter now preserves tag syntax in flow sequences, including required whitespace before closing brackets and commas inside verbatim tags.
 - YAML formatting preserves column-zero document-marker prefixes in plain scalar continuations, preventing a second formatting pass from rejecting the first pass's output.

--- a/pkg/formatter/jsoncfmt/jsonc.go
+++ b/pkg/formatter/jsoncfmt/jsonc.go
@@ -287,7 +287,9 @@ func (fs *formatState) formatArray(arr *hujson.Array, depth int) {
 	// A single-line array like [1, 2, 3] is cleaner without a trailing comma.
 	// Exception: concise arrays with source blank lines always expand (prettier
 	// behavior — blank lines force the group to break in fill layout).
-	if (!concise || !hasBlankLines) && fs.isInlineArray(arr, depth*len(fs.indent)) {
+	// Exception: homogeneous arrays of multi-element arrays/objects always expand
+	// (prettier's shouldBreak rule from src/language-js/print/array.js v3.9.6).
+	if !shouldBreakArray(arr) && (!concise || !hasBlankLines) && fs.isInlineArray(arr, depth*len(fs.indent)) {
 		for i := range arr.Elements {
 			if i == 0 {
 				arr.Elements[i].BeforeExtra = nil
@@ -536,6 +538,9 @@ func inlineValueLength(v *hujson.Value) int {
 		if len(val.Elements) == 0 {
 			return 2 // []
 		}
+		if shouldBreakArray(val) {
+			return -1 // prettier always expands these
+		}
 		total := 2 // "[" + "]"
 		for i, e := range val.Elements {
 			if i > 0 {
@@ -577,6 +582,40 @@ func (fs *formatState) isInlineObject(obj *hujson.Object, prefixLen int) bool {
 		return false
 	}
 	return prefixLen+fs.keyPrefixLen+valLen <= fs.maxLineWidth
+}
+
+// shouldBreakArray mirrors prettier v3.9.6's shouldBreak logic from
+// src/language-js/print/array.js. An array is forced to expand (regardless of
+// line width) when ALL of:
+//  1. More than 1 element in the outer array.
+//  2. Every element is the same composite type (all arrays OR all objects).
+//  3. Each child array has >1 element, or each child object has >1 property.
+//
+// This handles patterns like [["{", "}"], ["[", "]"], ["(", ")"]] which are
+// short enough to inline but prettier always expands.
+func shouldBreakArray(arr *hujson.Array) bool {
+	if len(arr.Elements) <= 1 {
+		return false
+	}
+	allArrays := true
+	allObjects := true
+	for _, e := range arr.Elements {
+		switch child := e.Value.(type) {
+		case *hujson.Array:
+			allObjects = false
+			if len(child.Elements) <= 1 {
+				return false
+			}
+		case *hujson.Object:
+			allArrays = false
+			if len(child.Members) <= 1 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return allArrays || allObjects
 }
 
 // isInlineArray returns true if the array should stay on one line.

--- a/pkg/formatter/jsoncfmt/jsonc_test.go
+++ b/pkg/formatter/jsoncfmt/jsonc_test.go
@@ -1,6 +1,7 @@
 package jsoncfmt_test
 
 import (
+	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
@@ -410,6 +411,67 @@ func TestInlineArrayDepthAware(t *testing.T) {
 	gotDeepShort, err := f.Format(deepShortSrc, defaultOpts)
 	require.NoError(t, err)
 	require.Contains(t, string(gotDeepShort), `["x", "y"]`, "deep but short array must collapse")
+}
+
+// TestShouldBreakArray verifies that arrays of homogeneous multi-element
+// arrays/objects always expand, matching prettier v3.9.6's shouldBreak rule.
+func TestShouldBreakArray(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		input        string
+		shouldExpand bool
+	}{
+		{"arrays_multi_element_expand",
+			`[["{", "}"], ["[", "]"], ["(", ")"]]`,
+			true},
+		{"arrays_single_element_inline",
+			`[[1], [2], [3]]`,
+			false},
+		{"single_outer_element_inline",
+			`[[1, 2, 3]]`,
+			false},
+		{"mixed_types_inline",
+			`[[1, 2], "a"]`,
+			false},
+		{"primitives_inline",
+			`[1, 2, 3]`,
+			false},
+		{"objects_multi_prop_expand",
+			`[{"a": 1, "b": 2}, {"c": 3, "d": 4}]`,
+			true},
+		{"objects_single_prop_inline",
+			`[{"a": 1}, {"b": 2}]`,
+			false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), defaultOpts)
+			require.NoError(t, err)
+			output := string(got)
+			if tc.shouldExpand {
+				require.Contains(t, output, "\n  ", "expected expanded (multiline) output")
+			} else {
+				// Should be single line (plus trailing newline).
+				lines := strings.Split(strings.TrimSpace(output), "\n")
+				require.Len(t, lines, 1, "expected single-line output, got:\n%s", output)
+			}
+
+			// Idempotency.
+			got2, err := f.Format(got, defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, got, got2, "must be idempotent")
+
+			// Semantic preservation.
+			var before, after any
+			require.NoError(t, json.Unmarshal([]byte(tc.input), &before))
+			std, err := hujson.Standardize(got)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(std, &after))
+			require.Equal(t, before, after, "formatting must not change parsed value")
+		})
+	}
 }
 
 // TestConciseArrayFillFormat verifies the fill layout for all-numeric arrays.


### PR DESCRIPTION
## Summary

JSON and JSONC arrays whose elements are ALL arrays (or ALL objects) with more than one child each are now always expanded, matching prettier v3.9.6's `shouldBreak` rule.

Closes #630. Closes #569.

## Root cause

prettier's JS printer forces expansion when all array elements are the same composite type (arrays or objects) with >1 child each. cfv's `isInlineArray` only checked total character width, so arrays like `[["{}", "}"], ["[", "]"]]` were inlined when prettier would expand them.

## Changes

- `pkg/formatter/jsoncfmt/jsonc.go`: Add `shouldBreakArray()` check before the inline path in `formatArray`
- `pkg/formatter/jsoncfmt/jsonc_test.go`: Add `TestShouldBreakArray` with 6 test cases

## Testing

- Unit tests pass (`go test -count=1 ./...`)
- Parity suite: #569 drops from 10→0 failures