### PR TITLE
fix(cli): 5 medium bug fixes for v3.0

### DIFF
--- a/cmd/cfv/cfv.go
+++ b/cmd/cfv/cfv.go
@@ -37,10 +37,12 @@ import (
 	"io"
 	"log"
 	"maps"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -194,6 +196,11 @@ var fileTypeFamilies = [][]string{
 
 // mainInit is the testable entry point. Returns an exit code.
 func mainInit() int {
+	// Limit HTTP schema fetches to 10 seconds. gojsonschema uses
+	// http.DefaultClient with no timeout control — a typo'd URL
+	// would otherwise block for 30+ seconds (OS TCP timeout).
+	http.DefaultClient.Timeout = 10 * time.Second
+
 	args := os.Args[1:]
 
 	// Phase 1: parse global flags. Only --version and --help live here.
@@ -349,14 +356,16 @@ func runCheck(args []string) int {
 		return exitStatus
 	}
 
+	optsResolver, prettierCfg := buildFormatOptionsResolver(&cfg, resolved)
 	c := buildCLI(resolved,
-		cli.WithFormatOptions(buildFormatOptionsResolver(&cfg, resolved)),
+		cli.WithFormatOptions(optsResolver),
 		cli.WithFormatIgnores(buildFormatIgnores(&cfg, resolved)),
 	)
 	exitStatus, err := c.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cfv: %v\n", err)
 	}
+	printPrettierWarnings(prettierCfg)
 	return exitStatus
 }
 
@@ -506,12 +515,13 @@ func runFormat(args []string) int {
 
 	// Build the per-format options resolver. This implements the cascade:
 	// CLI flags > [format.<type>] > [format] > format-specific defaults.
-	optsResolver := buildFormatOptionsResolver(&cfg, resolved)
+	optsResolver, prettierCfg := buildFormatOptionsResolver(&cfg, resolved)
 
 	exitStatus, err := c.Format(optsResolver)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cfv: %v\n", err)
 	}
+	printPrettierWarnings(prettierCfg)
 	return exitStatus
 }
 
@@ -655,14 +665,14 @@ func parseFormatFlags(args []string) (cfvConfig, error) {
 //
 // --no-config disables ALL config (pure defaults + CLI flags).
 // --no-editorconfig disables .editorconfig only (Tier 2 tool configs still apply).
-func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOptionsFunc {
+func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) (cli.FormatOptionsFunc, *formatter.PrettierConfig) {
 	// --no-config: pure defaults + CLI flags only. Skip everything.
 	if cfg.noConfig != nil && *cfg.noConfig {
 		return func(formatName, _ string) formatter.Options {
 			opts := formatDefaults(formatName)
 			applyCLIFormatFlags(&opts, cfg)
 			return opts
-		}
+		}, nil
 	}
 
 	// Tier 1: .cfv.toml exists — sole authority.
@@ -694,7 +704,7 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 			// CLI flags (highest priority)
 			applyCLIFormatFlags(&opts, cfg)
 			return opts
-		}
+		}, nil
 	}
 
 	// Tier 2: no .cfv.toml — per-format tool config ownership.
@@ -749,6 +759,17 @@ func buildFormatOptionsResolver(cfg *cfvConfig, rc *resolvedConfig) cli.FormatOp
 		// CLI flags (highest priority)
 		applyCLIFormatFlags(&opts, cfg)
 		return opts
+	}, prettierCfg
+}
+
+// printPrettierWarnings emits any .prettierrc config warnings to stderr.
+// Safe to call with nil (no-op when prettier config was not used).
+func printPrettierWarnings(pc *formatter.PrettierConfig) {
+	if pc == nil {
+		return
+	}
+	for _, w := range pc.Warnings() {
+		fmt.Fprintf(os.Stderr, "cfv: warning: %s\n", w)
 	}
 }
 
@@ -1538,6 +1559,10 @@ func parseSchemaMapFlags(flags schemaMapFlags) ([]cli.SchemaMapping, error) {
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return nil, fmt.Errorf("invalid schema-map format %q, expected pattern:schema_path", mapping)
 		}
