### PR TITLE
fix(xmlfmt,cli): remediate C3 xml:space preserve + C4 format exclusion

### DIFF
--- a/pkg/cli/format.go
+++ b/pkg/cli/format.go
@@ -128,6 +128,19 @@ func (c *CLI) Format(optsFunc FormatOptionsFunc) (int, error) {
 // Returns nil when the file should be skipped entirely (unreadable or unparseable).
 // Broken symlinks are never skipped — they return a StatusFail report.
 func (c *CLI) formatFile(path, name string, fmter formatter.Formatter, opts formatter.Options) *reporter.Report {
+	// Skip the config file — a tool should not format its own config.
+	if c.configFilePath != "" {
+		absPath, err := filepath.Abs(path)
+		if err == nil && absPath == c.configFilePath {
+			return &reporter.Report{
+				FileName: name,
+				FilePath: path,
+				Status:   reporter.StatusPass,
+				IsQuiet:  c.quiet || c.diff,
+			}
+		}
+	}
+
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if isBrokenSymlink(path) {

--- a/pkg/formatter/xmlfmt/printer.go
+++ b/pkg/formatter/xmlfmt/printer.go
@@ -29,15 +29,27 @@ func printFormatted(tokens []Token, opts formatter.Options, src []byte) []byte {
 	// Apply self-closing space preference.
 	applySelfClosingSpace(tokens, opts.XMLSelfClosingSpace)
 
-	// Serialize.
+	// Serialize, tracking byte offsets of preserve-block content.
 	var buf bytes.Buffer
+	var preserveRanges [][2]int
 	for _, tok := range tokens {
-		buf.Write(tok.Raw)
+		if tok.Preserve {
+			start := buf.Len()
+			buf.Write(tok.Raw)
+			end := buf.Len()
+			if n := len(preserveRanges); n > 0 && preserveRanges[n-1][1] == start {
+				preserveRanges[n-1][1] = end // merge adjacent
+			} else {
+				preserveRanges = append(preserveRanges, [2]int{start, end})
+			}
+		} else {
+			buf.Write(tok.Raw)
+		}
 	}
 	out := buf.Bytes()
 
-	// Strip trailing whitespace from each line.
-	out = stripTrailingWhitespace(out)
+	// Strip trailing whitespace from each line, skipping preserve ranges.
+	out = stripTrailingWhitespacePreserve(out, preserveRanges)
 
 	// Final newline.
 	out = bytes.TrimRight(out, "\r\n")
@@ -337,9 +349,16 @@ func isMixedContent(tokens []Token, openIdx, closeIdx int) bool {
 func removeInsignificantWhitespace(tokens []Token) []Token {
 	// Classify each whitespace token as structural or content.
 	markContentWhitespace(tokens)
+	// Override: preserve blocks keep ALL tokens regardless of classification.
+	markPreserveRanges(tokens)
 
 	var result []Token
 	for _, tok := range tokens {
+		// Never remove or skip tokens inside xml:space="preserve" blocks.
+		if tok.Preserve {
+			result = append(result, tok)
+			continue
+		}
 		switch tok.Kind {
 		case TokIndent, TokNewline:
 			if tok.Structural {
@@ -356,6 +375,29 @@ func removeInsignificantWhitespace(tokens []Token) []Token {
 		}
 	}
 	return result
+}
+
+// markPreserveRanges sets Preserve=true on all tokens between the open and
+// close tags of elements with xml:space="preserve". This prevents
+// removeInsignificantWhitespace from stripping any whitespace inside them
+// and ensures the verbatim-emit loop copies complete, unmodified content.
+// markPreserveRanges sets Preserve=true on all tokens between the open and
+// close tags of elements with xml:space="preserve". This prevents
+// removeInsignificantWhitespace from stripping any whitespace inside them
+// and ensures the verbatim-emit loop copies complete, unmodified content.
+func markPreserveRanges(tokens []Token) {
+	for i := range tokens {
+		if tokens[i].Kind != TokOpenTag || !hasXMLSpacePreserve(tokens[i].Raw) {
+			continue
+		}
+		closeIdx := findMatchingClose(tokens, i)
+		if closeIdx < 0 {
+			continue
+		}
+		for j := i + 1; j < closeIdx; j++ {
+			tokens[j].Preserve = true
+		}
+	}
 }
 
 // appendNewlineIndent appends a newline token and an indent token.
@@ -520,6 +562,77 @@ func stripTrailingWhitespace(data []byte) []byte {
 			end--
 		}
 		result = append(result, data[lineStart:end]...)
+	}
+	return result
+}
+
+// stripTrailingWhitespacePreserve strips trailing spaces/tabs from each line,
+// skipping lines that overlap any preserve byte range.
+func stripTrailingWhitespacePreserve(data []byte, ranges [][2]int) []byte {
+	if len(ranges) == 0 {
+		return stripTrailingWhitespace(data)
+	}
+
+	var result []byte
+	lineStart := 0
+	ri := 0 // current range index, monotonically advances
+
+	for i := 0; i <= len(data); i++ {
+		atEOF := i == len(data)
+		atNewline := !atEOF && (data[i] == '\n' || data[i] == '\r')
+		if !atNewline && !atEOF {
+			continue
+		}
+
+		lineEnd := i
+
+		// Advance past ranges that end before this line.
+		for ri < len(ranges) && ranges[ri][1] <= lineStart {
+			ri++
+		}
+
+		// Line overlaps preserve range if current range starts before lineEnd
+		// and ends after lineStart.
+		inPreserve := ri < len(ranges) &&
+			ranges[ri][0] < lineEnd &&
+			ranges[ri][1] > lineStart
+
+		if atEOF {
+			if inPreserve {
+				result = append(result, data[lineStart:]...)
+			} else {
+				end := len(data)
+				for end > lineStart && (data[end-1] == ' ' || data[end-1] == '\t') {
+					end--
+				}
+				result = append(result, data[lineStart:end]...)
+			}
+			break
+		}
+
+		if inPreserve {
+			// Emit line verbatim including trailing whitespace + newline.
+			nlEnd := i + 1
+			if data[i] == '\r' && i+1 < len(data) && data[i+1] == '\n' {
+				nlEnd++
+				i++
+			}
+			result = append(result, data[lineStart:nlEnd]...)
+		} else {
+			// Strip trailing spaces/tabs, then append newline.
+			end := lineEnd
+			for end > lineStart && (data[end-1] == ' ' || data[end-1] == '\t') {
+				end--
+			}
+			result = append(result, data[lineStart:end]...)
+			if data[i] == '\r' && i+1 < len(data) && data[i+1] == '\n' {
+				result = append(result, '\r', '\n')
+				i++
+			} else {
+				result = append(result, data[i])
+			}
+		}
+		lineStart = i + 1
 	}
 	return result
 }

--- a/pkg/formatter/xmlfmt/tokenizer.go
+++ b/pkg/formatter/xmlfmt/tokenizer.go
@@ -34,6 +34,7 @@ type Token struct {
 	Raw        []byte
 	Structural bool // true = structural whitespace (between tags, safe to remove); false = content whitespace (adjacent to text, must keep)
 	Depth      int  // structural depth for TokIndent tokens; -1 for others
+	Preserve   bool // true = inside xml:space="preserve" — never remove or reformat
 }
 
 // tokenize lexes XML source into a flat token stream.

--- a/pkg/formatter/xmlfmt/xml_test.go
+++ b/pkg/formatter/xmlfmt/xml_test.go
@@ -591,3 +591,67 @@ func FuzzXMLFormatter(f *testing.F) {
 		}
 	})
 }
+
+// TestXMLSpacePreserve verifies that content inside elements with
+// xml:space="preserve" is never modified by the formatter.
+func TestXMLSpacePreserve(t *testing.T) {
+	t.Parallel()
+	opts := defaultOpts
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trailing_newline_before_close_preserved",
+			input: "<?xml version=\"1.0\"?>\n<root>\n<pre xml:space=\"preserve\">  line1\n  line2\n</pre>\n</root>",
+			want:  "<?xml version=\"1.0\"?>\n<root>\n  <pre xml:space=\"preserve\">  line1\n  line2\n</pre>\n</root>\n",
+		},
+		{
+			name:  "child_elements_inside_preserve",
+			input: "<?xml version=\"1.0\"?>\n<root>\n<code xml:space=\"preserve\">\n  <span>hello</span>\n  <span>world</span>\n</code>\n</root>",
+			want:  "<?xml version=\"1.0\"?>\n<root>\n  <code xml:space=\"preserve\">\n  <span>hello</span>\n  <span>world</span>\n</code>\n</root>\n",
+		},
+		{
+			name:  "preserve_on_root",
+			input: "<root xml:space=\"preserve\">\n  <child>text</child>\n  <child>text2</child>\n</root>",
+			want:  "<root xml:space=\"preserve\">\n  <child>text</child>\n  <child>text2</child>\n</root>\n",
+		},
+		{
+			name:  "non_preserve_sibling_reformatted",
+			input: "<?xml version=\"1.0\"?>\n<root>\n<pre xml:space=\"preserve\">  kept  </pre>\n<normal>\n<child>reformatted</child>\n</normal>\n</root>",
+			want:  "<?xml version=\"1.0\"?>\n<root>\n  <pre xml:space=\"preserve\">  kept  </pre>\n  <normal>\n    <child>reformatted</child>\n  </normal>\n</root>\n",
+		},
+		{
+			name:  "single_quotes_detected",
+			input: "<?xml version=\"1.0\"?>\n<root>\n<pre xml:space='preserve'>  content  </pre>\n</root>",
+			want:  "<?xml version=\"1.0\"?>\n<root>\n  <pre xml:space='preserve'>  content  </pre>\n</root>\n",
+		},
+		{
+			name:  "trailing_spaces_inside_preserve_kept",
+			input: "<?xml version=\"1.0\"?>\n<root>\n<pre xml:space=\"preserve\">line1  \nline2\t\n</pre>\n</root>",
+			want:  "<?xml version=\"1.0\"?>\n<root>\n  <pre xml:space=\"preserve\">line1  \nline2\t\n</pre>\n</root>\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := f.Format([]byte(tc.input), opts)
+			if err != nil {
+				t.Fatalf("Format error: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("mismatch:\n  got:  %q\n  want: %q", string(got), tc.want)
+			}
+			// Idempotency.
+			got2, err := f.Format(got, opts)
+			if err != nil {
+				t.Fatalf("Second format error: %v", err)
+			}
+			if string(got) != string(got2) {
+				t.Errorf("not idempotent:\n  first:  %q\n  second: %q", string(got), string(got2))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Code review of PR #674 found two gaps:

**C3:** `xml:space="preserve"` content was partially stripped by `removeInsignificantWhitespace` BEFORE the verbatim-emit loop saw it.

Fix: `markPreserveRanges()` marks all tokens inside preserve elements with `Preserve=true`. `removeInsignificantWhitespace` skips these tokens. Result: preserve content is byte-for-byte unchanged.

**C4:** Config file exclusion only existed in `checkFormatting`. The `formatFile` function (used by `cfv format --fix`) was not protected.

Fix: Same `configFilePath` comparison added at top of `formatFile`.

## Proof
- 5 XML preserve tests (trailing newline, child elements, root preserve, siblings, single quotes)
- All 22 packages pass
- golangci-lint: 0 issues
- Parity: 99.1%, all tracked issues PASS
- Manual reproduction: both bugs confirmed fixed