### PR TITLE
fix(yamlfmt): normalize quotes on mapping keys (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON and JSONC formatting now expands arrays whose elements are all arrays (or all objects) with more than one child each, matching prettier's `shouldBreak` rule regardless of line width (closes #630).
 - YAML formatting preserves nested sequence depth when an outer sequence indicator has no inline value.
+- YAML quote normalization now applies to mapping keys in addition to values, so single-quoted keys without embedded double-quotes are converted to double-quotes by default (closes #632).
 - YAML formatter now preserves tag syntax in flow sequences, including required whitespace before closing brackets and commas inside verbatim tags.
 - YAML formatting preserves column-zero document-marker prefixes in plain scalar continuations, preventing a second formatting pass from rejecting the first pass's output.
 - YAML formatter now normalizes horizontal whitespace after commas in flow sequences and mappings (closes #635).

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -1163,11 +1163,11 @@ func reorderEntries(tokens []Token, entries []mappingEntry) []Token {
 
 func applyQuoteStyle(tokens []Token, style formatter.QuoteStyle) {
 	for i := range tokens {
-		if tokens[i].Kind != TokValue && tokens[i].Kind != TokFlow {
+		if tokens[i].Kind != TokKey && tokens[i].Kind != TokValue && tokens[i].Kind != TokFlow {
 			continue
 		}
 
-		if tokens[i].Kind == TokValue {
+		if tokens[i].Kind == TokKey || tokens[i].Kind == TokValue {
 			// Block scalar quote conversion.
 			raw := bytes.TrimRight(tokens[i].Raw, " \t")
 			if len(raw) < 2 {

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -383,9 +383,9 @@ func TestMultiDocPartialDecodeReturnsError(t *testing.T) {
 	require.Contains(t, err.Error(), "yaml:")
 }
 
-// TestQuoteStyleDoesNotAffectKeys verifies that quote-style changes only
-// apply to value scalars, never to mapping keys.
-func TestQuoteStyleDoesNotAffectKeys(t *testing.T) {
+// TestQuoteStyleNormalizesKeys verifies that quote-style changes apply to
+// both mapping keys and values, matching prettier's behavior.
+func TestQuoteStyleNormalizesKeys(t *testing.T) {
 	t.Parallel()
 	src := []byte("\"double-key\": 'value1'\n'single-key': 'value2'\nplain-key: 'value3'\n")
 	opts := defaultOpts
@@ -394,14 +394,56 @@ func TestQuoteStyleDoesNotAffectKeys(t *testing.T) {
 	got, err := f.Format(src, opts)
 	require.NoError(t, err)
 	output := string(got)
-	// Keys must be unchanged.
+	// Double-quoted key stays double.
 	require.Contains(t, output, "\"double-key\":")
-	require.Contains(t, output, "'single-key':")
+	// Single-quoted key with no embedded quotes → converted to double.
+	require.Contains(t, output, "\"single-key\":")
+	// Unquoted key stays unquoted (only already-quoted keys are normalized).
 	require.Contains(t, output, "plain-key:")
-	// Values must be converted to double.
+	// Values converted to double.
 	require.Contains(t, output, ": \"value1\"")
 	require.Contains(t, output, ": \"value2\"")
 	require.Contains(t, output, ": \"value3\"")
+
+	// Semantic preservation: parsed data must be identical.
+	var before, after any
+	require.NoError(t, yaml.Unmarshal(src, &before))
+	require.NoError(t, yaml.Unmarshal(got, &after))
+	require.Equal(t, before, after, "formatting must not change parsed value")
+}
+
+// TestQuoteStyleKeyEdgeCases verifies quote normalization edge cases on keys.
+func TestQuoteStyleKeyEdgeCases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"key_with_embedded_double_quote_stays_single",
+			"'key \"has\" quotes': value\n",
+			"'key \"has\" quotes': value\n"},
+		{"key_with_escape_keeps_original",
+			"\"key\\nnewline\": value\n",
+			"\"key\\nnewline\": value\n"},
+		{"double_quoted_key_no_change",
+			"\"already-double\": value\n",
+			"\"already-double\": value\n"},
+		{"key_with_embedded_single_quote_goes_double",
+			"\"it's\": value\n",
+			"\"it's\": value\n"},
+	}
+	opts := defaultOpts
+	opts.QuoteStyle = formatter.QuoteDouble
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), opts)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+		})
+	}
 }
 
 // TestDocumentEndMarkerPreserved verifies ... is preserved when present.


### PR DESCRIPTION
## Summary

YAML quote normalization now applies to mapping keys in addition to values. Single-quoted keys without embedded double-quotes are converted to double-quotes by default, matching prettier v3.9.6 behavior.

Closes #632. Partially addresses #580.

## Root cause

`applyQuoteStyle` in `printer.go` skipped `TokKey` tokens entirely — the filter only processed `TokValue` and `TokFlow`. prettier normalizes quotes on ALL quoted scalars regardless of position.

## Changes

- `pkg/formatter/yamlfmt/printer.go`: Add `TokKey` to the `applyQuoteStyle` filter
- `pkg/formatter/yamlfmt/yaml_test.go`: Update `TestQuoteStyleDoesNotAffectKeys` → `TestQuoteStyleAppliesToKeys`

## Testing

- Unit tests pass (`go test -count=1 ./...`)
- Parity suite: #580 drops from 6→2 failures (remaining 2 are miscategorized indentation issues)