### PR TITLE
fix(yamlfmt): correct sequence indentation in multi-document files (#582)

### DIFF
--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -2,7 +2,9 @@ package yamlfmt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -127,12 +129,19 @@ func buildASTMetadata(src []byte, tokens []Token) (map[int]lineMetadata, error) 
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src = append(bytes.Clone(src), '\n')
 	}
-	var root yaml.Node
-	if err := yaml.Unmarshal(src, &root); err != nil {
-		return nil, fmt.Errorf("cannot determine document structure: %w", err)
-	}
 	meta := make(map[int]lineMetadata)
-	collectMetadata(&root, meta, sequenceDashColumns(tokens), 0, false, 0, 0)
+	dashCols := sequenceDashColumns(tokens)
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	for {
+		var root yaml.Node
+		if err := dec.Decode(&root); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("cannot determine document structure: %w", err)
+		}
+		collectMetadata(&root, meta, dashCols, 0, false, 0, 0)
+	}
 	return meta, nil
 }
 
@@ -517,12 +526,15 @@ func buildStructuralLineSet(src []byte) map[int]bool {
 	if len(src) > 0 && src[len(src)-1] != '\n' {
 		src = append(bytes.Clone(src), '\n')
 	}
-	var root yaml.Node
-	if err := yaml.Unmarshal(src, &root); err != nil {
-		return nil
-	}
 	lines := make(map[int]bool)
-	collectStructuralLines(&root, lines)
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	for {
+		var root yaml.Node
+		if err := dec.Decode(&root); err != nil {
+			break
+		}
+		collectStructuralLines(&root, lines)
+	}
 	return lines
 }
 

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -383,6 +383,81 @@ func TestMultiDocPartialDecodeReturnsError(t *testing.T) {
 	require.Contains(t, err.Error(), "yaml:")
 }
 
+// TestMultiDocSequenceIndent verifies that sequences in documents 2+ receive
+// correct indentation (IndentSequences=Enabled). Before the fix (#582),
+// buildASTMetadata only parsed the first document, so sequences in later
+// documents had no AST depth and fell back to shift-based delta logic.
+func TestMultiDocSequenceIndent(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "sequence_in_second_doc",
+			input: "---\na: 1\n---\nkey:\n- item1\n- item2\n",
+			want:  "---\na: 1\n---\nkey:\n  - item1\n  - item2\n",
+		},
+		{
+			name:  "sequence_in_third_doc",
+			input: "---\na: 1\n---\nb: 2\n---\nlist:\n- one\n- two\n",
+			want:  "---\na: 1\n---\nb: 2\n---\nlist:\n  - one\n  - two\n",
+		},
+		{
+			name:  "first_doc_still_works",
+			input: "---\nkey:\n- item1\n- item2\n",
+			want:  "---\nkey:\n  - item1\n  - item2\n",
+		},
+		{
+			name:  "root_sequence_in_second_doc",
+			input: "---\na: 1\n---\n- item1\n- item2\n",
+			want:  "---\na: 1\n---\n- item1\n- item2\n",
+		},
+		{
+			name:  "nested_sequence_both_docs",
+			input: "---\nfoo:\n- a\n- b\n---\nbar:\n- c\n- d\n",
+			want:  "---\nfoo:\n  - a\n  - b\n---\nbar:\n  - c\n  - d\n",
+		},
+		{
+			name:  "mapping_only_second_doc_unchanged",
+			input: "---\na: 1\n---\nb: 2\nc: 3\n",
+			want:  "---\na: 1\n---\nb: 2\nc: 3\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+
+			// Idempotency check.
+			got2, err := f.Format(got, defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, string(got), string(got2), "format must be idempotent")
+
+			// Semantic preservation: decode all documents before/after.
+			decBefore := yaml.NewDecoder(strings.NewReader(tc.input))
+			decAfter := yaml.NewDecoder(strings.NewReader(string(got)))
+			docIdx := 0
+			for {
+				var before, after any
+				errB := decBefore.Decode(&before)
+				errA := decAfter.Decode(&after)
+				if errB != nil && errA != nil {
+					break
+				}
+				require.Equal(t, errB == nil, errA == nil,
+					"doc %d: decode mismatch (before err=%v, after err=%v)", docIdx, errB, errA)
+				require.Equal(t, before, after,
+					"doc %d: formatting must not change parsed value", docIdx)
+				docIdx++
+			}
+		})
+	}
+}
+
 // TestQuoteStyleNormalizesKeys verifies that quote-style changes apply to
 // both mapping keys and values, matching prettier's behavior.
 func TestQuoteStyleNormalizesKeys(t *testing.T) {


### PR DESCRIPTION
## Summary

The YAML formatter now applies correct sequence indentation in all documents of a multi-document file, not just the first.

Closes #582.

## Root cause

`buildASTMetadata()` and `buildStructuralLineSet()` used `yaml.Unmarshal` which only parses the first document. Documents 2+ had no AST metadata, so `reindentTokens` fell back to shift-based delta logic instead of applying `IndentSequences=Enabled`.

## Changes

- `pkg/formatter/yamlfmt/printer.go`: Replace `yaml.Unmarshal` with `yaml.NewDecoder` loops in both `buildASTMetadata` and `buildStructuralLineSet`
- `pkg/formatter/yamlfmt/yaml_test.go`: Add `TestMultiDocSequenceIndent` (6 cases with idempotency + semantic checks)

## Testing

- Unit tests pass (`go test -count=1 ./...`)
- Parity suite: #582 drops to 0 failures