+		// Validate glob pattern syntax — catch typos like "[invalid" early.
+		if _, err := doublestar.PathMatch(parts[0], ""); err != nil {
+			return nil, fmt.Errorf("invalid glob pattern in --schema-map %q: %w", parts[0], err)
+		}
 		result = append(result, cli.SchemaMapping{Pattern: parts[0], SchemaPath: parts[1]})
 	}
 	return result, nil
@@ -1606,6 +1631,9 @@ func setIgnoreFilesFromEnvIfNotSet(fs *flag.FlagSet, flags *ignoreFileFlags) {
 
 func applyConfigFile(cfg *cfvConfig) (string, *configfile.ValidatorOptions, *configfile.FormatConfig, error) {
 	if *cfg.noConfig {
+		if cfg.configPath != nil && *cfg.configPath != "" {
+			return "", nil, nil, errors.New("--config cannot be used with --no-config")
+		}
 		return "", nil, nil, nil
 	}
 

--- a/cmd/cfv/testdata/configfile.txtar
+++ b/cmd/cfv/testdata/configfile.txtar
@@ -47,6 +47,10 @@ stdout '✓'
 exec cfv check --no-config project/tsconfig.json
 stdout '✓'
 
+# --config + --no-config is contradictory
+! exec cfv check --config=cfv/typemap.toml --no-config project/good.json
+stderr 'cannot be used with --no-config'
+
 -- cfv/typemap.toml --
 [type-map]
 "**/tsconfig.json" = "jsonc"

--- a/cmd/cfv/testdata/format_stdin.txtar
+++ b/cmd/cfv/testdata/format_stdin.txtar
@@ -1,0 +1,47 @@
+# ============================================================
+# Functional tests for format subcommand stdin support
+# ============================================================
+
+# Format JSON from stdin — needs formatting (exit 1 = needs formatting)
+stdin unformatted.json
+! exec cfv format --no-config --file-types=json -
+stdout '^\{ "b": 1, "a": 2 \}$'
+
+# Format JSON from stdin — already formatted (exit 0)
+stdin formatted.json
+exec cfv format --no-config --file-types=json -
+stdout '^\{ "a": 1 \}$'
+
+# Format YAML from stdin — needs formatting
+stdin unformatted.yaml
+! exec cfv format --no-config --file-types=yaml -
+stdout '^b: 2'
+stdout '^a: 1'
+
+# Format stdin with --diff
+stdin unformatted.json
+! exec cfv format --no-config --file-types=json --diff -
+stdout '--- stdin'
+stdout '\+\+\+ stdin \(formatted\)'
+stdout '^\+\{ "b": 1, "a": 2 \}'
+
+# Stdin missing --file-types
+stdin unformatted.json
+! exec cfv format --no-config -
+stderr 'requires --file-types'
+
+# Stdin with unformattable type (csv has no formatter)
+stdin simple.csv
+! exec cfv format --no-config --file-types=csv -
+stderr 'has no formatter'
+
+-- unformatted.json --
+{"b":1,"a":2}
+-- formatted.json --
+{ "a": 1 }
+-- unformatted.yaml --
+b:  2
+a:   1
+-- simple.csv --
+a,b,c
+1,2,3

--- a/cmd/cfv/testdata/schema_map.txtar
+++ b/cmd/cfv/testdata/schema_map.txtar
@@ -39,6 +39,10 @@ stdout '✓'
 ! exec cfv check --schema-map=badformat .
 stderr 'invalid schema-map format'
 
+# Invalid glob pattern in --schema-map
+! exec cfv check --schema-map='[invalid:schema.json' .
+stderr 'invalid glob pattern'
+
 -- schema.json --
 {
   "type": "object",

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -38,6 +38,11 @@ reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
 ignoreUntil = "2026-12-01T00:00:00Z"
 
 [[IgnoredVulns]]
+id = "GO-2026-5942"
+reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
+ignoreUntil = "2026-12-01T00:00:00Z"
+
+[[IgnoredVulns]]
 id = "GO-2026-5972"
 reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
 ignoreUntil = "2026-12-01T00:00:00Z"
@@ -48,7 +53,17 @@ reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
 ignoreUntil = "2026-12-01T00:00:00Z"
 
 [[IgnoredVulns]]
+id = "GO-2026-6089"
+reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
+ignoreUntil = "2026-12-01T00:00:00Z"
+
+[[IgnoredVulns]]
 id = "GO-2026-6090"
+reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
+ignoreUntil = "2026-12-01T00:00:00Z"
+
+[[IgnoredVulns]]
+id = "GO-2026-6091"
 reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
 ignoreUntil = "2026-12-01T00:00:00Z"
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"io/fs"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/Boeing/config-file-validator/v3/pkg/filetype"
 	"github.com/Boeing/config-file-validator/v3/pkg/finder"
 	"github.com/Boeing/config-file-validator/v3/pkg/formatter"
+	"github.com/Boeing/config-file-validator/v3/pkg/formatter/jsonfmt"
 	"github.com/Boeing/config-file-validator/v3/pkg/formatter/xmlfmt"
 	"github.com/Boeing/config-file-validator/v3/pkg/reporter"
 	"github.com/Boeing/config-file-validator/v3/pkg/schemastore"
@@ -1396,4 +1398,72 @@ func Test_BOMStripping(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, exitCode)
 	})
+}
+
+func Test_FormatStdinBOMPreserved(t *testing.T) {
+	// JSON with BOM that needs formatting: output should have BOM restored.
+	bom := []byte{0xef, 0xbb, 0xbf}
+	input := append(bom, []byte(`{"b":1,"a":2}`)...)
+
+	jsonFT := filetype.JSONFileType
+	jsonFT.Formatter = jsonfmt.Formatter{}
+
+	// Capture stdout by redirecting via pipe.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	c := Init(WithStdinData(input, jsonFT))
+	exitStatus, err := c.Format(defaultJSONOpts())
+
+	require.NoError(t, w.Close())
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, exitStatus) // needed formatting
+	output := buf.Bytes()
+	require.True(t, hasBOM(output), "output should preserve BOM")
+	// Verify the content after BOM is valid formatted JSON.
+	require.Contains(t, string(output[3:]), `"b": 1`)
+}
+
+func Test_FormatStdinAlreadyFormatted(t *testing.T) {
+	// Already-formatted JSON with BOM: output should be unchanged.
+	bom := []byte{0xef, 0xbb, 0xbf}
+	formatted := "{\n  \"a\": 1\n}\n"
+	input := append(bom, []byte(formatted)...)
+
+	jsonFT := filetype.JSONFileType
+	jsonFT.Formatter = jsonfmt.Formatter{}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	c := Init(WithStdinData(input, jsonFT))
+	exitStatus, err := c.Format(defaultJSONOpts())
+
+	require.NoError(t, w.Close())
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitStatus) // already formatted
+	require.Equal(t, input, buf.Bytes(), "output should be identical to input including BOM")
+}
+
+func Test_FormatStdinSyntaxError(t *testing.T) {
+	// Invalid JSON from stdin should return exit 2 with error.
+	jsonFT := filetype.JSONFileType
+	jsonFT.Formatter = jsonfmt.Formatter{}
+
+	c := Init(WithStdinData([]byte(`{"broken":}`), jsonFT))
+	exitStatus, err := c.Format(defaultJSONOpts())
+
+	require.Error(t, err)
+	require.Equal(t, 2, exitStatus)
+	require.Contains(t, err.Error(), "formatting stdin")
 }

