### PR TITLE
fix(cli,xmlfmt): 4 critical bugs from adversarial testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ cfv replaces all of them. It's a single static binary with no runtime dependenci
 - **18 formats validated** (JSON, YAML, TOML, XML, HCL, INI, Properties, ENV, HOCON, CSV, Justfile, KDL, CUE, PList, EDITORCONFIG, JSONC, TOON, SARIF)
 - **9 formats formatted** (JSON, JSONC, YAML, TOML, HCL, XML, INI, Properties, ENV)
 - **Schema validation** via JSON Schema, XSD, and automatic [SchemaStore](https://www.schemastore.org/) lookup
-- **Duplicate key detection** for JSON, YAML, and INI
+- **Duplicate key detection** for YAML (always), JSON and INI (opt-in via `.cfv.toml`)
 - **Gitignore-aware** file discovery
 - [**Pre-commit hook**](https://boeing.github.io/config-file-validator/docs/integrations/pre-commit) and [**GitHub Action**](https://github.com/Boeing/validate-configs-action) with PR annotations
 

--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -116,22 +116,23 @@ type reporterConfig struct {
 
 // resolvedConfig is the final merged configuration passed to the CLI engine.
 type resolvedConfig struct {
-	reporters     []reporter.Reporter
-	groupOutput   []string
-	quiet         bool
-	requireSchema bool
-	noSchema      bool
-	schemaMap     map[string]string
-	store         *schemastore.Store
-	finderOpts    []finder.FSFinderOptions
-	stdinData     []byte
-	stdinFileType filetype.FileType
-	isStdin       bool
-	fix           bool
-	diff          bool
-	formatCfg     *configfile.FormatConfig
-	watch         bool
-	searchPaths   []string
+	reporters      []reporter.Reporter
+	groupOutput    []string
+	quiet          bool
+	requireSchema  bool
+	noSchema       bool
+	schemaMap      []cli.SchemaMapping
+	store          *schemastore.Store
+	finderOpts     []finder.FSFinderOptions
+	configFilePath string
+	stdinData      []byte
+	stdinFileType  filetype.FileType
+	isStdin        bool
+	fix            bool
+	diff           bool
+	formatCfg      *configfile.FormatConfig
+	watch          bool
+	searchPaths    []string
 }
 
 // --- Repeatable flag types ---
@@ -1199,7 +1200,7 @@ func getReporter(reportType, outputDest string) reporter.Reporter {
 // config file loading, reporters, groupOutput, quiet, fix, diff, stdin,
 // and finder options. It does not touch schema-specific fields.
 func resolveBaseConfig(cfg *cfvConfig) (*resolvedConfig, *configfile.ValidatorOptions, error) {
-	validatorOpts, formatCfg, err := applyConfigFile(cfg)
+	cfgFilePath, validatorOpts, formatCfg, err := applyConfigFile(cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config file: %w", err)
 	}
@@ -1254,6 +1255,13 @@ func resolveBaseConfig(cfg *cfvConfig) (*resolvedConfig, *configfile.ValidatorOp
 		return nil, nil, err
 	}
 	resolved.finderOpts = fsOpts
+
+	if cfgFilePath != "" {
+		abs, err := filepath.Abs(cfgFilePath)
+		if err == nil {
+			resolved.configFilePath = abs
+		}
+	}
 
 	return resolved, validatorOpts, nil
 }
@@ -1329,6 +1337,7 @@ func buildCLI(rc *resolvedConfig, extra ...cli.Option) *cli.CLI {
 		cli.WithNoSchema(rc.noSchema),
 		cli.WithSchemaMap(rc.schemaMap),
 		cli.WithSchemaStore(rc.store),
+		cli.WithConfigFile(rc.configFilePath),
 		cli.WithFix(rc.fix),
 		cli.WithDiff(rc.diff),
 	}
@@ -1352,6 +1361,7 @@ func buildCLIWithFinder(rc *resolvedConfig, f finder.FileFinder) *cli.CLI {
 		cli.WithNoSchema(rc.noSchema),
 		cli.WithSchemaMap(rc.schemaMap),
 		cli.WithSchemaStore(rc.store),
+		cli.WithConfigFile(rc.configFilePath),
 		cli.WithFix(rc.fix),
 		cli.WithDiff(rc.diff),
 		cli.WithFinder(f),
@@ -1521,14 +1531,14 @@ func parseTypeMapFlags(flags typeMapFlags) ([]finder.TypeOverride, error) {
 	return overrides, nil
 }
 
-func parseSchemaMapFlags(flags schemaMapFlags) (map[string]string, error) {
-	result := make(map[string]string)
+func parseSchemaMapFlags(flags schemaMapFlags) ([]cli.SchemaMapping, error) {
+	result := make([]cli.SchemaMapping, 0, len(flags))
 	for _, mapping := range flags {
 		parts := strings.SplitN(mapping, ":", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return nil, fmt.Errorf("invalid schema-map format %q, expected pattern:schema_path", mapping)
 		}
-		result[parts[0]] = parts[1]
+		result = append(result, cli.SchemaMapping{Pattern: parts[0], SchemaPath: parts[1]})
 	}
 	return result, nil
 }
@@ -1594,9 +1604,9 @@ func setIgnoreFilesFromEnvIfNotSet(fs *flag.FlagSet, flags *ignoreFileFlags) {
 // Config file (.cfv.toml) handling
 // =============================================================================
 
-func applyConfigFile(cfg *cfvConfig) (*configfile.ValidatorOptions, *configfile.FormatConfig, error) {
+func applyConfigFile(cfg *cfvConfig) (string, *configfile.ValidatorOptions, *configfile.FormatConfig, error) {
 	if *cfg.noConfig {
-		return nil, nil, nil
+		return "", nil, nil, nil
 	}
 
 	var cfgPath string
@@ -1606,12 +1616,12 @@ func applyConfigFile(cfg *cfvConfig) (*configfile.ValidatorOptions, *configfile.
 		cfgPath = configfile.Discover(".")
 	}
 	if cfgPath == "" {
-		return nil, nil, nil
+		return "", nil, nil, nil
 	}
 
 	fileCfg, err := configfile.Load(cfgPath)
 	if err != nil {
-		return nil, nil, err
+		return "", nil, nil, err
 	}
 
 	// CLI flag > env var (already applied to flagSet) > config file.
@@ -1629,14 +1639,14 @@ func applyConfigFile(cfg *cfvConfig) (*configfile.ValidatorOptions, *configfile.
 	}
 	if !cfg.isFlagSet("depth") && fileCfg.Depth != nil {
 		if err := cfg.fs.Set("depth", fmt.Sprintf("%d", *fileCfg.Depth)); err != nil {
-			return nil, nil, fmt.Errorf("config file depth: %w", err)
+			return "", nil, nil, fmt.Errorf("config file depth: %w", err)
 		}
 		cfg.depth = fileCfg.Depth
 	}
 	if !cfg.isFlagSet("reporter") && len(fileCfg.Reporter) > 0 {
 		conf, err := parseReporterFlags(reporterFlags(fileCfg.Reporter))
 		if err != nil {
-			return nil, nil, fmt.Errorf("config file reporter: %w", err)
+			return "", nil, nil, fmt.Errorf("config file reporter: %w", err)
 		}
 		cfg.reportType = conf
 	}
@@ -1669,8 +1679,14 @@ func applyConfigFile(cfg *cfvConfig) (*configfile.ValidatorOptions, *configfile.
 		cfg.ignoreFiles = ignoreFileFlags(fileCfg.IgnoreFiles)
 	}
 	if len(cfg.schemaMap) == 0 && len(fileCfg.SchemaMap) > 0 {
-		for pattern, schema := range fileCfg.SchemaMap {
-			cfg.schemaMap = append(cfg.schemaMap, pattern+":"+schema)
+		// Sort patterns for deterministic ordering (TOML maps are unordered).
+		patterns := make([]string, 0, len(fileCfg.SchemaMap))
+		for pattern := range fileCfg.SchemaMap {
+			patterns = append(patterns, pattern)
+		}
+		slices.Sort(patterns)
+		for _, pattern := range patterns {
+			cfg.schemaMap = append(cfg.schemaMap, pattern+":"+fileCfg.SchemaMap[pattern])
 		}
 	}
 	if len(cfg.typeMap) == 0 && len(fileCfg.TypeMap) > 0 {
@@ -1679,7 +1695,7 @@ func applyConfigFile(cfg *cfvConfig) (*configfile.ValidatorOptions, *configfile.
 		}
 	}
 
-	return &fileCfg.Validators, &fileCfg.Format, nil
+	return cfgPath, &fileCfg.Validators, &fileCfg.Format, nil
 }
 
 // =============================================================================

--- a/cmd/cfv/cfv_test.go
+++ b/cmd/cfv/cfv_test.go
@@ -179,7 +179,7 @@ func Test_ignoreFilesConfigOverridesEnvVar(t *testing.T) {
 	cfg, err := parseCheckFlags([]string{"--config=" + configPath, "."})
 	require.NoError(t, err)
 
-	_, _, err = applyConfigFile(&cfg)
+	_, _, _, err = applyConfigFile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, ignoreFileFlags{"config.ignore"}, cfg.ignoreFiles)
 }
@@ -193,7 +193,7 @@ func Test_ignoreFilesFlagOverridesConfigAndEnv(t *testing.T) {
 	cfg, err := parseCheckFlags([]string{"--config=" + configPath, "--ignore-file=cli.ignore", "."})
 	require.NoError(t, err)
 
-	_, _, err = applyConfigFile(&cfg)
+	_, _, _, err = applyConfigFile(&cfg)
 	require.NoError(t, err)
 	require.Equal(t, ignoreFileFlags{"cli.ignore"}, cfg.ignoreFiles)
 }

--- a/pkg/cli/check_format_test.go
+++ b/pkg/cli/check_format_test.go
@@ -197,7 +197,7 @@ func TestCheckSkipsFormatOnSchemaError(t *testing.T) {
 		WithFinder(finder.FileSystemFinderInit(finder.WithPathRoots(dir))),
 		WithReporters(capture),
 		WithFormatOptions(defaultJSONOpts()),
-		WithSchemaMap(map[string]string{"app.json": schemaPath}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "app.json", SchemaPath: schemaPath}}),
 	)
 
 	exitStatus, err := c.Run()

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -23,18 +23,26 @@ import (
 
 // CLI is the main entry point for running config file validation and formatting.
 // Use Init with Option functions to configure, then call Run (check) or Format.
+// SchemaMapping is a single glob-pattern → schema-path association.
+// Ordered slice preserves user-specified priority (first match wins).
+type SchemaMapping struct {
+	Pattern    string
+	SchemaPath string
+}
+
 type CLI struct {
-	finder        finder.FileFinder
-	reporters     []reporter.Reporter
-	groupOutput   []string
-	quiet         bool
-	requireSchema bool
-	noSchema      bool
-	schemaMap     map[string]string
-	schemaStore   *schemastore.Store
-	stdinData     []byte
-	stdinFileType filetype.FileType
-	errorFound    bool
+	finder         finder.FileFinder
+	reporters      []reporter.Reporter
+	groupOutput    []string
+	quiet          bool
+	requireSchema  bool
+	noSchema       bool
+	schemaMap      []SchemaMapping
+	schemaStore    *schemastore.Store
+	configFilePath string // excluded from format checking
+	stdinData      []byte
+	stdinFileType  filetype.FileType
+	errorFound     bool
 	// fix enables writing formatted output back to disk.
 	// When false, Format reports issues but does not write.
 	fix bool
@@ -90,9 +98,17 @@ func WithNoSchema(noSchema bool) Option {
 	}
 }
 
-func WithSchemaMap(m map[string]string) Option {
+func WithSchemaMap(m []SchemaMapping) Option {
 	return func(c *CLI) {
 		c.schemaMap = m
+	}
+}
+
+// WithConfigFile sets the path to the resolved config file so it can be
+// excluded from format checking (a tool should not format its own config).
+func WithConfigFile(path string) Option {
+	return func(c *CLI) {
+		c.configFilePath = path
 	}
 }
 
@@ -375,16 +391,22 @@ func (c *CLI) lookupSchemaMap(filePath string) (string, bool) {
 		return "", false
 	}
 	baseName := filepath.Base(filePath)
-	for pattern, schemaPath := range c.schemaMap {
-		if !tools.IsGlobPattern(pattern) {
-			if pattern == baseName {
-				return schemaPath, true
+	for _, m := range c.schemaMap {
+		if !tools.IsGlobPattern(m.Pattern) {
+			if m.Pattern == baseName {
+				return m.SchemaPath, true
 			}
 			continue
 		}
-		matched, err := doublestar.PathMatch(pattern, filePath)
+		// If pattern has no path separator, match against basename only.
+		// "*.json" matches any JSON file regardless of directory depth.
+		target := filePath
+		if !strings.Contains(m.Pattern, "/") {
+			target = baseName
+		}
+		matched, err := doublestar.PathMatch(m.Pattern, target)
 		if err == nil && matched {
-			return schemaPath, true
+			return m.SchemaPath, true
 		}
 	}
 	return "", false
@@ -572,6 +594,14 @@ func (c *CLI) resolveSchemaBytes(v validator.Validator, filePath string) []byte 
 // When the fixer has already written a new version of the file, content will
 // be stale — we re-read from disk in that case (detected by fix notes on the report).
 func (c *CLI) checkFormatting(report reporter.Report, content []byte, ft filetype.FileType, path string) reporter.Report {
+	// Skip the config file itself — a tool should not format-check its own config.
+	if c.configFilePath != "" {
+		absPath, err := filepath.Abs(path)
+		if err == nil && absPath == c.configFilePath {
+			return report
+		}
+	}
+
 	// Skip if file is format-ignored by external tool config.
 	if c.formatIgnores != nil {
 		absPath, err := filepath.Abs(path)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -336,7 +336,7 @@ func Test_CLISchemaMapValid(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"config.json": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "config.json", SchemaPath: schema}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func Test_CLISchemaMapInvalid(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"config.json": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "config.json", SchemaPath: schema}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func Test_CLISchemaMapGlob(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"**/configs/*.json": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "**/configs/*.json", SchemaPath: schema}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -420,7 +420,7 @@ func Test_CLISchemaMapYAML(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"config.yaml": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "config.yaml", SchemaPath: schema}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -444,7 +444,7 @@ func Test_CLISchemaMapTOML(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"config.toml": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "config.toml", SchemaPath: schema}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -460,7 +460,7 @@ func Test_CLISchemaMapUnmatched(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"other.json": "/nonexistent"}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "other.json", SchemaPath: "/nonexistent"}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -479,7 +479,7 @@ func Test_CLISchemaMapUnsupportedValidatorWarnsAndPasses(t *testing.T) {
 	cli := Init(
 		WithFinder(fsFinder),
 		WithReporters(capturingReporter),
-		WithSchemaMap(map[string]string{".env": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: ".env", SchemaPath: schema}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -503,7 +503,7 @@ func Test_CLISchemaMapUnsupportedValidatorFailsWithRequireSchema(t *testing.T) {
 	cli := Init(
 		WithFinder(fsFinder),
 		WithReporters(capturingReporter),
-		WithSchemaMap(map[string]string{".env": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: ".env", SchemaPath: schema}}),
 		WithRequireSchema(true),
 	)
 	exitStatus, err := cli.Run()
@@ -586,7 +586,7 @@ func Test_CLISchemaMapPriorityOverStore(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"package.json": strict}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "package.json", SchemaPath: strict}}),
 		WithSchemaStore(bundle),
 	)
 	exitStatus, err := cli.Run()
@@ -609,7 +609,7 @@ func Test_CLIDocumentSchemaPriorityOverAll(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"package.json": schema}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "package.json", SchemaPath: schema}}),
 		WithSchemaStore(bundle),
 	)
 	exitStatus, err := cli.Run()
@@ -762,7 +762,7 @@ func Test_CLISchemaMapXMLValid(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"config.xml": schemaPath}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "config.xml", SchemaPath: schemaPath}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -817,7 +817,7 @@ func Test_CLISchemaMapXMLInvalid(t *testing.T) {
 	)
 	cli := Init(
 		WithFinder(fsFinder),
-		WithSchemaMap(map[string]string{"config.xml": schemaPath}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "config.xml", SchemaPath: schemaPath}}),
 	)
 	exitStatus, err := cli.Run()
 	require.NoError(t, err)
@@ -1233,7 +1233,7 @@ func Test_CLICheckWithFixSchemaCoerce(t *testing.T) {
 		WithFinder(fsFinder),
 		WithReporters(rep),
 		WithFix(true),
-		WithSchemaMap(map[string]string{"**/*.json": filepath.Join(dir, "schema.json")}),
+		WithSchemaMap([]SchemaMapping{{Pattern: "**/*.json", SchemaPath: filepath.Join(dir, "schema.json")}}),
 	)
 
 	_, err := cli.Run()

--- a/pkg/formatter/xmlfmt/printer.go
+++ b/pkg/formatter/xmlfmt/printer.go
@@ -195,8 +195,18 @@ func insertFormattingWhitespace(tokens []Token, indentUnit string) []Token {
 			result = append(result, tok)
 			depth++
 
-			// Check if this element has mixed content.
+			// Check if this element has xml:space="preserve" — emit content verbatim.
 			closeIdx := findMatchingClose(cleaned, i)
+			if closeIdx > 0 && hasXMLSpacePreserve(tok.Raw) {
+				for j := i + 1; j <= closeIdx; j++ {
+					result = append(result, cleaned[j])
+				}
+				depth--
+				i = closeIdx + 1
+				continue
+			}
+
+			// Check if this element has mixed content.
 			if closeIdx > 0 && isMixedContent(cleaned, i, closeIdx) {
 				// Emit everything between open and close INLINE (no formatting).
 				for j := i + 1; j <= closeIdx; j++ {
@@ -280,6 +290,12 @@ func findMatchingClose(tokens []Token, openIdx int) int {
 
 // isMixedContent returns true if the element between openIdx and closeIdx
 // contains BOTH non-whitespace text AND child element tokens.
+// hasXMLSpacePreserve checks if an open tag token contains xml:space="preserve".
+func hasXMLSpacePreserve(raw []byte) bool {
+	return bytes.Contains(raw, []byte(`xml:space="preserve"`)) ||
+		bytes.Contains(raw, []byte(`xml:space='preserve'`))
+}
+
 func isMixedContent(tokens []Token, openIdx, closeIdx int) bool {
 	hasText := false
 	hasChild := false


### PR DESCRIPTION
## Bugs Fixed

### 1. schema-map glob matching (HIGH)
`--schema-map="*.json:schema.json"` now matches files. Previously `*` was matched against the full absolute path and never crossed `/`.

### 2. Non-deterministic schema selection (HIGH)
Replaced `map[string]string` with ordered `[]SchemaMapping` slice. First-match-wins, deterministic. TOML config entries sorted alphabetically.

### 3. XML xml:space="preserve" corruption (HIGH)
Elements with `xml:space="preserve"` now emit content verbatim. No reindentation inside preserve blocks.

### 4. .cfv.toml fails its own format check (HIGH)
Config file excluded from format checking via `configFilePath` field.

## Testing

- Full test suite: 22/22 packages pass
- golangci-lint: 0 issues
- Parity suite: all tracked issues PASS, no regressions
- Each bug manually reproduced before fix, confirmed fixed after