### PR TITLE
fix(docs,validator): PR #621 review followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** JSON, JSONC, TOML, and TOON no longer resolve schemas from `$schema` properties in documents. Use `--schema-map`, `--schemastore`, or `.cfv.toml [schema-map]` for schema validation of these formats. YAML (`# yaml-language-server` comment) and XML (`xsi:noNamespaceSchemaLocation`) inline declarations are unchanged.
 - **Breaking:** `--no-config` now disables ALL config file discovery (`.cfv.toml`, `.prettierrc`, `taplo.toml`, `.yamlfmt`, `.editorconfig`), matching prettier's `--no-config` semantics. Previously it only disabled `.cfv.toml`.
 - **Breaking:** Removed `--no-prettier-config`, `--no-taplo-config`, and `--no-yamlfmt-config` flags. Use `--no-config` to disable all config, or `.cfv.toml` to take explicit control.
 - JSONC formatting now adds trailing commas to expanded objects and arrays by default, matching Prettier; collapsed collections and strict JSON remain unchanged (closes #589).

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -544,6 +544,57 @@ func Test_YAMLMarshalToJSONInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_YAMLMarshalToJSON_InfReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := YAMLValidator{}.MarshalToJSON([]byte("value: .inf\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ".inf cannot be represented in JSON")
+}
+
+func Test_YAMLMarshalToJSON_NegInfReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := YAMLValidator{}.MarshalToJSON([]byte("value: -.inf\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-.inf cannot be represented in JSON")
+}
+
+func Test_YAMLMarshalToJSON_NaNReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := YAMLValidator{}.MarshalToJSON([]byte("value: .nan\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ".nan cannot be represented in JSON")
+}
+
+func Test_YAMLMarshalToJSON_NestedInfReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := YAMLValidator{}.MarshalToJSON([]byte("outer:\n  inner: .inf\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ".inf")
+}
+
+func Test_YAMLMarshalToJSON_InfInArrayReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := YAMLValidator{}.MarshalToJSON([]byte("values:\n  - 1.0\n  - .inf\n  - 3.0\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ".inf")
+}
+
+func Test_YAMLMarshalToJSON_NormalFloatsPass(t *testing.T) {
+	t.Parallel()
+	out, err := YAMLValidator{}.MarshalToJSON([]byte("value: 3.14\n"))
+	require.NoError(t, err)
+	require.Contains(t, string(out), "3.14")
+}
+
+func Test_YAMLValidateSchema_InfReturnsError(t *testing.T) {
+	t.Parallel()
+	src := []byte("# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json\nvalue: .inf\n")
+	ok, err := YAMLValidator{}.ValidateSchema(src, "/tmp/test.yaml")
+	require.False(t, ok)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ".inf cannot be represented in JSON")
+}
+
 func Test_TomlMarshalToJSON(t *testing.T) {
 	t.Parallel()
 	out, err := TomlValidator{}.MarshalToJSON([]byte("\"$schema\" = \"x\"\nkey = \"val\"\n"))

--- a/pkg/validator/yaml.go
+++ b/pkg/validator/yaml.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,7 +48,44 @@ func (YAMLValidator) MarshalToJSON(b []byte) ([]byte, error) {
 	if err := yaml.Unmarshal(b, &doc); err != nil {
 		return nil, err
 	}
+	if err := checkJSONRepresentable(doc); err != nil {
+		return nil, err
+	}
 	return json.Marshal(doc)
+}
+
+// checkJSONRepresentable walks a decoded value tree and returns an error if any
+// float is ±Inf or NaN — values that JSON cannot represent. Schema validation
+// requires JSON conversion, so documents containing these values cannot be
+// schema-validated.
+func checkJSONRepresentable(v any) error {
+	switch val := v.(type) {
+	case map[string]any:
+		for k, item := range val {
+			if err := checkJSONRepresentable(item); err != nil {
+				return fmt.Errorf("key %q: %w", k, err)
+			}
+		}
+	case []any:
+		for i, item := range val {
+			if err := checkJSONRepresentable(item); err != nil {
+				return fmt.Errorf("index %d: %w", i, err)
+			}
+		}
+	case float64:
+		if math.IsInf(val, 1) {
+			return errors.New("value .inf cannot be represented in JSON; schema validation cannot be performed")
+		}
+		if math.IsInf(val, -1) {
+			return errors.New("value -.inf cannot be represented in JSON; schema validation cannot be performed")
+		}
+		if math.IsNaN(val) {
+			return errors.New("value .nan cannot be represented in JSON; schema validation cannot be performed")
+		}
+	default:
+		// Other types (string, bool, int, nil) are JSON-representable.
+	}
+	return nil
 }
 
 // ValidateSchema validates YAML against a JSON Schema referenced via comment.
@@ -59,6 +97,10 @@ func (YAMLValidator) ValidateSchema(b []byte, filePath string) (bool, error) {
 
 	var doc any
 	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return false, err
+	}
+
+	if err := checkJSONRepresentable(doc); err != nil {
 		return false, err
 	}
 

--- a/website/docs/guides/schema-validation.md
+++ b/website/docs/guides/schema-validation.md
@@ -7,7 +7,7 @@ The validator checks syntax first. If the file parses correctly and a schema is 
 
 Schemas are resolved in order:
 
-1. **From the file** — a `$schema` property in JSON/TOML, a `yaml-language-server` comment in YAML, or an `xsi:noNamespaceSchemaLocation` attribute in XML.
+1. **From the file** — a `yaml-language-server` comment in YAML, or an `xsi:noNamespaceSchemaLocation` attribute in XML.
 2. **From `--schema-map`** — a glob pattern mapped to a schema file.
 3. **From `--schemastore`** — automatic lookup by filename against the SchemaStore catalog.
 
@@ -15,19 +15,7 @@ The first match wins. If no schema is found, the file passes on syntax alone.
 
 ## Declaring a schema in your files
 
-Each format uses a different convention to reference a schema.
-
-### JSON and JSONC
-
-Add a `$schema` property at the top level:
-
-```json
-{
-  "$schema": "https://json.schemastore.org/package.json",
-  "name": "my-package",
-  "version": "1.0.0"
-}
-```
+YAML and XML support inline schema declarations. JSON, JSONC, TOML, and TOON use external schema sources (`--schema-map` or `--schemastore`).
 
 ### YAML
 
@@ -40,28 +28,6 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-```
-
-### TOML
-
-Add a `$schema` key at the top level:
-
-```toml
-"$schema" = "https://json.schemastore.org/pyproject.json"
-
-[project]
-name = "my-project"
-version = "1.0.0"
-```
-
-### TOON
-
-Add a quoted `"$schema"` key at the top level:
-
-```
-"$schema": https://example.com/schema.json
-host: localhost
-port: 5432
 ```
 
 ### XML
@@ -169,11 +135,15 @@ The same mappings can be set in `.cfv.toml`:
 
 When multiple schema sources are available for a file, the validator uses this precedence (highest first):
 
-1. Schema declared in the document (`$schema`, `yaml-language-server`, `xsi:noNamespaceSchemaLocation`)
+1. Schema declared in the document (`yaml-language-server` comment in YAML, `xsi:noNamespaceSchemaLocation` in XML)
 2. `--schema-map` patterns
 3. `--schemastore` catalog lookup
 
-Document-level declarations always take priority. SchemaStore acts as a fallback for files that don't declare their own schema.
+Document-level declarations take priority over external sources. SchemaStore acts as a fallback for files that don't declare their own schema.
+
+:::note
+JSON, JSONC, TOML, and TOON files may contain a `$schema` property, but cfv treats it as inert data. Use `--schema-map` or `--schemastore` for schema validation of these formats.
+:::
 
 ## Requiring schemas
 


### PR DESCRIPTION
## Summary

Three issues identified during deep code review of PR #621:

### 1. Stale documentation (schema-validation.md)

The schema validation guide still referenced `$schema` in JSON/TOML/TOON as a schema resolution mechanism. Updated to reflect that only YAML and XML support inline schema declarations.

### 2. Missing breaking-change changelog entry

Added `**Breaking:**` entry under `[Unreleased] > Changed` for the `$schema` removal.

### 3. Restore friendly error for .inf/.nan in YAML schema validation

PR #621 unintentionally removed `checkJSONRepresentable` (collateral damage from reverting #618). This caused both `MarshalToJSON` and `ValidateSchema` to produce the opaque Go stdlib error `json: unsupported value: +Inf` instead of the clear `value .inf cannot be represented in JSON; schema validation cannot be performed`.

Restored the helper and added it to BOTH paths (the original #618 only covered `MarshalToJSON`, missing the `ValidateSchema`/yaml-language-server path).

## Testing

- 7 new unit tests covering .inf, -.inf, .nan, nested, array, normal floats, and ValidateSchema path
- Full test suite passes (`go test -count=1 ./...`)
- `golangci-lint run ./...` — 0 issues