--- a/pkg/cli/format.go
+++ b/pkg/cli/format.go
@@ -36,6 +36,11 @@ type FormatOptionsFunc func(formatName, path string) formatter.Options
 // Returns 0 if all files are formatted (or all were fixed), 1 if any file
 // needs formatting and --fix was not set, 2 on tool error.
 func (c *CLI) Format(optsFunc FormatOptionsFunc) (int, error) {
+	// Stdin mode: format the piped content and write to stdout.
+	if c.stdinData != nil {
+		return c.formatStdin(optsFunc)
+	}
+
 	foundFiles, err := c.finder.Find()
 	if err != nil {
 		return 2, fmt.Errorf("unable to find files: %w", err)
@@ -122,6 +127,50 @@ func (c *CLI) Format(optsFunc FormatOptionsFunc) (int, error) {
 		return 1, nil
 	}
 	return 0, nil
+}
+
+// formatStdin formats stdin data and writes the result to stdout.
+// With --diff: prints unified diff between stdin and formatted output.
+// With --fix: ignored (cannot write back to stdin); behaves like plain format.
+// Returns 0 if content was already formatted, 1 if it needed formatting.
+func (c *CLI) formatStdin(optsFunc FormatOptionsFunc) (int, error) {
+	fmter := c.stdinFileType.Formatter
+	if fmter == nil {
+		return 2, fmt.Errorf("file type %q has no formatter", c.stdinFileType.Name)
+	}
+
+	hadBOM := hasBOM(c.stdinData)
+	content := stripBOM(c.stdinData)
+	opts := optsFunc(c.stdinFileType.Name, "stdin")
+
+	formatted, err := fmter.Format(content, opts)
+	if err != nil {
+		return 2, fmt.Errorf("formatting stdin: %w", err)
+	}
+
+	if bytes.Equal(content, formatted) {
+		// Already formatted — write original to stdout unchanged (preserves BOM).
+		if _, err := os.Stdout.Write(c.stdinData); err != nil {
+			return 2, fmt.Errorf("writing to stdout: %w", err)
+		}
+		return 0, nil
+	}
+
+	if c.diff {
+		diff := unifiedDiff("stdin", content, formatted)
+		fmt.Print(diff)
+		return 1, nil
+	}
+
+	// Restore BOM in output if the original input had one.
+	if hadBOM {
+		formatted = append([]byte{0xef, 0xbb, 0xbf}, formatted...)
+	}
+
+	if _, err := os.Stdout.Write(formatted); err != nil {
+		return 2, fmt.Errorf("writing to stdout: %w", err)
+	}
+	return 1, nil
 }
 
 // formatFile formats a single file and returns its report.

--- a/pkg/formatter/prettierconfig.go
+++ b/pkg/formatter/prettierconfig.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -56,6 +57,9 @@ type PrettierConfig struct {
 	// (nil = file absent or malformed), so a config shared by many
 	// directories in a walk is only parsed once.
 	fileCache map[string]*prettierRC
+	// warnings collects diagnostic messages about config issues (e.g.,
+	// type mismatches in .prettierrc). Callers retrieve them via Warnings().
+	warnings []string
 }
 
 // NewPrettierConfig returns a PrettierConfig backed by a cache, so a
@@ -65,6 +69,17 @@ func NewPrettierConfig() *PrettierConfig {
 		dirCache:  make(map[string]*prettierRC),
 		fileCache: make(map[string]*prettierRC),
 	}
+}
+
+// Warnings returns diagnostic messages collected during config resolution
+// (e.g., type mismatches in .prettierrc fields). Each message is a
+// human-readable string without a trailing newline. Safe for concurrent use.
+func (p *PrettierConfig) Warnings() []string {
+	p.mu.Lock()
+	w := p.warnings
+	p.warnings = nil
+	p.mu.Unlock()
+	return w
 }
 
 // Apply overlays the resolved .prettierrc properties for path onto opts.
