### PR TITLE
fix(yamlfmt): accept non-string-keyed maps for formatting (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML formatting preserves nested sequence depth when an outer sequence indicator has no inline value.
 - YAML quote normalization now applies to mapping keys in addition to values, so single-quoted keys without embedded double-quotes are converted to double-quotes by default (closes #632).
 - YAML formatting now strips blank lines after document markers (`---`/`...`), strips blank lines between a mapping key and its child block, and preserves blank lines between sibling entries at the same indentation level (closes #634).
+- YAML formatter now accepts documents with non-string mapping keys (integer, boolean, etc.) instead of rejecting them with a type error (closes #585).
 - YAML formatter now preserves tag syntax in flow sequences, including required whitespace before closing brackets and commas inside verbatim tags.
 - YAML formatting preserves column-zero document-marker prefixes in plain scalar continuations, preventing a second formatting pass from rejecting the first pass's output.
 - YAML formatter now normalizes horizontal whitespace after commas in flow sequences and mappings (closes #635).

--- a/pkg/formatter/yamlfmt/yaml.go
+++ b/pkg/formatter/yamlfmt/yaml.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 
@@ -88,8 +89,11 @@ func (Formatter) Format(src []byte, opts formatter.Options) ([]byte, error) {
 	// Only format documents whose root is a mapping or sequence.
 	// Bare scalars are valid YAML but not config files.
 	// Nil roots (empty documents, binary garbage parsed as nil) have nothing to format.
-	switch firstDoc.(type) {
-	case map[string]any, []any:
+	if firstDoc == nil {
+		return nil, errors.New("yaml: cannot format (document root is nil)")
+	}
+	switch reflect.TypeOf(firstDoc).Kind() {
+	case reflect.Map, reflect.Slice:
 		// formattable
 	default:
 		return nil, errors.New("yaml: cannot format (document root is not a mapping or sequence)")

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -484,6 +484,79 @@ func TestBareScalarReturnsError(t *testing.T) {
 	require.Contains(t, err.Error(), "not a mapping or sequence")
 }
 
+// TestIntegerKeyedMapFormats verifies that maps with non-string keys (which
+// Go decodes as map[any]any or map[int]any) pass the type gate and format
+// correctly. Fixes #585: the old type switch only accepted map[string]any.
+func TestIntegerKeyedMapFormats(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "flow_integer_keys",
+			input: "{1: one, 2: two, 3: three}\n",
+			want:  "{ 1: one, 2: two, 3: three }\n",
+		},
+		{
+			name:  "block_integer_keys",
+			input: "1: one\n2: two\n3: three\n",
+			want:  "1: one\n2: two\n3: three\n",
+		},
+		{
+			name:  "mixed_key_types_flow",
+			input: "{1: one, two: 2, 3: three}\n",
+			want:  "{ 1: one, two: 2, 3: three }\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), defaultOpts)
+			require.NoError(t, err, "integer-keyed maps must be formattable")
+			require.Equal(t, tc.want, string(got))
+
+			// Semantic preservation: parsed data structure must be identical.
+			var before, after any
+			require.NoError(t, yaml.Unmarshal([]byte(tc.input), &before))
+			require.NoError(t, yaml.Unmarshal(got, &after))
+			require.Equal(t, before, after, "formatting must not change parsed value")
+		})
+	}
+}
+
+// TestNilRootReturnsError verifies that nil/empty documents are rejected.
+func TestNilRootReturnsError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty_document", "---\n"},
+		{"null_literal", "null\n"},
+		{"tilde_null", "~\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := f.Format([]byte(tc.input), defaultOpts)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "nil")
+		})
+	}
+}
+
+// TestNumericScalarRootReturnsError verifies that numeric bare scalars at root
+// are rejected (they are valid YAML but not config files).
+func TestNumericScalarRootReturnsError(t *testing.T) {
+	t.Parallel()
+	src := []byte("42\n")
+	_, err := f.Format(src, defaultOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a mapping or sequence")
+}
+
 // TestZeroOptionsUsesDefaults verifies that all-zero Options produces
 // sensible output (2-space indent). FinalNewline is false (zero value) so
 // the formatter doesn't force a trailing newline.


### PR DESCRIPTION
## Summary

The YAML formatter now accepts documents with non-string mapping keys (integer, boolean, etc.) instead of rejecting them with a type error.

Closes #585.

## Root cause

The type gate in `yaml.go` used a Go type switch checking only `map[string]any` and `[]any`. When yaml.v3 decodes `{1: 1, 2: 2}` (integer keys), Go produces `map[any]any` which did not match and hit the error path.

## Changes

- `pkg/formatter/yamlfmt/yaml.go`: Replace type switch with `reflect.TypeOf().Kind()` check for `reflect.Map` or `reflect.Slice`
- `pkg/formatter/yamlfmt/yaml_test.go`: Add `TestIntegerKeyedMapFormats` (3 cases), `TestNilRootReturnsError` (3 cases), `TestNumericScalarRootReturnsError`

## Testing

- Unit tests pass (`go test -count=1 ./...`)
- Parity suite: #585 drops from 3→1 (remaining file is a separate `?` key indicator issue)