### PR TITLE
chore(ci): scope MegaLinter security scans to Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Only propose Docusaurus updates. Transitive npm deps (express, qs, etc.)
+  # are build tooling for a static site — not shipped in the Go binary.
+  # Security fixes for transitive deps arrive inside Docusaurus releases.
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "@docusaurus/*"

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -32,6 +32,11 @@ DISABLE_ERRORS_LINTERS:
   # secretlint flags fake postgres URLs in stress_format_test.go
   - REPOSITORY_SECRETLINT
 
+# The website/ directory is a Docusaurus static site — npm deps are build
+# tooling only, not shipped in the Go binary. Skip it in vulnerability scans.
+REPOSITORY_TRIVY_ARGUMENTS: "--skip-dirs website"
+REPOSITORY_OSV_SCANNER_ARGUMENTS: "--experimental-exclude website"
+
 FILTER_REGEX_EXCLUDE: "(test/|testdata/)"
 JSON_JSONLINT_FILTER_REGEX_EXCLUDE: "(test/|testdata/)"
 YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: "(test/|testdata/)"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,15 +1,3 @@
-# gray-matter (Docusaurus dep) requires js-yaml 3.x which has no patch for this CVE.
-# js-yaml 4.2.0 fixes it but breaks gray-matter's API (removed safeLoad).
-# Only used to parse trusted markdown front matter from this repo — not exploitable.
-# Re-evaluate when Docusaurus updates gray-matter or switches to js-yaml 4.x.
-CVE-2026-53550
-
-# brace-expansion 1.x is pinned by @docusaurus/core via serve-handler/minimatch@3.1.x.
-# The fix (5.0.8) requires a major version bump that breaks minimatch 3.x.
-# Not user-addressable without a Docusaurus update. Not exploitable in a static docs build.
-CVE-2026-14257
-
-# image-size 2.0.2 — transitive dep of Docusaurus (via @docusaurus/utils).
-# No fix released upstream. DoS via crafted image buffer — not exploitable in static docs build.
-CVE-2025-71329
-CVE-2025-71330
+# Trivy skips website/ entirely via REPOSITORY_TRIVY_ARGUMENTS in .mega-linter.yml.
+# The website is a Docusaurus static site generator — npm deps are build tooling
+# only, not shipped in the Go binary. No npm CVEs need individual suppression.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -57,12 +57,6 @@ id = "GO-2026-6218"
 reason = "Go stdlib — fixed in 1.26.6, MegaLinter container ships 1.26.3"
 ignoreUntil = "2026-12-01T00:00:00Z"
 
-[[IgnoredVulns]]
-id = "GHSA-5p2g-fcmc-qvqq"
-reason = "npm image-size — transitive dep of Docusaurus, no fix released"
-ignoreUntil = "2026-12-01T00:00:00Z"
-
-[[IgnoredVulns]]
-id = "GHSA-w3rx-r6r6-pgpr"
-reason = "npm image-size — transitive dep of Docusaurus, no fix released"
-ignoreUntil = "2026-12-01T00:00:00Z"
+# The website/ directory is a Docusaurus static site generator — npm deps are
+# build tooling only, not shipped in the Go binary. osv-scanner skips website/
+# via REPOSITORY_OSV_SCANNER_ARGUMENTS in .mega-linter.yml.


### PR DESCRIPTION
Skip npm vulnerability scanning in MegaLinter. The website is a static site generator — npm deps are build tooling, not shipped in the binary.

Replaces individual CVE suppressions with blanket path exclusions for trivy and osv-scanner. Adds dependabot version updates scoped to `@docusaurus/*`.