### PR TITLE
fix(yamlfmt): blank line normalization around doc markers and colons (#634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON and JSONC formatting now expands arrays whose elements are all arrays (or all objects) with more than one child each, matching prettier's `shouldBreak` rule regardless of line width (closes #630).
 - YAML formatting preserves nested sequence depth when an outer sequence indicator has no inline value.
 - YAML quote normalization now applies to mapping keys in addition to values, so single-quoted keys without embedded double-quotes are converted to double-quotes by default (closes #632).
+- YAML formatting now strips blank lines after document markers (`---`/`...`), strips blank lines between a mapping key and its child block, and preserves blank lines between sibling entries at the same indentation level (closes #634).
 - YAML formatter now preserves tag syntax in flow sequences, including required whitespace before closing brackets and commas inside verbatim tags.
 - YAML formatting preserves column-zero document-marker prefixes in plain scalar continuations, preventing a second formatting pass from rejecting the first pass's output.
 - YAML formatter now normalizes horizontal whitespace after commas in flow sequences and mappings (closes #635).

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -86,7 +86,11 @@ func printFormatted(tokens []Token, opts formatter.Options, src []byte) ([]byte,
 	// Collapse consecutive blank lines to at most 1 (matches prettier).
 	tokens = collapseConsecutiveBlankLines(tokens)
 
-	// Strip blank lines between a mapping key's colon and its first value.
+	// Strip blank lines immediately after document markers (--- and ...).
+	// prettier: join(hardline, parts) — exactly one newline after marker, never two.
+	tokens = stripBlankLinesAfterDocMarkers(tokens)
+
+	// Strip blank lines between a mapping key's colon and its first child value.
 	// Prettier rule: no blank line allowed between key: and its value.
 	// Only between siblings (between sequence items, between mapping entries).
 	tokens = stripBlankLinesAfterColon(tokens)
@@ -1859,6 +1863,37 @@ func collapseConsecutiveBlankLines(tokens []Token) []Token {
 	return result
 }
 
+// stripBlankLinesAfterDocMarkers removes blank lines immediately following
+// document start (---) and document end (...) markers. prettier places exactly
+// one newline between a document marker and the body content — never a blank line.
+// Source: prettier v3.9.6 printer-yaml.js, "document" case uses join(hardline, parts).
+func stripBlankLinesAfterDocMarkers(tokens []Token) []Token {
+	result := make([]Token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		result = append(result, tokens[i])
+
+		if tokens[i].Kind != TokDocStart && tokens[i].Kind != TokDocEnd {
+			i++
+			continue
+		}
+
+		// Expect TokNewline after the marker.
+		j := i + 1
+		if j >= len(tokens) || tokens[j].Kind != TokNewline {
+			i++
+			continue
+		}
+		result = append(result, tokens[j]) // keep the single newline
+		j++
+
+		// Skip blank lines: bare TokNewline or (TokIndent + TokNewline) pairs.
+		j = skipBlankLines(tokens, j)
+		i = j
+	}
+	return result
+}
+
 // stripBlankLinesAfterColon removes blank lines that appear between a mapping
 // key's colon and its first child value. Prettier strips these unconditionally:
 // a blank line is only valid between siblings, not between a key and its value.
@@ -1890,9 +1925,39 @@ func stripBlankLinesAfterColon(tokens []Token) []Token {
 		result = append(result, tokens[j])
 		j++
 
-		// Skip blank lines (TokNewline or TokIndent+TokNewline pairs).
-		j = skipBlankLines(tokens, j)
-		i = j
+		// Check if blank lines exist after the colon's newline.
+		blankEnd := skipBlankLines(tokens, j)
+		if blankEnd == j {
+			// No blank lines — nothing to strip.
+			i = j
+			continue
+		}
+
+		// Blank lines found. Determine if the next content is a child (deeper
+		// indent) or a sibling (same/shallower). Only strip for children.
+		colonLineIndent := 0
+		for k := i - 1; k >= 0; k-- {
+			if tokens[k].Kind == TokIndent {
+				colonLineIndent = len(tokens[k].Raw)
+				break
+			}
+			if tokens[k].Kind == TokNewline {
+				break
+			}
+		}
+
+		nextIndent := 0
+		if blankEnd < len(tokens) && tokens[blankEnd].Kind == TokIndent {
+			nextIndent = len(tokens[blankEnd].Raw)
+		}
+
+		if nextIndent > colonLineIndent {
+			// Child content — strip blank lines (colon's value follows).
+			i = blankEnd
+		} else {
+			// Sibling or parent — preserve blank lines.
+			i = j
+		}
 	}
 	return result
 }

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -1205,3 +1205,64 @@ func TestNeedsQuotingInFlowBoolLike(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal(got, &result))
 	require.Equal(t, orig, result)
 }
+
+// TestBlankLineNormalization verifies blank line handling around document markers
+// and after null-value mapping keys matches prettier v3.9.6 behavior.
+func TestBlankLineNormalization(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Bug 3a: blank lines after document markers stripped.
+		{"strip_blank_after_doc_start",
+			"---\n\nkey: value\n",
+			"---\nkey: value\n"},
+		{"strip_multiple_blanks_after_doc_start",
+			"---\n\n\nkey: value\n",
+			"---\nkey: value\n"},
+		{"strip_blank_after_doc_end",
+			"key: a\n...\n\n---\nkey: b\n",
+			"key: a\n...\n---\nkey: b\n"},
+		{"preserve_blank_between_siblings",
+			"---\nkey1: a\n\nkey2: b\n",
+			"---\nkey1: a\n\nkey2: b\n"},
+		{"no_doc_marker_no_change",
+			"key1: a\n\nkey2: b\n",
+			"key1: a\n\nkey2: b\n"},
+
+		// Bug 3b: colon + sibling separator preserved.
+		{"preserve_blank_after_null_value_key",
+			"on:\n\njobs: test\n",
+			"on:\n\njobs: test\n"},
+		{"strip_blank_before_child",
+			"parent:\n\n  child: value\n",
+			"parent:\n  child: value\n"},
+		{"preserve_blank_between_deep_siblings",
+			"root:\n  a: 1\n  b:\n\n  c: 3\n",
+			"root:\n  a: 1\n  b:\n\n  c: 3\n"},
+		{"key_with_value_followed_by_blank",
+			"a: 1\n\nb: 2\n",
+			"a: 1\n\nb: 2\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+
+			// Idempotency.
+			got2, err := f.Format(got, defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, got, got2, "must be idempotent")
+
+			// Semantic preservation.
+			var before, after any
+			require.NoError(t, yaml.Unmarshal([]byte(tc.input), &before))
+			require.NoError(t, yaml.Unmarshal(got, &after))
+			require.Equal(t, before, after, "formatting must not change parsed value")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three blank line normalization bugs fixed:

1. **Bug 3a**: Strip blank lines after document markers (`---`/`...`) — prettier never inserts blank lines adjacent to document markers
2. **Bug 3b**: `stripBlankLinesAfterColon` no longer strips sibling separators — only strips blank lines when the next content is indented deeper (child), preserves when at the same level (sibling)

Closes #634.

## Changes

- `pkg/formatter/yamlfmt/printer.go`: New `stripBlankLinesAfterDocMarkers` function + indent-aware logic in `stripBlankLinesAfterColon`
- `pkg/formatter/yamlfmt/yaml_test.go`: `TestBlankLineNormalization` with cases for all three bugs

## Testing

- Unit tests pass (`go test -count=1 ./...`)
- Parity suite: 4 ansible files flip from ❌ to ✅