@@ -173,6 +188,7 @@ func (p *PrettierConfig) parseDir(dir string) *prettierRC {
 		rc := parsePrettierRC(name, src)
 		p.fileCache[path] = rc
 		if rc != nil {
+			p.collectTypeMismatches(path, name, src, rc)
 			return rc
 		}
 	}
@@ -182,6 +198,11 @@ func (p *PrettierConfig) parseDir(dir string) *prettierRC {
 // parsePrettierRC parses src according to name's format. A malformed file
 // returns nil rather than an error, matching the "ignore, don't fail the
 // run" behavior used for .editorconfig.
+//
+// For JSON configs, type mismatches (e.g., "tabWidth": "4") are tolerated:
+// the correctly-typed fields are used and the mismatched ones fall through
+// to defaults. The caller should invoke warnPrettierTypeMismatches to emit
+// user-facing diagnostics.
 func parsePrettierRC(name string, src []byte) *prettierRC {
 	var rc prettierRC
 
@@ -203,6 +224,13 @@ func parsePrettierRC(name string, src []byte) *prettierRC {
 			if err := json.Unmarshal(std, &rc); err == nil {
 				return &rc
 			}
+			// Type mismatches: json.Unmarshal partially populates the
+			// struct but returns an error. Parse via raw map to extract
+			// only correctly-typed values.
+			var raw map[string]any
+			if json.Unmarshal(std, &raw) == nil && len(raw) > 0 {
+				return parsePrettierRCFromRaw(raw)
+			}
 		}
 		if name == ".prettierrc" {
 			if err := yaml.Unmarshal(src, &rc); err == nil {
@@ -213,4 +241,68 @@ func parsePrettierRC(name string, src []byte) *prettierRC {
 	}
 
 	return &rc
+}
+
+// parsePrettierRCFromRaw builds a prettierRC from a raw JSON map, extracting
+// only values with correct types. This is the fallback path when
+// json.Unmarshal into the typed struct fails due to type mismatches.
+func parsePrettierRCFromRaw(raw map[string]any) *prettierRC {
+	rc := &prettierRC{}
+	if v, ok := raw["tabWidth"].(float64); ok {
+		i := int(v)
+		rc.TabWidth = &i
+	}
+	if v, ok := raw["printWidth"].(float64); ok {
+		i := int(v)
+		rc.PrintWidth = &i
+	}
+	if v, ok := raw["useTabs"].(bool); ok {
+		rc.UseTabs = &v
+	}
+	if v, ok := raw["endOfLine"].(string); ok {
+		rc.EndOfLine = &v
+	}
+	if v, ok := raw["trailingComma"].(string); ok {
+		rc.TrailingComma = &v
+	}
+	if v, ok := raw["singleQuote"].(bool); ok {
+		rc.SingleQuote = &v
+	}
+	return rc
+}
+
+// collectTypeMismatches appends warnings to p.warnings when a .prettierrc
+// contains keys with wrong types (e.g., "tabWidth": "4" instead of
+// "tabWidth": 4). Only JSON-format configs are checked since YAML and TOML
+// parsers report type errors during unmarshal rather than silently dropping.
+//
+// Must be called under p.mu.
+func (p *PrettierConfig) collectTypeMismatches(path, name string, src []byte, rc *prettierRC) {
+	// Only JSON-parsed configs have the silent-nil problem. YAML/TOML
+	// parsers return errors on type mismatch rather than silently skipping.
+	if name == ".prettierrc.yaml" || name == ".prettierrc.yml" || name == ".prettierrc.toml" {
+		return
+	}
+
+	std, err := hujson.Standardize(src)
+	if err != nil {
+		return
+	}
+	var raw map[string]any
+	if json.Unmarshal(std, &raw) != nil {
+		return
+	}
+
+	if v, ok := raw["tabWidth"]; ok && rc.TabWidth == nil {
+		p.warnings = append(p.warnings, fmt.Sprintf("%s: tabWidth: expected number, got %T; using default", path, v))
+	}
+	if v, ok := raw["printWidth"]; ok && rc.PrintWidth == nil {
+		p.warnings = append(p.warnings, fmt.Sprintf("%s: printWidth: expected number, got %T; using default", path, v))
+	}
+	if v, ok := raw["useTabs"]; ok && rc.UseTabs == nil {
+		p.warnings = append(p.warnings, fmt.Sprintf("%s: useTabs: expected boolean, got %T; using default", path, v))
+	}
+	if v, ok := raw["singleQuote"]; ok && rc.SingleQuote == nil {
+		p.warnings = append(p.warnings, fmt.Sprintf("%s: singleQuote: expected boolean, got %T; using default", path, v))
+	}
 }

--- a/pkg/formatter/prettierconfig_test.go
+++ b/pkg/formatter/prettierconfig_test.go
@@ -185,3 +185,73 @@ func TestPrettierConfigApply_LeavesOptionsAloneWhenAbsent(t *testing.T) {
 
 	require.Equal(t, want, got)
 }
+
+func TestPrettierConfigApply_TypeMismatchPartialParse(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// tabWidth is wrong type (string), endOfLine is correct (string).
+	// The correct field should be applied; the wrong one should use default.
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": "4", "endOfLine": "crlf"}`)
+
+	opts := formatter.Options{IndentWidth: 2}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	// tabWidth was a string — ignored, default preserved.
+	require.Equal(t, 2, opts.IndentWidth)
+	// endOfLine was correct — applied.
+	require.Equal(t, formatter.LineEndingCRLF, opts.LineEnding)
+}
+
+func TestPrettierConfigApply_AllTypeMismatchesIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// All fields have wrong types.
+	writePrettierRC(t, dir, ".prettierrc.json", `{
+		"tabWidth": "4",
+		"useTabs": "yes",
+		"printWidth": true,
+		"singleQuote": 1
+	}`)
+
+	opts := formatter.Options{IndentWidth: 2, IndentStyle: formatter.IndentSpaces}
+	formatter.NewPrettierConfig().Apply(&opts, filepath.Join(dir, "app.json"))
+
+	// All wrong types — original values preserved.
+	require.Equal(t, 2, opts.IndentWidth)
+	require.Equal(t, formatter.IndentSpaces, opts.IndentStyle)
+	require.Equal(t, 0, opts.MaxLineWidth)
+	require.Equal(t, formatter.QuotePreserve, opts.QuoteStyle)
+}
+
+func TestPrettierConfigWarnings_CollectedCorrectly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": "4", "useTabs": "yes"}`)
+
+	pc := formatter.NewPrettierConfig()
+	opts := formatter.Options{IndentWidth: 2}
+	pc.Apply(&opts, filepath.Join(dir, "app.json"))
+
+	// Warnings should be collected (not printed to stderr).
+	warnings := pc.Warnings()
+	require.Len(t, warnings, 2)
+	require.Contains(t, warnings[0], "tabWidth")
+	require.Contains(t, warnings[0], "expected number")
+	require.Contains(t, warnings[1], "useTabs")
+	require.Contains(t, warnings[1], "expected boolean")
+
+	// Calling Warnings() again should return nil (consumed).
+	require.Nil(t, pc.Warnings())
+}
+
+func TestPrettierConfigWarnings_NoWarningsForCorrectConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writePrettierRC(t, dir, ".prettierrc.json", `{"tabWidth": 4, "useTabs": true}`)
+
+	pc := formatter.NewPrettierConfig()
+	opts := formatter.Options{}
+	pc.Apply(&opts, filepath.Join(dir, "app.json"))
+
+	require.Nil(t, pc.Warnings())
+}


### PR DESCRIPTION
## Summary

5 bug fixes found during pre-release testing:

| # | Fix | Risk |
|---|-----|------|
| M1 | 10s HTTP timeout for schema fetches (was 30s+ on unreachable URLs) | Low |
| M2 | Invalid glob in `--schema-map` now errors at startup | Low |
| M3 | `--config` + `--no-config` conflict detected with clear error | Low |
| M4 | `.prettierrc` type mismatches emit warnings (correct fields still apply) | Low |
| M5 | `cfv format` works with stdin (`echo ... \| cfv format --file-types json -`) | Medium |

Also adds osv-scanner ignore entries for 3 new Go stdlib CVEs (GO-2026-5942, -6089, -6091).

## Testing

- 22 packages pass, golangci-lint 0 issues
- New txtar tests: `format_stdin.txtar`, additions to `schema_map.txtar` and `configfile.txtar`
- New unit tests: BOM preservation on stdin format, prettier config warnings collection
- Parity suite: 971/978 (99.3%) — no regressions

## Architecture notes

- M4 warnings are collected in `pkg/formatter` via `Warnings() []string` and printed by `cmd/` — no stderr I/O from library packages.
- M5 stdin format preserves UTF-8 BOM on output, consistent with file-mode behavior.