### PR TITLE
fix(yamlfmt): normalize quotes on multi-line scalars (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON and JSONC formatting now expands arrays whose elements are all arrays (or all objects) with more than one child each, matching prettier's `shouldBreak` rule regardless of line width (closes #630).
 - YAML formatting preserves nested sequence depth when an outer sequence indicator has no inline value.
+- YAML quote normalization now applies to multi-line quoted scalars, matching prettier behavior (closes #580).
 - YAML quote normalization now applies to mapping keys in addition to values, so single-quoted keys without embedded double-quotes are converted to double-quotes by default (closes #632).
 - YAML formatting now strips blank lines after document markers (`---`/`...`), strips blank lines between a mapping key and its child block, and preserves blank lines between sibling entries at the same indentation level (closes #634).
 - YAML formatter now accepts documents with non-string mapping keys (integer, boolean, etc.) instead of rejecting them with a type error (closes #585).

--- a/pkg/formatter/yamlfmt/printer.go
+++ b/pkg/formatter/yamlfmt/printer.go
@@ -1248,13 +1248,6 @@ func isSimpleQuoted(raw []byte, quote byte) bool {
 func convertQuote(raw []byte, style formatter.QuoteStyle, currentQuote byte) []byte {
 	content := raw[1 : len(raw)-1]
 
-	// Don't convert multi-line scalars.
-	for _, b := range content {
-		if b == '\n' || b == '\r' {
-			return raw
-		}
-	}
-
 	// Don't convert if content has backslashes (escapes).
 	if currentQuote == '"' {
 		for j := 0; j < len(content); j++ {

--- a/pkg/formatter/yamlfmt/yaml_test.go
+++ b/pkg/formatter/yamlfmt/yaml_test.go
@@ -604,6 +604,63 @@ func TestQuoteStyleKeyEdgeCases(t *testing.T) {
 	}
 }
 
+// TestMultiLineQuoteConversion verifies that multi-line quoted scalars are
+// normalized to the target quote style, matching prettier v3.9.6 behavior.
+// Previously, convertQuote bailed on any multi-line content unconditionally.
+func TestMultiLineQuoteConversion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple_multiline_single_to_double",
+			input: "msg: 'hello\n  world'\n",
+			want:  "msg: \"hello\n  world\"\n",
+		},
+		{
+			name:  "multiline_single_with_backslash_preserved",
+			input: "path: 'C:\\Users\\file\n  continues'\n",
+			want:  "path: 'C:\\Users\\file\n  continues'\n",
+		},
+		{
+			name:  "multiline_with_embedded_double_stays_single",
+			input: "msg: 'she said \"hello\"\n  to them'\n",
+			want:  "msg: 'she said \"hello\"\n  to them'\n",
+		},
+		{
+			name:  "multiline_double_with_escape_preserved",
+			input: "msg: \"line\\ttab\n  continues\"\n",
+			want:  "msg: \"line\\ttab\n  continues\"\n",
+		},
+		{
+			name:  "multiline_single_no_conflicts_to_double",
+			input: "msg: 'walking path for files: lstat /tmp/deploy:\n  no such file or directory'\n",
+			want:  "msg: \"walking path for files: lstat /tmp/deploy:\n  no such file or directory\"\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+
+			// Idempotency.
+			got2, err := f.Format(got, defaultOpts)
+			require.NoError(t, err)
+			require.Equal(t, string(got), string(got2), "format must be idempotent")
+
+			// Semantic preservation.
+			var before, after any
+			require.NoError(t, yaml.Unmarshal([]byte(tc.input), &before))
+			require.NoError(t, yaml.Unmarshal(got, &after))
+			require.Equal(t, before, after, "formatting must not change parsed value")
+		})
+	}
+}
+
 // TestDocumentEndMarkerPreserved verifies ... is preserved when present.
 func TestDocumentEndMarkerPreserved(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
6-line deletion. Removes the unconditional bail-out in `convertQuote` for multi-line content. Prettier v3.9.6 has no such restriction.

Parity: #580 drops from 1→0. All tracked issues now PASS.

Closes #580.